### PR TITLE
added alias 929001953301 to Signify/LTG002 model

### DIFF
--- a/custom_components/powercalc/data/signify/LTG002/model.json
+++ b/custom_components/powercalc/data/signify/LTG002/model.json
@@ -11,5 +11,7 @@
     "supported_modes": [
         "lut"
     ],
-    "aliases": []
+    "aliases": [
+        "929001953301"
+    ]
 }


### PR DESCRIPTION
In order to automatically detect and configure Hue White Ambiance GU10 w/ BT i've added the alias to the Signify/LTG002 model and this has worked in my Home Assistant instance. 