### PR TITLE
Add Nudging

### DIFF
--- a/utils/measure/.env.dist
+++ b/utils/measure/.env.dist
@@ -25,6 +25,14 @@ SLEEP_TIME_CT=1
 # Set to a value higher than 1 to take multiple samples to reduce noise
 SAMPLE_COUNT=2
 
+# Power Meter Nudging configuration (Useful if PM doesn't report a new reading if readings are unchanged)
+# How many times should nudging the Power Meter be attempted?
+MAX_NUDGES=0
+# When Nudging, how long to hold the non-desired state for?
+PULSE_TIME_NUDGE=2
+# How long to wait for the Power Meter to settle on the desired measurement after nudging
+SLEEP_NUDGE=10
+
 # Precision for the HS mode loop. You can increase it up to 4 to improve the precision
 # of the profile by taking more measurements
 

--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -279,7 +279,7 @@ class Measure:
 
         if bool(answers.get("gzip", True)):
             self.gzip_csv(csv_file_path)
-    def nudge_and_remeasure(self, color_mode, variation):
+    def nudge_and_remeasure(self, color_mode: str, variation: Variation):
         for nudge_count in range(MAX_NUDGES):
             try:
                 # Likely not significant enough change for PM to detect. Try nudging it
@@ -294,7 +294,8 @@ class Measure:
                 # Wait a longer amount of time for the PM to settle
                 time.sleep(SLEEP_TIME_NUDGE)
                 power = self.take_power_measurement(variation_start_time)
-            except OutdatedMeasurementError as error:
+                return power
+            except OutdatedMeasurementError:
                 continue
             except ZeroReadingError as error:
                 self.num_0_readings += 1
@@ -303,14 +304,7 @@ class Measure:
                     _LOGGER.error("Aborting measurement session. Received too many 0 readings")
                     return
                 continue
-            except PowerMeterError as error:
-                _LOGGER.error(f"Aborting: {error}")
-                return
-            except error:
-                raise error
-            else:
-                return power
-        raise OutdatedMeasurementError(f"Power measurement is outdated. Aborting after {nudge_count} nudged retries")
+        raise OutdatedMeasurementError(f"Power measurement is outdated. Aborting after {nudge_count + 1} nudged retries")
 
     def should_resume(self, csv_file_path: str) -> bool:
         """Check whether we are able to resume a previous measurement session"""

--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -402,7 +402,7 @@ class Measure:
         time.sleep(SLEEP_STANDBY)
         try:
             return self.take_power_measurement(start_time)
-        except OutdatedMeasurementError as error:
+        except OutdatedMeasurementError:
             self.nudge_and_remeasure(MODE_BRIGHTNESS, Variation(0))
         except ZeroReadingError:
             _LOGGER.error("Measured 0 watt as standby usage, continuing now, but you probably need to have a look into measuring multiple lights at the same time or using a dummy load.")

--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -119,7 +119,10 @@ SLEEP_TIME_SAMPLE = config("SLEEP_TIME_SAMPLE", default=1, cast=int)
 SLEEP_TIME_HUE = config("SLEEP_TIME_HUE", default=5, cast=int)
 SLEEP_TIME_SAT = config("SLEEP_TIME_SAT", default=10, cast=int)
 SLEEP_TIME_CT = config("SLEEP_TIME_CT", default=10, cast=int)
+SLEEP_TIME_NUDGE = config("SLEEP_TIME_NUDGE", default=10, cast=float)
+PULSE_TIME_NUDGE = config("PULSE_TIME_NUDGE", default=2, cast=float)
 MAX_RETRIES = config("MAX_RETRIES", default=5, cast=int)
+MAX_NUDGES = config("MAX_NUDGES", default=0, cast=int)
 SAMPLE_COUNT = config("SAMPLE_COUNT", default=1, cast=int)
 
 SHELLY_IP = config("SHELLY_IP")
@@ -256,6 +259,8 @@ class Measure:
                 time.sleep(SLEEP_TIME)
                 try:
                     power = self.take_power_measurement(variation_start_time)
+                except OutdatedMeasurementError as error:
+                    self.nudge_and_remeasure(self.color_mode, variation)
                 except ZeroReadingError as error:
                     self.num_0_readings += 1
                     _LOGGER.warning(f"Discarding measurement: {error}")
