### PR TITLE
Adds Ikea/Sonos Symfonisk speaker

### DIFF
--- a/custom_components/powercalc/data/sonos/symfonisk/model.json
+++ b/custom_components/powercalc/data/sonos/symfonisk/model.json
@@ -1,0 +1,30 @@
+{
+    "measure_description": "Streamed 'Pink noise' from https://www.genelec.com/audio-test-signals, and took average measurements over 20s using the docker container",
+    "measure_method": "manual",
+    "measure_device": "TPlink HS110 (kasa)",
+    "name": "SYMFONISK Bookshelf",
+    "standby_power": 2.56,
+    "device_type": "smart_speaker",
+    "supported_modes": [
+        "linear"
+    ],
+    "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+    "linear_config": {
+        "calibrate": [
+            "0 -> 2.98",
+            "10 -> 3.76",
+            "20 -> 3.81",
+            "30 -> 3.8",
+            "40 -> 3.77",
+            "50 -> 3.81",
+            "60 -> 3.92",
+            "70 -> 4.11",
+            "80 -> 4.6",
+            "90 -> 5.92",
+            "100 -> 9.3"
+        ]
+    },
+    "aliases": [
+        "IKEA SYMFONISK Bookshelf"
+    ]
+}


### PR DESCRIPTION
Streamed 'Pink noise' from https://www.genelec.com/audio-test-signals, and took average measurements over 20s using the docker container