### PR TITLE
Add alias for Sonos One SL

### DIFF
--- a/custom_components/powercalc/data/sonos/one/model.json
+++ b/custom_components/powercalc/data/sonos/one/model.json
@@ -25,6 +25,7 @@
         ]
     },
     "aliases": [
-        "Sonos ONE"
+        "Sonos ONE",
+        "Sonos One SL"
     ]
 }


### PR DESCRIPTION
This is a Sonos ONE without the microphone.