### PR TITLE
add alias for hue impress pedestal low

### DIFF
--- a/custom_components/powercalc/data/signify/1743130P7/model.json
+++ b/custom_components/powercalc/data/signify/1743130P7/model.json
@@ -9,6 +9,7 @@
    "measure_method":"script",
    "linked_lut":"signify/1742930P7",
     "aliases": [
-        "1743430P7"
+        "1743430P7",
+        "1745430P7"
     ]
 }


### PR DESCRIPTION
This light is identical, but just one that comes with a power cord in the box.