### PR TITLE
Added TRADFRI bulb E27 W opal 1000lm

### DIFF
--- a/custom_components/powercalc/const.py
+++ b/custom_components/powercalc/const.py
@@ -101,6 +101,7 @@ MODEL_DIRECTORY_MAPPING = {
         "TRADFRI bulb E27 WS opal 980lm": "LED1545G12",
         "TRADFRI bulb E27 WS clear 950lm": "LED1546G12",
         "TRADFRI bulb E27 opal 1000lm": "LED1623G12",
+        "TRADFRI bulb E27 W opal 1000lm": "LED1623G12",
         "TRADFRI bulb E27 CWS opal 600lm": "LED1624G9",
         "TRADFRI bulb E14 W op/ch 400lm": "LED1649C5",
         "TRADFRI bulb GU10 W 400lm": "LED1650R5",


### PR DESCRIPTION
Refers to same data files as "TRADFRI bulb E27 opal 1000lm" per https://zigbee.blakadder.com/Ikea_LED1623G12.html