### PR TITLE
Add note to wled documentation

### DIFF
--- a/docs/source/strategies/wled.rst
+++ b/docs/source/strategies/wled.rst
@@ -6,7 +6,7 @@ Supported domains: ``light``
 
 You can use WLED strategy for light strips which are controlled by [WLED](https://github.com/Aircoookie/WLED).
 WLED calculates estimated current based on brightness levels and the microcontroller (ESP) used.
-Powercalc asks to input the voltage on which the lightstrip is running and optionally a power factor. Based on these factors the wattage is calculated.
+Powercalc asks to input the voltage on which the lightstrip is running and optionally a power factor. Based on these factors the wattage is calculated (Important notice: The brightness limiter must be turned on in WLED for this to work! Otherwise WLED will not provide an estimated current).
 
 You can setup sensors both with YAML or GUI.
 When you use the GUI select :guilabel:`wled` in the calculation_strategy dropdown.

--- a/docs/source/strategies/wled.rst
+++ b/docs/source/strategies/wled.rst
@@ -6,7 +6,10 @@ Supported domains: ``light``
 
 You can use WLED strategy for light strips which are controlled by [WLED](https://github.com/Aircoookie/WLED).
 WLED calculates estimated current based on brightness levels and the microcontroller (ESP) used.
-Powercalc asks to input the voltage on which the lightstrip is running and optionally a power factor. Based on these factors the wattage is calculated (Important notice: The brightness limiter must be turned on in WLED for this to work! Otherwise WLED will not provide an estimated current).
+Powercalc asks to input the voltage on which the lightstrip is running and optionally a power factor. Based on these factors the wattage is calculated.
+
+.. important::
+    The brightness limiter must be turned on in WLED for this to work! Otherwise WLED will not provide an estimated current.
 
 You can setup sensors both with YAML or GUI.
 When you use the GUI select :guilabel:`wled` in the calculation_strategy dropdown.


### PR DESCRIPTION
Added an important notice to the WLED sub-chapter in the documentation which states that the brightness limiter in WLED must be turned on for Powercalc to work with WLED.