### PR TITLE
Increase digits from 2 to 4 for energy sensors

### DIFF
--- a/custom_components/powercalc/sensor.py
+++ b/custom_components/powercalc/sensor.py
@@ -218,7 +218,7 @@ async def async_setup_platform(
             VirtualEnergySensor(
                 source_entity=power_sensor.entity_id,
                 name=energy_sensor_name,
-                round_digits=2,
+                round_digits=4,
                 unit_prefix="k",
                 unit_of_measurement=None,
                 unit_time=TIME_HOURS,


### PR DESCRIPTION
As already discussed, this seems to improve graphs for low-wattage devices.