### PR TITLE
Add alias for LED1835C6

### DIFF
--- a/custom_components/powercalc/data/ikea/LED1835C6/model.json
+++ b/custom_components/powercalc/data/ikea/LED1835C6/model.json
@@ -13,6 +13,7 @@
         "lut"
     ],
     "aliases": [
-        "TRADFRI bulb E14 WS 470lm"
+        "TRADFRI bulb E14 WS 470lm",
+        "LED1903C5/LED1835C6"
     ]
 }


### PR DESCRIPTION
added a alias, I think these is due to differences between deconz and z2m in how the model of a light is reported