### PR TITLE
Fix utility meter tariffs being reset to []

### DIFF
--- a/custom_components/powercalc/sensor.py
+++ b/custom_components/powercalc/sensor.py
@@ -171,9 +171,7 @@ SENSOR_CONFIG = {
     vol.Optional(CONF_DAILY_FIXED_ENERGY): DAILY_FIXED_ENERGY_SCHEMA,
     vol.Optional(CONF_CREATE_ENERGY_SENSOR): cv.boolean,
     vol.Optional(CONF_CREATE_UTILITY_METERS): cv.boolean,
-    vol.Optional(CONF_UTILITY_METER_TARIFFS, default=[]): vol.All(
-        cv.ensure_list, [cv.string]
-    ),
+    vol.Optional(CONF_UTILITY_METER_TARIFFS): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_UTILITY_METER_TYPES): vol.All(
         cv.ensure_list, [vol.In(METER_TYPES)]
     ),


### PR DESCRIPTION
When setting a global tariff, but not individual device tariffs, the config was merged to [] because of the default set in 'sensor.py'.

Removing this resolves that problem. The default will still be set at a global level.