### PR TITLE
indent on filters within include

### DIFF
--- a/docs/source/include-entities.rst
+++ b/docs/source/include-entities.rst
@@ -88,8 +88,8 @@ Domain
         create_group: Outdoor lights
         include:
           area: outdoor
-        filter:
-          domain: light
+          filter:
+            domain: light
 
 This will include only light entities from area outdoor.
 


### PR DESCRIPTION
Seems like the indent in the docs are incorrect, must be within the include