### PR TITLE
Spelling: to much -> too many

### DIFF
--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -260,7 +260,7 @@ class Measure:
                     self.num_0_readings += 1
                     _LOGGER.warning(f"Discarding measurement: {error}")
                     if self.num_0_readings > MAX_ALLOWED_0_READINGS:
-                        _LOGGER.error("Aborting measurement session. Received to much 0 readings")
+                        _LOGGER.error("Aborting measurement session. Received too many 0 readings")
                         return
                     continue
                 except PowerMeterError as error:


### PR DESCRIPTION
Annoyingly, there's some issue with my tuya based Arlec power measuring tool.

https://www.bunnings.com.au/arlec-grid-connect-black-smart-plug-in-socket-with-energy-meter_p0273366

Seems to work with localtuya and homeassistant, not so much here; thus finding the spelling error:
```
2022-07-17 07:57:58,478 [WARNING] Discarding measurement: 0 watt was read from the power meter
2022-07-17 07:57:58,479 [INFO] Progress: 20%, Estimated time left: 32.3m
2022-07-17 07:57:58,479 [INFO] Changing light to: Variation(bri=51)
2022-07-17 07:58:01,841 [INFO] {'datetime': '2022-07-17T07:58:01Z', 'switch': True, 'power': 0.0, 'current': 0.0, 'voltage': 241.0}
2022-07-17 07:58:05,117 [INFO] {'datetime': '2022-07-17T07:58:04Z', 'switch': True, 'power': 0.0, 'current': 0.0, 'voltage': 241.0}
2022-07-17 07:58:08,305 [INFO] {'datetime': '2022-07-17T07:58:08Z', 'switch': True, 'power': 0.0, 'current': 0.0, 'voltage': 241.0}
2022-07-17 07:58:11,568 [INFO] {'datetime': '2022-07-17T07:58:11Z', 'switch': True, 'power': 0.0, 'current': 0.0, 'voltage': 241.0}
2022-07-17 07:58:14,889 [INFO] {'datetime': '2022-07-17T07:58:14Z', 'switch': True, 'power': 0.0, 'current': 0.0, 'voltage': 241.0}
2022-07-17 07:58:18,122 [INFO] {'datetime': '2022-07-17T07:58:17Z', 'switch': True, 'power': 0.0, 'current': 0.0, 'voltage': 241.0}
2022-07-17 07:58:18,123 [WARNING] Discarding measurement: 0 watt was read from the power meter
2022-07-17 07:58:18,123 [ERROR] Aborting measurement session. Received to much 0 readings
```