### PR TITLE
Add remote domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sensor:
 ```
 
 ### Fixed mode
-Supported platforms: `light`, `fan`, `switch`, `binary_sensor`, `remote`
+Supported platforms: `light`, `fan`, `switch`, `binary_sensor`, `remote`, `media_player`
 
 When you have an appliance which only can be set on and off you can use this mode.
 You need to supply a single watt value in the configuration which will be used when the device is ON

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sensor:
 ```
 
 ### Fixed mode
-Supported platforms: `light`, `fan`, `switch`, `binary_sensor`
+Supported platforms: `light`, `fan`, `switch`, `binary_sensor`, `remote`
 
 When you have an appliance which only can be set on and off you can use this mode.
 You need to supply a single watt value in the configuration which will be used when the device is ON

--- a/custom_components/powercalc/sensor.py
+++ b/custom_components/powercalc/sensor.py
@@ -36,7 +36,8 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_ENTITY_ID,
     STATE_OFF,
-    STATE_UNAVAILABLE
+    STATE_UNAVAILABLE,
+    STATE_STANDBY
 )
 import voluptuous as vol
 
@@ -266,7 +267,7 @@ class GenericPowerSensor(Entity):
         if (state.state == STATE_UNAVAILABLE):
             return False
 
-        if (state.state == STATE_OFF):
+        if (state.state == STATE_OFF or state.state == STATE_STANDBY):
             self._power = self._standby_usage or 0
         else:
             self._power = await self._power_calculator.calculate(state)

--- a/custom_components/powercalc/sensor.py
+++ b/custom_components/powercalc/sensor.py
@@ -44,6 +44,7 @@ from homeassistant.components import binary_sensor
 from homeassistant.components import fan
 from homeassistant.components import light
 from homeassistant.components import switch
+from homeassistant.components import remote
 from homeassistant.components.light import Light, PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from .errors import (
@@ -63,7 +64,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 light.DOMAIN,
                 switch.DOMAIN,
                 fan.DOMAIN,
-                binary_sensor.DOMAIN
+                binary_sensor.DOMAIN,
+                remote.DOMAIN
             )
         ),
         vol.Optional(CONF_MODEL): cv.string,

--- a/custom_components/powercalc/sensor.py
+++ b/custom_components/powercalc/sensor.py
@@ -45,6 +45,7 @@ from homeassistant.components import fan
 from homeassistant.components import light
 from homeassistant.components import switch
 from homeassistant.components import remote
+from homeassistant.components import media_player
 from homeassistant.components.light import Light, PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from .errors import (
@@ -65,7 +66,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 switch.DOMAIN,
                 fan.DOMAIN,
                 binary_sensor.DOMAIN,
-                remote.DOMAIN
+                remote.DOMAIN,
+                media_player.DOMAIN
             )
         ),
         vol.Optional(CONF_MODEL): cv.string,


### PR DESCRIPTION
Some TV's use a a remote domain on/off switch to toggle standby mode (The Roku TV integration for example).

I simply allowed the configuration to accept remote domain as a valid option.

I see no errors and everything works as if it was using a switch entity.