### PR TITLE
Ikea WA for model names given by zigbee2mqtt

### DIFF
--- a/custom_components/powercalc/light_model.py
+++ b/custom_components/powercalc/light_model.py
@@ -27,7 +27,10 @@ class LightModel:
         custom_model_directory: str,
     ):
         self._manufacturer = manufacturer
-        self._model = model
+        if manufacturer and manufacturer.lower() == "ikea":
+            self._model = model.split("/")[0]
+        else:
+            self._model = model
         self._custom_model_directory = custom_model_directory
         self._hass = hass
         self._json_data = self.load_model_manifest()


### PR DESCRIPTION
Zigbee2mqtt after auto-discovery named some of ikea devices as:
LED1537R6/LED1739R5 or E2001/E2002	
to WA this, we can get first part of the name and calculate power based on this.