### PR TITLE
Revert "Removing redundant model id from model name string"

### DIFF
--- a/custom_components/powercalc/data/ikea/LED1536G5/model.json
+++ b/custom_components/powercalc/data/ikea/LED1536G5/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "TRADFRI bulb E14 WS opal 400lm",
+    "name": "TRADFRI bulb E14 WS opal 400lm LED1536G5",
     "standby_usage": 0.44,
     "supported_modes": [
         "lut"

--- a/custom_components/powercalc/data/ikea/LED1537R6/model.json
+++ b/custom_components/powercalc/data/ikea/LED1537R6/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "TRADFRI bulb GU10 WS 400lm",
+    "name": "TRADFRI bulb GU10 WS 400lm LED1537R6",
     "standby_usage": 0.44,
     "supported_modes": [
         "lut"

--- a/custom_components/powercalc/data/ikea/LED1545G12/model.json
+++ b/custom_components/powercalc/data/ikea/LED1545G12/model.json
@@ -1,8 +1,5 @@
 {
-    "measure_device": "unknown",
-    "measure_method": "script",
-    "name": "TRADFRI bulb E27 WS opal 980lm",
-    "standby_usage": 0.4,
+    "name": "TRADFRI bulb E27 WS opal 980lm LED1545G12",
     "supported_modes": [
         "lut"
     ]

--- a/custom_components/powercalc/data/ikea/LED1546G12/model.json
+++ b/custom_components/powercalc/data/ikea/LED1546G12/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "TRADFRI bulb E27 WS clear 950lm",
+    "name": "TRADFRI bulb E27 WS clear 950lm LED1546G12",
     "standby_usage": 0.43,
     "supported_modes": [
         "lut"

--- a/custom_components/powercalc/data/ikea/LED1623G12/model.json
+++ b/custom_components/powercalc/data/ikea/LED1623G12/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "TRADFRI bulb E27 opal 1000lm",
+    "name": "TRADFRI bulb E27 opal 1000lm LED1623G12",
     "standby_usage": 0.36,
     "supported_modes": [
         "lut"

--- a/custom_components/powercalc/data/ikea/LED1649C5/model.json
+++ b/custom_components/powercalc/data/ikea/LED1649C5/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "TRADFRI bulb E14 W op/ch 400lm",
+    "name": "TRADFRI bulb E14 W op/ch 400lm LED1649C5",
     "standby_usage": 0.40,
     "supported_modes": [
         "lut"

--- a/custom_components/powercalc/data/ikea/LED1650R5/model.json
+++ b/custom_components/powercalc/data/ikea/LED1650R5/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "TRADFRI bulb GU10 W 400lm",
+    "name": "TRADFRI bulb GU10 W 400lm LED1650R5",
     "standby_usage": 0.38,
     "supported_modes": [
         "lut"

--- a/custom_components/powercalc/data/ikea/LED1732G11/model.json
+++ b/custom_components/powercalc/data/ikea/LED1732G11/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "TRADFRI bulb E27 WS opal 1000lm",
+    "name": "TRADFRI bulb E27 WS opal 1000lm LED1732G11",
     "standby_usage": 0.26,
     "supported_modes": [
         "lut"

--- a/custom_components/powercalc/data/ikea/LED1837R5/model.json
+++ b/custom_components/powercalc/data/ikea/LED1837R5/model.json
@@ -1,7 +1,7 @@
 {
     "measure_device": "Fibaro FGWP102",
     "measure_method": "script",
-    "name": "TRADFRI bulb GU10 WW 400lm",
+    "name": "IKEA Tradfri LED1837R5",
     "standby_usage": 0.4,
     "supported_modes": [
         "lut"


### PR DESCRIPTION
Reverts bramstroker/homeassistant-powercalc#234
as I described in #234 

And I can only suggest to use as much as possible information in name field in model.json file.