### PR TITLE
Add zigbee2mqtt aliases for Signify lights

### DIFF
--- a/custom_components/powercalc/data/signify/LTW010/model.json
+++ b/custom_components/powercalc/data/signify/LTW010/model.json
@@ -6,5 +6,8 @@
     ],
     "measure_method": "script",
     "measure_device": "Shelly Plug S",
-    "measure_description": "Measured with script made by bramstroker and partially verified manual"
+    "measure_description": "Measured with script made by bramstroker and partially verified manual",
+    "aliases": [
+        "8718696548738"
+    ]
 }

--- a/custom_components/powercalc/data/signify/LWO001/model.json
+++ b/custom_components/powercalc/data/signify/LWO001/model.json
@@ -7,6 +7,8 @@
     "supported_modes": [
         "lut"
     ],
-    "aliases": []
+    "aliases": [
+        "8718699688882" 
+    ]
 }
 

--- a/custom_components/powercalc/data/signify/LWV001/model.json
+++ b/custom_components/powercalc/data/signify/LWV001/model.json
@@ -6,5 +6,8 @@
    ],
    "measure_device":"Gosund SP111 on Tasmota 9.5.0",
    "measure_description":"Measure Script for Tasmota",
-   "measure_method":"script"
+   "measure_method":"script",
+   "aliases":[
+      "929002241201"
+   ]
 }


### PR DESCRIPTION
Add zigbee2mqtt aliases for some Signify lights.

Links:
- https://www.zigbee2mqtt.io/devices/8718696548738.html#philips-8718696548738
- https://www.zigbee2mqtt.io/devices/8718699688882.html#philips-8718699688882
- https://www.zigbee2mqtt.io/devices/929002241201.html#philips-929002241201