### PR TITLE
Use entity_id as base for power/energy sensors ids

### DIFF
--- a/custom_components/powercalc/model_discovery.py
+++ b/custom_components/powercalc/model_discovery.py
@@ -1,0 +1,88 @@
+"""Utilities for auto discovery of light models."""
+
+from __future__ import annotations
+from collections import namedtuple
+
+import logging
+import os
+from typing import NamedTuple, Optional
+
+from .const import (
+    CONF_CUSTOM_MODEL_DIRECTORY,
+    CONF_MANUFACTURER,
+    CONF_MODEL,
+)
+
+from homeassistant.components.hue.const import DOMAIN as HUE_DOMAIN
+from homeassistant.components.light import Light
+import homeassistant.helpers.entity_registry as er
+from homeassistant.helpers.typing import (
+    HomeAssistantType,
+)
+
+from .light_model import LightModel
+
+_LOGGER = logging.getLogger(__name__)
+
+async def get_light_model(
+    hass: HomeAssistantType, entity_entry, config: dict
+) -> Optional[LightModel]:
+    manufacturer = config.get(CONF_MANUFACTURER)
+    model = config.get(CONF_MODEL)
+    if (manufacturer is None or model is None) and entity_entry:
+        hue_model_info = await autodiscover_hue_model(hass, entity_entry)
+        if hue_model_info:
+            manufacturer = hue_model_info.manufacturer
+            model = hue_model_info.model
+
+    if manufacturer is None or model is None:
+        return None
+
+    custom_model_directory = config.get(CONF_CUSTOM_MODEL_DIRECTORY)
+    if custom_model_directory:
+        custom_model_directory = os.path.join(
+            hass.config.config_dir, custom_model_directory
+        )
+
+    return LightModel(manufacturer, model, custom_model_directory)
+
+
+async def autodiscover_hue_model(hass: HomeAssistantType, entity_entry) -> Optional[HueModelInfo]:
+    # When Philips Hue model is enabled we can auto discover manufacturer and model from the bridge data
+    if hass.data.get(HUE_DOMAIN) is None or entity_entry.platform != "hue":
+        return
+
+    light = await find_hue_light(hass, entity_entry)
+    if light is None:
+        _LOGGER.error(
+            "Cannot autodiscover model for '%s', not found in the hue bridge api",
+            entity_entry.entity_id,
+        )
+        return
+
+    _LOGGER.debug(
+        "Auto discovered Hue model for entity %s: (manufacturer=%s, model=%s)",
+        entity_entry.entity_id,
+        light.manufacturername,
+        light.modelid,
+    )
+
+    return HueModelInfo(light.manufacturername, light.modelid)
+
+async def find_hue_light(
+    hass: HomeAssistantType, entity_entry: er.RegistryEntry
+) -> Light | None:
+    """Find the light in the Hue bridge, we need to extract the model id."""
+
+    bridge = hass.data[HUE_DOMAIN][entity_entry.config_entry_id]
+    lights = bridge.api.lights
+    for light_id in lights:
+        light = bridge.api.lights[light_id]
+        if light.uniqueid == entity_entry.unique_id:
+            return light
+
+    return None
+
+class HueModelInfo(NamedTuple):
+    manufacturer: str
+    model: str

--- a/custom_components/powercalc/sensor.py
+++ b/custom_components/powercalc/sensor.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import logging
-import os
-from typing import Any, Optional
+from typing import Any, NamedTuple
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.entity_registry as er
@@ -20,12 +19,12 @@ from homeassistant.components import (
     sensor,
     switch,
 )
-from homeassistant.components.hue.const import DOMAIN as HUE_DOMAIN
+
 from homeassistant.components.integration.sensor import (
     TRAPEZOIDAL_METHOD,
     IntegrationSensor,
 )
