### PR TITLE
Add Signify 1743130P7

### DIFF
--- a/custom_components/powercalc/data/signify/1743130P7/model.json
+++ b/custom_components/powercalc/data/signify/1743130P7/model.json
@@ -1,0 +1,12 @@
+{
+   "name":"Hue Impress Pedestal Low",
+   "standby_power":0.17,
+   "supported_modes":[
+      "lut"
+   ],
+   "measure_device":"Zhurui PR10",
+   "measure_description":"Measured with utils/measure script using OCR",
+   "measure_method":"script",
+   "linked_lut":"signify/1742930P7",
+   "aliases": []
+}


### PR DESCRIPTION
Signify confirmed the 1742930P7 and 1743130P7 are the same lights (except the design).