### PR TITLE
Correct wrong watt data for hs100 and hs110

### DIFF
--- a/custom_components/powercalc/data/tp-link/HS100/model.json
+++ b/custom_components/powercalc/data/tp-link/HS100/model.json
@@ -11,7 +11,7 @@
 	"device_type": "smart_switch",
 	"calculation_strategy": "fixed",
 	"fixed_config": {
-		"power": 1.5434
+		"power": 1.461
 	},
 	"aliases": [
 		"HS100(EU)"

--- a/custom_components/powercalc/data/tp-link/HS100/model.json
+++ b/custom_components/powercalc/data/tp-link/HS100/model.json
@@ -3,7 +3,7 @@
 	"measure_method": "manual",
 	"measure_device": "TP-Link Tapo P110",
 	"name": "HS100",
-	"standby_power": 1.044,
+	"standby_power": 0.89,
 	"sensor_config": {
 		"power_sensor_naming": "{} Device Power",
 		"energy_sensor_naming": "{} Device Energy"

--- a/custom_components/powercalc/data/tp-link/HS110/model.json
+++ b/custom_components/powercalc/data/tp-link/HS110/model.json
@@ -3,7 +3,7 @@
 	"measure_method": "manual",
 	"measure_device": "Zhurui PR10-D",
 	"name": "HS110",
-	"standby_power": 1.77,
+	"standby_power": 1.54,
 	"sensor_config": {
 		"power_sensor_naming": "{} Device Power",
 		"energy_sensor_naming": "{} Device Energy"

--- a/custom_components/powercalc/data/tp-link/HS110/model.json
+++ b/custom_components/powercalc/data/tp-link/HS110/model.json
@@ -11,7 +11,7 @@
 	"device_type": "smart_switch",
 	"calculation_strategy": "fixed",
 	"fixed_config": {
-		"power": 2.56
+		"power": 2.19
 	},
 	"aliases": [
 		"HS110(EU)"


### PR DESCRIPTION
I testet the HS100 and HS110 with an Fritz DECT 200 plug. Then i took the average of the collected data.
![Power](https://user-images.githubusercontent.com/19667033/216621580-3a1826bb-d91d-4905-92e5-1f4b659180dc.png)
