### PR TITLE
added TuYa BSD29, Nous A1Z

### DIFF
--- a/custom_components/powercalc/data/nous/A1Z/model.json
+++ b/custom_components/powercalc/data/nous/A1Z/model.json
@@ -2,7 +2,7 @@
 	"measure_description": "Manually measured",
 	"measure_method": "manual",
 	"measure_device": "Brennenstuhl PM 231 E",
-	"name": "A1Z",
+	"name": "Smart plug (with power monitoring)",
 	"standby_power": 0.1,
 	"sensor_config": {
 		"power_sensor_naming": "{} Device Power",
@@ -12,5 +12,8 @@
 	"calculation_strategy": "fixed",
 	"fixed_config": {
 		"power": 0.4
-	}
+	},
+	"aliases": [
+		"A1Z"
+	]
 }

--- a/custom_components/powercalc/data/nous/A1Z/model.json
+++ b/custom_components/powercalc/data/nous/A1Z/model.json
@@ -1,0 +1,16 @@
+{
+	"measure_description": "Manually measured",
+	"measure_method": "manual",
+	"measure_device": "Brennenstuhl PM 231 E",
+	"name": "A1Z",
+	"standby_power": 0.1,
+	"sensor_config": {
+		"power_sensor_naming": "{} Device Power",
+		"energy_sensor_naming": "{} Device Energy"
+  	},
+	"device_type": "smart_switch",
+	"calculation_strategy": "fixed",
+	"fixed_config": {
+		"power": 0.4
+	}
+}

--- a/custom_components/powercalc/data/tuya/TS011F/model.json
+++ b/custom_components/powercalc/data/tuya/TS011F/model.json
@@ -16,6 +16,7 @@
 	"aliases": [
 		"TS011F_plug_1",
 		"TS011F_plug_3",
-		"TS011F"
+		"TS011F",
+		"BSD29"
 	]
 }


### PR DESCRIPTION
My TuYa BSD29s look exactly the same as the TS011F and show comparable standby and non-standby power. I think it's feasible to merge them with the TS011F versions (they look the same and appear to have the same measurements). My Brennenstuhl power meter only provides 1 decimal place and providing a new model with my less precise measurements would be subpar.