-from homeassistant.components.light import PLATFORM_SCHEMA, Light
+from homeassistant.components.light import PLATFORM_SCHEMA
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
 from homeassistant.const import (
     CONF_ENTITY_ID,
@@ -79,6 +78,7 @@ from .const import (
 )
 from .errors import ModelNotSupported, StrategyConfigurationError, UnsupportedMode
 from .light_model import LightModel
+from .model_discovery import get_light_model
 from .strategy_fixed import CONFIG_SCHEMA as FIXED_SCHEMA
 from .strategy_interface import PowerCalculationStrategyInterface
 from .strategy_linear import CONFIG_SCHEMA as LINEAR_SCHEMA
@@ -135,19 +135,15 @@ async def async_setup_platform(
 ):
     """Set up the sensor platform."""
 
-    calculation_strategy_factory = hass.data[DOMAIN][DATA_CALCULATOR_FACTORY]
     component_config = hass.data[DOMAIN][DOMAIN_CONFIG]
 
     source_entity = config[CONF_ENTITY_ID]
+    source_entity_domain, source_object_id = split_entity_id(source_entity)
 
     entity_registry = await er.async_get_registry(hass)
     entity_entry = entity_registry.async_get(source_entity)
-    entity_state = hass.states.get(source_entity)
 
     unique_id = None
-
-    source_entity_domain, source_object_id = split_entity_id(source_entity)
-
     if entity_entry:
         source_entity_name = entity_entry.name or entity_entry.original_name
         source_entity_domain = entity_entry.domain
@@ -155,60 +151,24 @@ async def async_setup_platform(
     else:
         source_entity_name = source_object_id.replace("_", " ")
 
+    entity_state = hass.states.get(source_entity)
     if entity_state:
         source_entity_name = entity_state.name
 
-    light_model = None
-    try:
-        light_model = await get_light_model(hass, entity_entry, config)
-    except (ModelNotSupported) as err:
-        _LOGGER.info("Model not found in library %s: %s", source_entity, err)
-
-    try:
-        mode = select_calculation_mode(config, light_model)
-        calculation_strategy = calculation_strategy_factory.create(
-            config, mode, light_model, source_entity_domain
-        )
-        await calculation_strategy.validate_config(entity_entry)
-    except (ModelNotSupported, UnsupportedMode) as err:
-        _LOGGER.error("Skipping sensor setup %s: %s", source_entity, err)
-        return
-    except StrategyConfigurationError as err:
-        _LOGGER.error("Error setting up calculation strategy: %s", err)
-        return
-
-    standby_usage = None
-    if not config.get(CONF_DISABLE_STANDBY_USAGE):
-        standby_usage = config.get(CONF_STANDBY_USAGE)
-        if standby_usage is None and light_model is not None:
-            standby_usage = light_model.standby_usage
-
-    power_name_pattern = component_config.get(CONF_POWER_SENSOR_NAMING)
-    name = config.get(CONF_NAME) or power_name_pattern.format(source_entity_name)
-    entity_id = config.get(CONF_NAME) or power_name_pattern.format(source_object_id)
-
-    _LOGGER.debug(
-        "Setting up power sensor. entity_id:%s sensor_name:%s strategy=%s manufacturer=%s model=%s standby_usage=%s unique_id=%s",
+    source_entity = SourceEntity(
+        unique_id,
+        source_object_id,
         source_entity,
-        name,
-        calculation_strategy.__class__.__name__,
-        light_model.manufacturer if light_model else "",
-        light_model.model if light_model else "",
-        standby_usage,
-        unique_id
+        source_entity_name,
+        source_entity_domain
     )
 
-    power_sensor = VirtualPowerSensor(
-        hass=hass,
-        power_calculator=calculation_strategy,
-        entity_id=entity_id,
-        name=name,
-        source_entity=source_entity,
-        source_domain=source_entity_domain,
-        unique_id=unique_id,
-        standby_usage=standby_usage,
-        scan_interval=component_config.get(CONF_SCAN_INTERVAL),
-        multiply_factor=config.get(CONF_MULTIPLY_FACTOR),
+    power_sensor = await create_power_sensor(
+        hass,
+        entity_entry,
+        config,
+        component_config,
+        source_entity
     )
 
     entities_to_add = [power_sensor]
@@ -218,33 +178,111 @@ async def async_setup_platform(
         should_create_energy_sensor = config.get(CONF_CREATE_ENERGY_SENSOR)
 
     if should_create_energy_sensor:
-        energy_name_pattern = component_config.get(CONF_ENERGY_SENSOR_NAMING)
-        energy_sensor_name = energy_name_pattern.format(source_entity_name)
-        energy_sensor_entity_id = energy_name_pattern.format(source_object_id)
-        energy_sensor_entity_id = async_generate_entity_id("sensor.{}", energy_sensor_entity_id, hass=hass)
-
-
-        _LOGGER.debug("Creating energy sensor: %s", energy_sensor_name)
         entities_to_add.append(
-            VirtualEnergySensor(
-                source_entity=power_sensor.entity_id,
-                unique_id=unique_id,
-                entity_id=energy_sensor_entity_id,
-                name=energy_sensor_name,
-                round_digits=4,
-                unit_prefix="k",
-                unit_of_measurement=None,
-                unit_time=TIME_HOURS,
-                integration_method=TRAPEZOIDAL_METHOD,
-                powercalc_source_entity=source_entity,
-                powercalc_source_domain=source_entity_domain,
+            await create_energy_sensor(
+                hass,
+                component_config,
+                power_sensor,
+                source_entity
             )
         )
 
     async_add_entities(entities_to_add)
 
+async def create_power_sensor(
+    hass: HomeAssistantType,
+    entity_entry,
+    sensor_config: dict,
+    component_config: dict,
+    source_entity: SourceEntity
+) -> VirtualPowerSensor:
+    """Create the power sensor entity"""
 
-def select_calculation_mode(config: dict, light_model: LightModel):
+    calculation_strategy_factory = hass.data[DOMAIN][DATA_CALCULATOR_FACTORY]
+
+    name_pattern = component_config.get(CONF_POWER_SENSOR_NAMING)
+    name = sensor_config.get(CONF_NAME) or name_pattern.format(source_entity.name)
+    entity_id = sensor_config.get(CONF_NAME) or name_pattern.format(source_entity.object_id)
+
+    light_model = None
+    try:
+        light_model = await get_light_model(hass, entity_entry, sensor_config)
+    except (ModelNotSupported) as err:
+        _LOGGER.info("Model not found in library %s: %s", source_entity.entity_id, err)
+
+    try:
+        mode = select_calculation_mode(sensor_config, light_model)
+        calculation_strategy = calculation_strategy_factory.create(
+            sensor_config, mode, light_model, source_entity.domain
+        )
+        await calculation_strategy.validate_config(entity_entry)
+    except (ModelNotSupported, UnsupportedMode) as err:
+        _LOGGER.error("Skipping sensor setup %s: %s", source_entity.entity_id, err)
+        return
+    except StrategyConfigurationError as err:
+        _LOGGER.error("Error setting up calculation strategy: %s", err)
+        return
+
+    standby_usage = None
+    if not sensor_config.get(CONF_DISABLE_STANDBY_USAGE):
+        standby_usage = sensor_config.get(CONF_STANDBY_USAGE)
+        if standby_usage is None and light_model is not None:
+            standby_usage = light_model.standby_usage
+
+    _LOGGER.debug(
+        "Setting up power sensor. entity_id:%s sensor_name:%s strategy=%s manufacturer=%s model=%s standby_usage=%s unique_id=%s",
+        source_entity.entity_id,
+        name,
+        calculation_strategy.__class__.__name__,
+        light_model.manufacturer if light_model else "",
+        light_model.model if light_model else "",
+        standby_usage,
+        source_entity.unique_id
+    )
+
+    return VirtualPowerSensor(
+        hass=hass,
+        power_calculator=calculation_strategy,
+        entity_id=entity_id,
+        name=name,
+        source_entity=source_entity.entity_id,
+        source_domain=source_entity.domain,
+        unique_id=source_entity.unique_id,
+        standby_usage=standby_usage,
+        scan_interval=component_config.get(CONF_SCAN_INTERVAL),
+        multiply_factor=sensor_config.get(CONF_MULTIPLY_FACTOR),
+    )
+
+async def create_energy_sensor(
+    hass: HomeAssistantType,
+    component_config: dict,
+    power_sensor: VirtualPowerSensor,
+    source_entity: SourceEntity
+) -> VirtualEnergySensor:
+    name_pattern = component_config.get(CONF_ENERGY_SENSOR_NAMING)
+    name = name_pattern.format(source_entity.name)
+    entity_id = async_generate_entity_id(
+        "sensor.{}",
+        name_pattern.format(source_entity.object_id), 
+        hass=hass
+    )
+
+    _LOGGER.debug("Creating energy sensor: %s", name)
+    return VirtualEnergySensor(
+        source_entity=power_sensor.entity_id,
+        unique_id=source_entity.unique_id,
+        entity_id=entity_id,
+        name=name,
+        round_digits=4,
+        unit_prefix="k",
+        unit_of_measurement=None,
+        unit_time=TIME_HOURS,
+        integration_method=TRAPEZOIDAL_METHOD,
+        powercalc_source_entity=source_entity.entity_id,
+        powercalc_source_domain=source_entity.domain,
+    )
+
+def select_calculation_mode(config: dict, light_model: LightModel) -> str:
     """Select the calculation mode"""
     config_mode = config.get(CONF_MODE)
     if config_mode:
@@ -270,67 +308,6 @@ def select_calculation_mode(config: dict, light_model: LightModel):
     raise UnsupportedMode(
         "Cannot select a mode (LINEAR, FIXED or LUT), supply it in the config"
     )
-
-
-async def get_light_model(
-    hass: HomeAssistantType, entity_entry, config: dict
-) -> Optional[LightModel]:
-    manufacturer = config.get(CONF_MANUFACTURER)
-    model = config.get(CONF_MODEL)
-    if (manufacturer is None or model is None) and entity_entry:
-        hue_model_data = await autodiscover_hue_model(hass, entity_entry)
-        if hue_model_data:
-            manufacturer = hue_model_data["manufacturer"]
-            model = hue_model_data["model"]
-
-    if manufacturer is None or model is None:
-        return None
-
-    custom_model_directory = config.get(CONF_CUSTOM_MODEL_DIRECTORY)
-    if custom_model_directory:
-        custom_model_directory = os.path.join(
-            hass.config.config_dir, custom_model_directory
-        )
-
-    return LightModel(manufacturer, model, custom_model_directory)
-
-
-async def autodiscover_hue_model(hass: HomeAssistantType, entity_entry):
-    # When Philips Hue model is enabled we can auto discover manufacturer and model from the bridge data
-    if hass.data.get(HUE_DOMAIN) is None or entity_entry.platform != "hue":
-        return
-
-    light = await find_hue_light(hass, entity_entry)
-    if light is None:
-        _LOGGER.error(
-            "Cannot autodiscover model for '%s', not found in the hue bridge api",
-            entity_entry.entity_id,
-        )
-        return
-
-    _LOGGER.debug(
-        "Auto discovered Hue model for entity %s: (manufacturer=%s, model=%s)",
-        entity_entry.entity_id,
-        light.manufacturername,
-        light.modelid,
-    )
-
-    return {"manufacturer": light.manufacturername, "model": light.modelid}
-
-
-async def find_hue_light(
-    hass: HomeAssistantType, entity_entry: er.RegistryEntry
-) -> Light | None:
-    """Find the light in the Hue bridge, we need to extract the model id."""
-
-    bridge = hass.data[HUE_DOMAIN][entity_entry.config_entry_id]
-    lights = bridge.api.lights
-    for light_id in lights:
-        light = bridge.api.lights[light_id]
-        if light.uniqueid == entity_entry.unique_id:
-            return light
-
-    return None
 
 
 class VirtualPowerSensor(Entity):
@@ -495,3 +472,10 @@ class VirtualEnergySensor(IntegrationSensor):
     @property
     def icon(self):
         return ENERGY_ICON
+
+class SourceEntity(NamedTuple):
+    unique_id: str
+    object_id: str
+    entity_id: str
+    name: str
+    domain: str


### PR DESCRIPTION
 and prefer friendly name for name

Todo:
- Cleanup code
- Extensive testing
  - Change the friendly name of the source entity
  - Change the entity_id of the source entity
  - Specific name for power sensor (does this still override the global setting)
  - Change the naming pattern. Will this remove historic data?