### PR TITLE
Add Sonos Connect

### DIFF
--- a/custom_components/powercalc/data/sonos/connect/model.json
+++ b/custom_components/powercalc/data/sonos/connect/model.json
@@ -1,0 +1,18 @@
+{
+    "measure_description": "Streamed 'Pink noise' from https://www.genelec.com/audio-test-signals and measured using Docker container.",
+    "measure_method": "script",
+    "measure_device": "TP-Link Kasa KP115",
+    "name": "Sonos Connect",
+    "standby_power": 5.0,
+    "device_type": "smart_speaker",
+    "supported_modes": [
+        "fixed"
+    ],
+    "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+    "fixed_config": {
+        "power": 5.33
+    },
+    "aliases": [
+        "Connect"
+    ]
+}

--- a/custom_components/powercalc/data/sonos/connect/model.json
+++ b/custom_components/powercalc/data/sonos/connect/model.json
@@ -11,8 +11,5 @@
     "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
     "fixed_config": {
         "power": 5.33
-    },
-    "aliases": [
-        "Connect"
-    ]
+    }
 }


### PR DESCRIPTION
Add measured power consumption for Sonos Connect. Because the Sonos Connect media streamer is not amplified and requires an external amplifier or receiver, the measured power consumption is not impacted by volume level. `Playing` state measured ~5.33 W; all other states tested (e.g., `paused` or `idle`) measured standby wattage of ~5.00 W. Accordingly, I chose `fixed` mode for this device, with `calculation_enabled_condition` based on an entity state of `playing`. If there is a another preferred method of achieving this result in the model, please feel free to tweak as you see fit. 