### PR TITLE
Adding Aliases for Hue Lightstrips LST002 and LST001

### DIFF
--- a/custom_components/powercalc/aliases.py
+++ b/custom_components/powercalc/aliases.py
@@ -91,6 +91,8 @@ MODEL_DIRECTORY_MAPPING = {
         "8718699703424": "LCL001",
         "8718699671211": "LWE002",
         "9290020399": "LWE002",
+        "915005106701": "LST002",
+        "7299355PH":,"LST001",
         # US Versions. Alias to EU versions
         "LCA005": "LCA001",
         "9290022266A": "LCA001",

--- a/custom_components/powercalc/aliases.py
+++ b/custom_components/powercalc/aliases.py
@@ -92,7 +92,7 @@ MODEL_DIRECTORY_MAPPING = {
         "8718699671211": "LWE002",
         "9290020399": "LWE002",
         "915005106701": "LST002",
-        "7299355PH":,"LST001",
+        "7299355PH":"LST001",
         # US Versions. Alias to EU versions
         "LCA005": "LCA001",
         "9290022266A": "LCA001",


### PR DESCRIPTION
Hey,
i'm using Zigbee2Mqtt and needed to add two aliases for my LST001 and LST002 Lightstrips.
It works on my setup.

It is my very first Pull Request.  