### PR TITLE
Signify (Hue) LCF002 Alias 8718696167991 and LCF001

### DIFF
--- a/custom_components/powercalc/data/signify/LCF002/model.json
+++ b/custom_components/powercalc/data/signify/LCF002/model.json
@@ -6,6 +6,8 @@
    "measure_description":"Measure Script for Tasmota",
    "measure_method":"script",
    "aliases": [
-        "1742030P7"
+        "1742030P7",
+        "8718696167991",
+        "LCF001"
     ]
 }


### PR DESCRIPTION
Trying again, but one at a time, and with the ones we are pretty sure about first.

Attempting to alias Hue 8718696167991 and LCF001 to LCF002.

See https://github.com/bramstroker/homeassistant-powercalc/discussions/741