### PR TITLE
Update const.py

### DIFF
--- a/custom_components/powercalc/const.py
+++ b/custom_components/powercalc/const.py
@@ -30,6 +30,8 @@ MODE_FIXED = "fixed"
 MANUFACTURER_DIRECTORY_MAPPING = {
     "IKEA of Sweden": "ikea",
     "Feibit Inc co.  ": "jiawen",
+    "LEDVANCE": "ledvance",
+    "MLI": "mueller-licht",
     "OSRAM": "osram",
     "Signify Netherlands B.V.": "signify",
 }
@@ -37,12 +39,12 @@ MANUFACTURER_DIRECTORY_MAPPING = {
 MODEL_DIRECTORY_MAPPING = {
     "IKEA of Sweden": {
         "TRADFRI bulb E14 WS opal 400lm": "LED1536G5",
+        "TRADFRI bulb E27 WS opal 980lm": "LED1545G12",
         "TRADFRI bulb E27 WS clear 950lm": "LED1546G12",
         "TRADFRI bulb E27 opal 1000lm": "LED1623G12",
         "TRADFRI bulb E27 CWS opal 600lm": "LED1624G9",
         "TRADFRI bulb E14 W op/ch 400lm": "LED1649C5",
         "TRADFRI bulb GU10 W 400lm": "LED1650R5",
         "TRADFRI bulb E27 WS opal 1000lm": "LED1732G11",
-        "TRADFRI bulb E27 WS opal 980lm": "LED1545G12",
     }
 }


### PR DESCRIPTION
Create mappings for Ledvance (I'm really surprised, but older Ledvance products still use brand Osram as manufacturer but newer not) and for Müller-Licht
https://www.mueller-licht.de

and also sort Ikea models by model number (to be easier to maintain, manufaturer mappings are also sorted by value).