### PR TITLE
Add Aliases for Amazon Echo Dot 3 & 4

### DIFF
--- a/custom_components/powercalc/data/amazon/B7W64E/model.json
+++ b/custom_components/powercalc/data/amazon/B7W64E/model.json
@@ -28,6 +28,7 @@
     "name": "Amazon Alexa Echo Dot Gen 4",
     "standby_power": 0.9,
     "aliases": [
-        "A2U21SRK4QGSE1"
+        "A2U21SRK4QGSE1",
+        "B7W644"
     ]
 }

--- a/custom_components/powercalc/data/amazon/B7W64E/model.json
+++ b/custom_components/powercalc/data/amazon/B7W64E/model.json
@@ -26,5 +26,8 @@
         "VERSION": "master"
     },
     "name": "Amazon Alexa Echo Dot Gen 4",
-    "standby_power": 0.9
+    "standby_power": 0.9,
+    "aliases": [
+        "A2U21SRK4QGSE1"
+    ]
 }

--- a/custom_components/powercalc/data/amazon/D91029T/model.json
+++ b/custom_components/powercalc/data/amazon/D91029T/model.json
@@ -26,5 +26,8 @@
         "VERSION": "master"
     },
     "name": "Amazon Alexa Echo Dot Gen 3",
-    "standby_power": 1.75
+    "standby_power": 1.75,
+    "aliases": [
+        "A32DOYMUN6DTXA"
+    ]
 }

--- a/custom_components/powercalc/data/amazon/D91029T/model.json
+++ b/custom_components/powercalc/data/amazon/D91029T/model.json
@@ -28,6 +28,8 @@
     "name": "Amazon Alexa Echo Dot Gen 3",
     "standby_power": 1.75,
     "aliases": [
-        "A32DOYMUN6DTXA"
+        "A32DOYMUN6DTXA",
+        "A1RABVCI4QCIKC",
+        "C78MP8"
     ]
 }

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -258,8 +258,8 @@
 
 |manufacturer |            model id             |                  name                  |        aliases         |standby|
 |-------------|---------------------------------|----------------------------------------|------------------------|------:|
-|amazon       |B7W64E                           |Amazon Alexa Echo Dot Gen 4             |                        |   0.90|
-|amazon       |D91029T                          |Amazon Alexa Echo Dot Gen 3             |                        |   1.75|
+|amazon       |B7W64E                           |Amazon Alexa Echo Dot Gen 4             |A2U21SRK4QGSE1          |   0.90|
+|amazon       |D91029T                          |Amazon Alexa Echo Dot Gen 3             |A32DOYMUN6DTXA          |   1.75|
 |bose         |416776                           |Bose SoundTouch 10                      |                        |   1.50|
 |bose         |767520-2100                      |Bose SoundTouch 300                     |                        |   1.50|
 |denon        |HEOS 1 HS2                       |HEOS 1 HS2                              |HEOS 1                  |   3.99|

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -256,24 +256,24 @@
 ## Smart speakers
 #### 16 total
 
-|manufacturer |            model id             |                  name                  |        aliases         |standby|
-|-------------|---------------------------------|----------------------------------------|------------------------|------:|
-|amazon       |B7W64E                           |Amazon Alexa Echo Dot Gen 4             |A2U21SRK4QGSE1          |   0.90|
-|amazon       |D91029T                          |Amazon Alexa Echo Dot Gen 3             |A32DOYMUN6DTXA          |   1.75|
-|bose         |416776                           |Bose SoundTouch 10                      |                        |   1.50|
-|bose         |767520-2100                      |Bose SoundTouch 300                     |                        |   1.50|
-|denon        |HEOS 1 HS2                       |HEOS 1 HS2                              |HEOS 1                  |   3.99|
-|google       |Home                             |Google Home                             |                        |   2.40|
-|google       |Home Mini (HOA)                  |Google Home Mini                        |Google Home Mini        |   1.65|
-|google       |Nest Mini (H2C)                  |Google Nest Mini                        |Google Nest Mini        |   1.65|
-|harman kardon|HK Citation MultiBeam 700        |HK Citation MultiBeam 700               |                        |   7.58|
-|lenovo       |Smart Clock with Google Assistant|Lenovo Smart Clock with Google Assistant|Lenovo Smart Clock      |   2.51|
-|sonos        |connect                          |Sonos Connect                           |                        |   5.00|
-|sonos        |one                              |Sonos One                               |Sonos ONE               |   2.92|
-|sonos        |one sl                           |Sonos One SL                            |                        |   2.83|
-|sonos        |play 3                           |Sonos Play:3                            |Play:3                  |   4.17|
-|sonos        |symfonisk bookshelf              |SYMFONISK Bookshelf                     |IKEA SYMFONISK Bookshelf|   2.56|
-|sonos        |symfonisk picture frame          |SYMFONISK Picture Frame                 |SYMFONISK Picture frame |   2.40|
+|manufacturer |            model id             |                  name                  |        aliases                         |standby|
+|-------------|---------------------------------|----------------------------------------|----------------------------------------|------:|
+|amazon       |B7W64E                           |Amazon Alexa Echo Dot Gen 4             |A2U21SRK4QGSE1, B7W644                   |   0.90|
+|amazon       |D91029T                          |Amazon Alexa Echo Dot Gen 3             |A32DOYMUN6DTXA, A1RABVCI4QCIKC, C78MP8  |   1.75|
+|bose         |416776                           |Bose SoundTouch 10                      |                                        |   1.50|
+|bose         |767520-2100                      |Bose SoundTouch 300                     |                                        |   1.50|
+|denon        |HEOS 1 HS2                       |HEOS 1 HS2                              |HEOS 1                                  |   3.99|
+|google       |Home                             |Google Home                             |                                        |   2.40|
+|google       |Home Mini (HOA)                  |Google Home Mini                        |Google Home Mini                        |   1.65|
+|google       |Nest Mini (H2C)                  |Google Nest Mini                        |Google Nest Mini                        |   1.65|
+|harman kardon|HK Citation MultiBeam 700        |HK Citation MultiBeam 700               |                                        |   7.58|
+|lenovo       |Smart Clock with Google Assistant|Lenovo Smart Clock with Google Assistant|Lenovo Smart Clock                      |   2.51|
+|sonos        |connect                          |Sonos Connect                           |                                        |   5.00|
+|sonos        |one                              |Sonos One                               |Sonos ONE                               |   2.92|
+|sonos        |one sl                           |Sonos One SL                            |                                        |   2.83|
+|sonos        |play 3                           |Sonos Play:3                            |Play:3                                  |   4.17|
+|sonos        |symfonisk bookshelf              |SYMFONISK Bookshelf                     |IKEA SYMFONISK Bookshelf                |   2.56|
+|sonos        |symfonisk picture frame          |SYMFONISK Picture Frame                 |SYMFONISK Picture frame                 |   2.40|
 
 ## Smart switches
 #### 24 total


### PR DESCRIPTION
Hi, 

I kept track of the releases and heard Amazon Echo deices were supported - yay. However, after trying and trying I found out that the IDs are different when not using the official integration. There's a popular unofficial version (free) that is available on HACS but those use a different ID.

I added both the aliases as I have both devices in HA. Repo for custom component is: https://github.com/custom-components/alexa_media_player