### PR TITLE
measure: fix that retried measurements weren't used

### DIFF
--- a/utils/measure/measure.py
+++ b/utils/measure/measure.py
@@ -344,7 +344,7 @@ class Measure:
                     raise error
                 retry_count += 1
                 time.sleep(SLEEP_TIME)
-                self.take_power_measurement(start_timestamp, retry_count)
+                return self.take_power_measurement(start_timestamp, retry_count)
 
             measurements.append(measurement.power)
             if SAMPLE_COUNT > 1:


### PR DESCRIPTION
Without the fix if there's an issue encountered in one of the measurements, the half-result is still used, after doing a full remeasurement in the recursion (and dropping those results).

Which may lead to a crash in L349 due to `AttributeError: 'NoneType' object has no attribute 'power'` or to a crash in L353: `ZeroDivisionError: division by zero`