### PR TITLE
additional sleeps only for significant changes in hue, sat and ct - fixes #257

### DIFF
--- a/utils/measure_v2/.env.dist
+++ b/utils/measure_v2/.env.dist
@@ -7,11 +7,14 @@ LIGHT_CONTROLLER=hue
 # time between changing the light params and taking the measurement
 SLEEP_TIME=2
 
-# time to wait between each increase in hue
+# additional time to wait for each significant change in hue
 SLEEP_TIME_HUE=5 
 
-# time to wait between each increase in saturation
+# additional time to wait for each significant change in saturation
 SLEEP_TIME_SAT=10
+
+# additional time to wait for each significant change in color temperature
+SLEEP_TIME_CT=10
 
 # Change this when the script crashes due to connectivity issues, so you don't have to start all over again
 START_BRIGHTNESS=1


### PR DESCRIPTION
Executes the additional SLEEPs only for significant jumps in hue, saturation or color temperature in order to significantly (at least with default parameters) reduce overall run time of the measurement script.