### PR TITLE
Add alias for Müller Licht GU10 spots (sold seperately) to kit model id

### DIFF
--- a/custom_components/powercalc/aliases.py
+++ b/custom_components/powercalc/aliases.py
@@ -91,4 +91,7 @@ MODEL_DIRECTORY_MAPPING = {
         "color2": "YLDP06YL",
 	"color4": "YLDP13YL",
     },
+    "MLI": {
+        "45327": "45318",
+    },
 }

--- a/custom_components/powercalc/aliases.py
+++ b/custom_components/powercalc/aliases.py
@@ -6,13 +6,14 @@ MANUFACTURER_ALIASES = {
     "Xiaomi": "Aqara",
     "LUMI": "Aqara",
     "ADEO": "Lexman",
+    "MLI": "Müller Licht",
 }
 
 MANUFACTURER_DIRECTORY_MAPPING = {
     "IKEA of Sweden": "ikea",
     "Feibit Inc co.  ": "jiawen",
     "LEDVANCE": "ledvance",
-    "MLI": "mueller-licht",
+    "Müller Licht": "mueller-licht",
     "OSRAM": "osram",
     "Signify Netherlands B.V.": "signify",
     "Aqara": "aqara",
@@ -91,7 +92,7 @@ MODEL_DIRECTORY_MAPPING = {
         "color2": "YLDP06YL",
 	"color4": "YLDP13YL",
     },
-    "MLI": {
+    "Müller Licht": {
         "45327": "45318",
     },
 }


### PR DESCRIPTION
The kit (a remote and a GU10 bulb has the model id 45318 while the seperately sold bulb has the model id 45327. But the bulbs are in fact the same devices.