### PR TITLE
Fix Power calculation with Dummy Load

### DIFF
--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -350,9 +350,15 @@ class Measure:
             if SAMPLE_COUNT > 1:
                 time.sleep(SLEEP_TIME_SAMPLE)
 
-        value = sum(measurements) / len(measurements) / self.num_lights
+        # Determine Average PM reading
+        value = sum(measurements) / len(measurements)
+
+        # Subtract Dummy Load (if present)
         if self.is_dummy_load_connected:
             value = value - self.dummy_load_value
+        
+        # Determine per load power consumption
+        value /= self.num_lights
 
         return round(value, 2)
 


### PR DESCRIPTION
Hey, I found a bug with dummy loads used in conjunction of multiple lights
Calculation was accounting for dummy load on a per-light basis.
(I tried to paste the LaTeX here, but looks like GitHub can't render that)
<img width="304" alt="image" src="https://user-images.githubusercontent.com/31318348/183268024-747026f3-b3c1-4385-9876-e69d42859854.png">
