### PR TITLE
Müller Licht: change standby consumption to certificated consumption

### DIFF
--- a/custom_components/powercalc/data/mueller-licht/45311/model.json
+++ b/custom_components/powercalc/data/mueller-licht/45311/model.json
@@ -8,7 +8,7 @@
         "VERSION": "v0.20.3:docker"
     },
     "name": "M\u00fcller Licht E27 Globe Gold",
-    "standby_power": 0.21,
+    "standby_power": 0.26,
     "supported_modes": [
         "lut"
     ]

--- a/custom_components/powercalc/data/mueller-licht/45318/model.json
+++ b/custom_components/powercalc/data/mueller-licht/45318/model.json
@@ -8,7 +8,7 @@
         "VERSION": "v0.20.3:docker"
     },
     "name": "M\u00fcller Licht GU10 Spot white+color",
-    "standby_power": 0.32,
+    "standby_power": 0.15,
     "supported_modes": [
         "lut"
     ]

--- a/custom_components/powercalc/data/mueller-licht/45328/model.json
+++ b/custom_components/powercalc/data/mueller-licht/45328/model.json
@@ -8,7 +8,7 @@
         "VERSION": "v0.20.3:docker"
     },
     "name": "M\u00fcller Licht E14 Kerze white+color",
-    "standby_power": 0.39,
+    "standby_power": 0.31,
     "supported_modes": [
         "lut"
     ]


### PR DESCRIPTION
In the EU bulbs have an energy label – usually not really helpful for us – but they have to specify the "networked standby power Pnet" – so I changed my standby measurements to these values with this PR.

While my measurements are pretty accurate, this is still a bit off from real laboratory equipment. Especially on very low "idle consumption" which is only taking a small amount of energy in a fraction of each wave.

This is also an issue with these new "smart" power meters, actually and just a limitation of cheaper electronics:

https://www.augsburger-allgemeine.de/digital/Geraete-Test-Forscher-Smart-Meter-messen-ungenau-id40833181.html