### PR TITLE
Added Support for Bose SoundTouch 10 and Bose SoundTouch 300

### DIFF
--- a/custom_components/powercalc/data/bose/416776/model.json
+++ b/custom_components/powercalc/data/bose/416776/model.json
@@ -1,0 +1,30 @@
+{
+    "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+    "calculation_strategy": "linear",
+    "device_type": "smart_speaker",
+    "linear_config": {
+        "calibrate": [
+            "10 -> 2.94",
+            "20 -> 2.94",
+            "30 -> 2.94",
+            "40 -> 2.94",
+            "50 -> 3.03",
+            "60 -> 3.2",
+            "70 -> 3.49",
+            "80 -> 4.57",
+            "90 -> 6.96",
+            "100 -> 8.54",
+            "0 -> 3.15"
+        ]
+    },
+    "measure_description": "Measured with utils/measure script",
+    "measure_device": "Gosund, UP111 (ESPHome)",
+    "measure_method": "script",
+    "measure_settings": {
+        "SAMPLE_COUNT": 2,
+        "SLEEP_TIME": 3,
+        "VERSION": "master"
+    },
+    "name": "Bose SoundTouch 10",
+    "standby_power": 1.5
+}

--- a/custom_components/powercalc/data/bose/767520-2100/model.json
+++ b/custom_components/powercalc/data/bose/767520-2100/model.json
@@ -1,0 +1,30 @@
+{
+    "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+    "calculation_strategy": "linear",
+    "device_type": "smart_speaker",
+    "linear_config": {
+        "calibrate": [
+            "10 -> 7.41",
+            "20 -> 8.63",
+            "30 -> 8.63",
+            "40 -> 9.01",
+            "50 -> 10.09",
+            "60 -> 12.96",
+            "70 -> 21.15",
+            "80 -> 33.44",
+            "90 -> 36.44",
+            "100 -> 37.56",
+            "0 -> 11.71"
+        ]
+    },
+    "measure_description": "Measured with utils/measure script",
+    "measure_device": "Gosund, UP111 (ESPHome)",
+    "measure_method": "script",
+    "measure_settings": {
+        "SAMPLE_COUNT": 2,
+        "SLEEP_TIME": 3,
+        "VERSION": "master"
+    },
+    "name": "Bose SoundTouch 300",
+    "standby_power": 8.2
+}


### PR DESCRIPTION
Measure power using the measure utility and Pink Noise for two bose devices. 