### PR TITLE
Add aliases for LCA009 and LTA010

### DIFF
--- a/custom_components/powercalc/data/signify/LCA009/model.json
+++ b/custom_components/powercalc/data/signify/LCA009/model.json
@@ -10,5 +10,7 @@
     "name": "Hue color lamp (LCA009)",
     "standby_power": 0.19,
     "calculation_strategy": "lut",
-    "aliases": []
+    "aliases": [
+        "9290024717"
+    ]
 }

--- a/custom_components/powercalc/data/signify/LTA010/model.json
+++ b/custom_components/powercalc/data/signify/LTA010/model.json
@@ -9,7 +9,7 @@
     },
     "name": "Hue ambiance lamp",
     "standby_power": 0.25,
-    "calculation_strategy": "lut"
+    "calculation_strategy": "lut",
     "aliases": [
         "9290024717"
     ]

--- a/custom_components/powercalc/data/signify/LTA010/model.json
+++ b/custom_components/powercalc/data/signify/LTA010/model.json
@@ -11,6 +11,6 @@
     "standby_power": 0.25,
     "calculation_strategy": "lut",
     "aliases": [
-        "9290024717"
+        "9290024683"
     ]
 }

--- a/custom_components/powercalc/data/signify/LTA010/model.json
+++ b/custom_components/powercalc/data/signify/LTA010/model.json
@@ -10,4 +10,7 @@
     "name": "Hue ambiance lamp",
     "standby_power": 0.25,
     "calculation_strategy": "lut"
+    "aliases": [
+        "9290024717"
+    ]
 }


### PR DESCRIPTION
PowerCalc was not identifying bulbs that are on the list of supported lights (LCA009 and LTA010).
The logs indicated that they weren't being reported with any necessary identifying information.

2023-05-12 18:27:12.822 DEBUG (MainThread) [custom_components.powercalc.discovery] light.living_bulb_b: Auto discovered model (manufacturer=Signify Netherlands B.V., model=Hue white and color ambiance E26#slash#A19 1600lm (9290024717))
2023-05-12 18:27:12.160 DEBUG (MainThread) [custom_components.powercalc.discovery] light.bathroom_bulb_outer_a: Auto discovered model (manufacturer=Signify Netherlands B.V., model=Hue white ambiance A19 1100lm with Bluetooth (9290024683))

Adding the model numbers as aliases allowed PowerCalc to discover these bulbs again.