### PR TITLE
Improvement to Swedish translation of "confirm"

### DIFF
--- a/custom_components/powercalc/translations/sv.json
+++ b/custom_components/powercalc/translations/sv.json
@@ -74,10 +74,10 @@
             },
             "lut": {
                 "data": {
-                    "confirm_autodisovered_model": "Konfirmera modell"
+                    "confirm_autodisovered_model": "Bekräfta modell"
                 },
                 "data_description": {
-                    "confirm_autodisovered_model": "Om du väljer att inte konfirmera kan du ange tillverkare och modell själv"
+                    "confirm_autodisovered_model": "Om du väljer att inte bekräfta kan du ange tillverkare och modell själv"
                 },
                 "description": "Tillverkare '({manufacturer})' och modell '({model})' var automatiskt detekterade för din lampa",
                 "title": "LUT konfig"


### PR DESCRIPTION
Use the word "bekräfta" instead of "konfirmera". Both are technically correct, but "bekräfta" is more commonly used (e.g. according to frequency of use in Google Translate).