### PR TITLE
Change values for measurement

### DIFF
--- a/utils/measure/.env.dist
+++ b/utils/measure/.env.dist
@@ -25,15 +25,12 @@ SLEEP_TIME_CT=1
 # Set to a value higher than 1 to take multiple samples to reduce noise
 SAMPLE_COUNT=2
 
-# Step sizes for HS mode loop. You can increase these to improve the duration of measure session
-# Don't set higher than duplicate these values!
+# Precision for the HS mode loop. You can increase it up to 4 to improve the precision
+# of the profile by taking more measurements
 
-# 5 values
-HS_BRI_STEPS=51
-# 24 values
-HS_HUE_STEPS=2731
-# 8 values
-HS_SAT_STEPS=32
+HS_BRI_PRECISION=1.0
+HS_HUE_PRECISION=1.0
+HS_SAT_PRECISION=1.0
 
 # Shelly
 SHELLY_IP=x.x.x.x

--- a/utils/measure/.env.dist
+++ b/utils/measure/.env.dist
@@ -8,32 +8,36 @@ LIGHT_CONTROLLER=hue
 LOG_LEVEL=INFO
 
 # time between changing the light params and taking the measurement
-SLEEP_TIME=2
+SLEEP_TIME=3
 
 # time between taking multiple samples for the same light setting
-SLEEP_TIME_SAMPLE=1
+SLEEP_TIME_SAMPLE=3
 
 # additional time to wait for each significant change in hue
-SLEEP_TIME_HUE=5 
+SLEEP_TIME_HUE=2 
 
 # additional time to wait for each significant change in saturation
-SLEEP_TIME_SAT=10
+SLEEP_TIME_SAT=2
 
 # additional time to wait for each significant change in color temperature
-SLEEP_TIME_CT=10
+SLEEP_TIME_CT=1
 
 # Set to a value higher than 1 to take multiple samples to reduce noise
-SAMPLE_COUNT=1
+SAMPLE_COUNT=2
 
 # Step sizes for HS mode loop. You can increase these to improve the duration of measure session
 # Don't set higher than duplicate these values!
-HS_BRI_STEPS=10
-HS_HUE_STEPS=2000
-HS_SAT_STEPS=10
+
+# 5 values
+HS_BRI_STEPS=51
+# 24 values
+HS_HUE_STEPS=2731
+# 8 values
+HS_SAT_STEPS=32
 
 # Shelly
 SHELLY_IP=x.x.x.x
-SHELLY_TIMEOUT=5
+SHELLY_TIMEOUT=60
 
 # Tuya
 TUYA_DEVICE_ID=aaaaaaaaad89682385bbb

--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -49,8 +49,8 @@ MIN_BRIGHTNESS = min(max(
     ), 1), 255
 )
 MAX_BRIGHTNESS = 255
-MIN_SAT = min(max(config("MIN_SAT", default=1, cast=int), 1), 254)
-MAX_SAT = min(max(config("MAX_SAT", default=254, cast=int), 1), 254)
+MIN_SAT = min(max(config("MIN_SAT", default=1, cast=int), 1), 255)
+MAX_SAT = min(max(config("MAX_SAT", default=255, cast=int), 1), 255)
 MIN_HUE = min(max(config("MIN_HUE", default=1, cast=int), 1), 65535)
 MAX_HUE = min(max(config("MAX_HUE", default=65535, cast=int), 1), 65535)
 CT_BRI_STEPS = min(config("CT_BRI_STEPS", default=5, cast=int), 10)

--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -56,9 +56,24 @@ MAX_HUE = min(max(config("MAX_HUE", default=65535, cast=int), 1), 65535)
 CT_BRI_STEPS = min(config("CT_BRI_STEPS", default=5, cast=int), 10)
 CT_MIRED_STEPS = min(config("CT_BRI_STEPS", default=10, cast=int), 10)
 BRI_BRI_STEPS = 1
-HS_BRI_STEPS = min(config("HS_BRI_STEPS", default=10, cast=int), 20)
-HS_HUE_STEPS = min(config("HS_HUE_STEPS", default=2000, cast=int), 4000)
-HS_SAT_STEPS = min(config("HS_SAT_STEPS", default=10, cast=int), 20)
+
+HS_BRI_PRECISION = config("HS_BRI_PRECISION", default=1, cast=float)
+HS_BRI_PRECISION = min(HS_BRI_PRECISION, 4)
+HS_BRI_PRECISION = max(HS_BRI_PRECISION, 0.5)
+HS_BRI_STEPS = round(32 / HS_BRI_PRECISION)
+del HS_BRI_PRECISION
+
+HS_HUE_PRECISION = config("HS_HUE_PRECISION", default=1, cast=float)
+HS_HUE_PRECISION = min(HS_HUE_PRECISION, 4)
+HS_HUE_PRECISION = max(HS_HUE_PRECISION, 0.5)
+HS_HUE_STEPS = round(2731 / HS_HUE_PRECISION)
+del HS_HUE_PRECISION
+
+HS_SAT_PRECISION = config("HS_SAT_PRECISION", default=1, cast=float)
+HS_SAT_PRECISION = min(HS_SAT_PRECISION, 4)
+HS_SAT_PRECISION = max(HS_SAT_PRECISION, 0.5)
+HS_SAT_STEPS = round(32 / HS_SAT_PRECISION)
+del HS_SAT_PRECISION
 
 POWER_METER_DUMMY = "dummy"
 POWER_METER_HASS = "hass"


### PR DESCRIPTION
Shelly is kinda slow to respond with new values to changes of the bulb. That's why it makes sense to have a generous sleep time between individual measurements, to avoid reading the "previous value".

Since the overall sleep time is pretty generous we can reduce the sleep time for sat/hue/ct changes.

---


I further reduced the steps to the default of HA:

24 different colors in a ring with 8 saturation steps. Also I think 5 brightness steps allows fair estimations if between them.

This results in a measuring time of around 12 hours instead of 36 which I previous got with longer sleep intervals (because of shellys slow response.

--- 

I increase the timeout for the shelly. There's nothing wrong with waiting a bit longer instead of aborting - since we talk about wifi here.