### PR TITLE
Update Hue LWA017 standby power

### DIFF
--- a/custom_components/powercalc/data/signify/LWA017/model.json
+++ b/custom_components/powercalc/data/signify/LWA017/model.json
@@ -8,7 +8,7 @@
         "VERSION": "v0.17.0:docker"
     },
     "name": "Hue white A60 bulb E27 1050lm with Bluetooth",
-    "standby_power": 0.0,
+    "standby_power": 0.42,
     "supported_modes": [
         "lut"
     ],


### PR DESCRIPTION
Standby power updated (if zero it should always be checked before commit).

0,42W it is mean from 6 measured bulbs (LUT also probably need some corrections, but i don't have time to measure it).