### PR TITLE
Add Alias 1743130P7 1743430P7

### DIFF
--- a/custom_components/powercalc/data/signify/1743130P7/model.json
+++ b/custom_components/powercalc/data/signify/1743130P7/model.json
@@ -8,5 +8,7 @@
    "measure_description":"Measured with utils/measure script using OCR",
    "measure_method":"script",
    "linked_lut":"signify/1742930P7",
-   "aliases": []
+    "aliases": [
+        "1743430P7"
+    ]
 }


### PR DESCRIPTION
It appears Signify has an extra alias for the Hue Impress Pedestal Low