### PR TITLE
Add Zigbee2Mqtt alias for LWA004 for autodiscovery

### DIFF
--- a/custom_components/powercalc/data/signify/LWA004/model.json
+++ b/custom_components/powercalc/data/signify/LWA004/model.json
@@ -3,6 +3,9 @@
     "supported_modes": [
         "lut"
     ],
+        "aliases": [
+        "8718699688820" 
+    ],
     "measure_method": "script",
     "measure_device": "Shelly plug S",
     "measure_description": "Used script utils/measure_shelly.py from repository",


### PR DESCRIPTION
I added the alias, which is detected by zigbee2mqtt. This will allow the light to be autodiscovered.