### PR TITLE
update the idle consumption of Aquara ZNLDP12LM with a real value

### DIFF
--- a/custom_components/powercalc/data/aqara/ZNLDP12LM/model.json
+++ b/custom_components/powercalc/data/aqara/ZNLDP12LM/model.json
@@ -8,7 +8,7 @@
         "VERSION": "v0.10.4"
     },
     "name": "Aqara LED light bulb (tunable white)",
-    "standby_power": 0.05,
+    "standby_power": 0.41,
     "supported_modes": [
         "lut"
     ]


### PR DESCRIPTION
The previous value was just a placeholder, since the real consumption couldn't be measured with the available equipment. 