### PR TITLE
Fix LCG002 alias typo

### DIFF
--- a/custom_components/powercalc/data/signify/LCG002/model.json
+++ b/custom_components/powercalc/data/signify/LCG002/model.json
@@ -8,6 +8,6 @@
     "measure_description":"Measure Script for Tasmota",
     "measure_method":"script",
     "aliases": [
-       "929001953101","5062348P","5062448P7"
+       "929001953101","5062348P7","5062448P7"
     ]
  }


### PR DESCRIPTION
Made an error with the second Alias, as it was missing the 7 at the end.