@@ -274,6 +279,38 @@ class Measure:
 
         if bool(answers.get("gzip", True)):
             self.gzip_csv(csv_file_path)
+    def nudge_and_remeasure(self, color_mode, variation):
+        for nudge_count in range(MAX_NUDGES):
+            try:
+                # Likely not significant enough change for PM to detect. Try nudging it
+                _LOGGER.warning("Measurement is stuck, Nudging")
+                # If brightness is low, set brightness high. Else, turn light off
+                self.light_controller.change_light_state(MODE_BRIGHTNESS, on=(variation.bri < 128), bri=255)
+                time.sleep(PULSE_TIME_NUDGE)
+                variation_start_time = time.time()
+                self.light_controller.change_light_state(
+                    color_mode, on=True, **asdict(variation)
+                )
+                # Wait a longer amount of time for the PM to settle
+                time.sleep(SLEEP_TIME_NUDGE)
+                power = self.take_power_measurement(variation_start_time)
+            except OutdatedMeasurementError as error:
+                continue
+            except ZeroReadingError as error:
+                self.num_0_readings += 1
+                _LOGGER.warning(f"Discarding measurement: {error}")
+                if self.num_0_readings > MAX_ALLOWED_0_READINGS:
+                    _LOGGER.error("Aborting measurement session. Received too many 0 readings")
+                    return
+                continue
+            except PowerMeterError as error:
+                _LOGGER.error(f"Aborting: {error}")
+                return
+            except error:
+                raise error
+            else:
+                return power
+        raise OutdatedMeasurementError(f"Power measurement is outdated. Aborting after {nudge_count} nudged retries")
 
     def should_resume(self, csv_file_path: str) -> bool:
         """Check whether we are able to resume a previous measurement session"""
@@ -332,7 +369,7 @@ class Measure:
 
             # Check if measurement is not outdated
             if measurement.updated < start_timestamp:
-                error = OutdatedMeasurementError(f"Power measurement is outdated. Aborting after {MAX_RETRIES} retries")
+                error = OutdatedMeasurementError(f"Power measurement is outdated. Aborting after {MAX_RETRIES} successive retries")
 
             # Check if we not have a 0 measurument
             if measurement.power == 0:
@@ -371,6 +408,8 @@ class Measure:
         time.sleep(SLEEP_STANDBY)
         try:
             return self.take_power_measurement(start_time)
+        except OutdatedMeasurementError as error:
+            self.nudge_and_remeasure(MODE_BRIGHTNESS, Variation(0))
         except ZeroReadingError:
             _LOGGER.error("Measured 0 watt as standby usage, continuing now, but you probably need to have a look into measuring multiple lights at the same time or using a dummy load.")
             return 0


### PR DESCRIPTION
An Important Note: I am very new to Python, most of my programming is done in C based languages, which I have been doing for over a decade. (I am confident in my logic, but keep an eye out for odd syntax or bad conventions)

Added Logic to "Nudge" the PM when it isn't measuring any new readings. To enable this feature, there are additional configuration settings:
* MAX_NUDGES - The number of attempts to nudge and remeasure the PM.
Defaults to 0, disabling this feature.
* PULSE_TIME_NUDGE - How long to hold the non-desired state.
Defaults to 2
(How long to hold: Max brightness on low power measurements, min brightness on high power measurements)
* SLEEP_TIME_NUDGE - After nudging the PM, how long to wait for the PM to settle at the correct power level. 
Defaults to 10
(The amount of time it takes for the PM to settle from a large transition)

This logic resolved the issue in my case, but also has some room for improvement. 
(In my case I did use another improvement I'll submit as a separate PR)
Future Improvements that could be made:
1. Add logic to the new "nudge_and_remeasure" method to make calls to the PM to get new readings
(e.g. the HASS_CALL_UPDATE_ENTITY_SERVICE setting)
1. Quicker Light Transition Time
(So that the PMs settle quicker on the correct power reading, I'll submit a PR for the hass light driver)
3. Perform a secondary reading to verify the PM has settled

The Risk with swinging the power level between high and low is that it requires some increased settling time. If the users of this feature don't account for that, they could see some noisy measurements.