### PR TITLE
runDocker.BAT for docker with local files + message about missing configuration.

### DIFF
--- a/utils/measure/.gitignore
+++ b/utils/measure/.gitignore
@@ -5,3 +5,4 @@ light_controller/.python_hue
 measure.log
 .persistent
 !/**/.gitkeep
+DOCKER_IMAGE_BUILT

--- a/utils/measure/Dockerfile
+++ b/utils/measure/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
-COPY . .
+# Not copying local dir, export local dir to container.
+#COPY . .
 
 CMD [ "python3", "measure.py"]

--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import time
 from dataclasses import asdict, dataclass
 from typing import Iterator, Optional
@@ -47,7 +48,11 @@ POWER_METERS = [
     POWER_METER_TUYA,
 ]
 
-SELECTED_POWER_METER = config("POWER_METER")
+NOT_DEFINED="Not defined"
+SELECTED_POWER_METER = config("POWER_METER","Not defined")
+if SELECTED_POWER_METER == NOT_DEFINED:
+    print("*** ERROR: You need to setup '.env' from '.env.dist' with a POWER_METER.  See README.md ***\n")
+    sys.exit(-1)
 
 LIGHT_CONTROLLER_HUE = "hue"
 LIGHT_CONTROLLER_HASS = "hass"

--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -49,7 +49,7 @@ POWER_METERS = [
 ]
 
 NOT_DEFINED="Not defined"
-SELECTED_POWER_METER = config("POWER_METER","Not defined")
+SELECTED_POWER_METER = config("POWER_METER",NOT_DEFINED)
 if SELECTED_POWER_METER == NOT_DEFINED:
     print("*** ERROR: You need to setup '.env' from '.env.dist' with a POWER_METER.  See README.md ***\n")
     sys.exit(-1)

--- a/utils/measure/runDocker.BAT
+++ b/utils/measure/runDocker.BAT
@@ -1,0 +1,13 @@
+@echo off
+REM Build & Launch on windows
+if not exist DOCKER_IMAGE_BUILT (
+  docker build -t measure_local .
+  echo Done > DOCKER_IMAGE_BUILT
+)
+REM CYGWIN COMMAND : 
+REM docker run --rm --name=measure_local -env-file=.env -v "$(cygpath -w $(pwd)):/app" -it  measure_local
+
+
+SET SCRIPTPATH=%~dp0
+docker run --rm --name=measure_local -env-file=.env -v "%SCRIPTPATH%:/app" -it  measure_local
+


### PR DESCRIPTION
runDocker.BAT will build the docker image from the local files (not from remote repository)
and use the local files in the docker image which makes updating and testing them easier.

Updated 'measure.py' to hint that the .env file needs to be created.

The README.md contains setup instruction that require to execute python commands
that did not seem to apply to the docker setup.
But in fact, setting up '.env' still applies.

The README.md could also be updated, but I added an exit message to
measure.py.

I do not know if this is the "docker" way of doing things,
but this was an occasion for me to have another look at docker -;).