### PR TITLE
Updated documentation: sensor yaml changed

### DIFF
--- a/docs/source/daily-fixed-energy.rst
+++ b/docs/source/daily-fixed-energy.rst
@@ -23,7 +23,7 @@ Configuration options
 Examples
 --------
 
-This will add 0.05 kWh per day to the energy sensor called "IP camera upstairs"
+This will add 0.05 kWh per day to the energy sensor called "IP camera upstairs". You'll have to add a new entry under ``sensor:`` in `configuration.yaml`:
 
 .. code-block:: yaml
 

--- a/docs/source/daily-fixed-energy.rst
+++ b/docs/source/daily-fixed-energy.rst
@@ -27,23 +27,21 @@ This will add 0.05 kWh per day to the energy sensor called "IP camera upstairs"
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - name: IP camera upstairs
-          daily_fixed_energy:
-            value: 0.05
+  - platform: powercalc
+    name: IP camera upstairs
+    daily_fixed_energy:
+      value: 0.05
 
 Or define in watts, with an optional on time (which is 24 hour a day by default).
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - name: Intercom
-          daily_fixed_energy:
-            value: 21
-            unit_of_measurement: W
-            on_time: 12:00:00
+  - platform: powercalc
+    name: Intercom
+    daily_fixed_energy:
+        value: 21
+        unit_of_measurement: W
+        on_time: 12:00:00
 
 This will simulate the device using 21 watts for 12 hours a day. The energy sensor will increase by 0.252 kWh a day.
 

--- a/docs/source/group.rst
+++ b/docs/source/group.rst
@@ -27,19 +27,18 @@ Select :guilabel:`Group` and follow the instructions.
 Create group with YAML
 ----------------------
 
-You can combine the ``entities`` option and ``create_group`` to group individual power sensors into a group.
+You can combine the ``entities`` option and ``create_group`` to group individual power sensors into a group. You'll have to add a new entry under ``sensor:`` in `configuration.yaml`:
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: All hallway lights
-          entities:
-            - entity_id: light.hallway
-            - entity_id: light.living_room
-              linear:
-                min_power: 0.5
-                max_power: 8
+  - platform: powercalc
+    create_group: All hallway lights
+    entities:
+      - entity_id: light.hallway
+      - entity_id: light.living_room
+        linear:
+          min_power: 0.5
+          max_power: 8
 
 This will create the following entities:
 
@@ -57,18 +56,17 @@ You can also nest groups, this makes it possible to add an entity to multiple gr
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: All lights
-          entities:
-            - entity_id: light.a
-            - entity_id: light.b
-            - create_group: Upstairs lights
-              entities:
-                - entity_id: light.c
-                - create_group: Bedroom Bob lights
-                  entities:
-                    - entity_id: light.d
+  - platform: powercalc
+    create_group: All lights
+    entities:
+      - entity_id: light.a
+      - entity_id: light.b
+      - create_group: Upstairs lights
+        entities:
+          - entity_id: light.c
+          - create_group: Bedroom Bob lights
+            entities:
+              - entity_id: light.d
 
 Each group will have power sensors created for the following lights:
 
@@ -98,13 +96,12 @@ You can use the following configuration:
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: Living Room
-          entities:
-            - power_sensor_id: sensor.heater_power
-              energy_sensor_id: sensor.heater_kwh
-            - entity_id: light.hallway #Powercalc sensor
+  - platform: powercalc
+    create_group: Living Room
+    entities:
+      - power_sensor_id: sensor.heater_power
+        energy_sensor_id: sensor.heater_kwh
+      - entity_id: light.hallway #Powercalc sensor
 
 .. note::
     When you don't supply ``energy_sensor_id``, but only ``power_sensor_id`` powercalc tries to find a related energy sensor on the same device.

--- a/docs/source/include-entities.rst
+++ b/docs/source/include-entities.rst
@@ -16,25 +16,22 @@ Area
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: Outdoor
-          include:
-            area: outdoor
+  - platform: powercalc
+    create_group: Outdoor
+    include:
+      area: outdoor
 
 This can also be mixed with the ``entities`` option, to add or override entities to the group. i.e.
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: Outdoor
-          include:
-            area: outdoor
-          entities:
-            - entity_id: light.frontdoor
-              fixed:
-                power: 100
+  - platform: powercalc
+    create_group: Outdoor
+    include:
+        area: outdoor
+    entities:
+      - entity_id: light.frontdoor
+        fixed:
 
 Group
 -----
@@ -43,33 +40,30 @@ Includes entities from an existing Home Assistant `group <https://www.home-assis
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: Livingroom lights
-          include:
-            group: group.livingroom_lights
+  - platform: powercalc
+    create_group: Livingroom lights
+    include:
+      group: group.livingroom_lights
 
 Domain
 ------
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: All lights
-          include:
-            domain: light
+  - platform: powercalc
+    create_group: All lights
+    include:
+      domain: light
 
 Template
 --------
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: All indoor lights
-          include:
-            template: {{expand('group.all_indoor_lights')|map(attribute='entity_id')|list}}
+  - platform: powercalc
+    create_group: All indoor lights
+    include:
+      template: {{expand('group.all_indoor_lights')|map(attribute='entity_id')|list}}
 
 .. warning::
     The template option sometimes does not work correctly because of loading order of components in HA which powercalc cannot influence.
@@ -83,13 +77,12 @@ Domain
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - create_group: Outdoor lights
-          include:
-            area: outdoor
-            filter:
-              domain: light
+  - platform: powercalc
+    create_group: Outdoor lights
+    include:
+      area: outdoor
+      filter:
+        domain: light
 
 This will include only light entities from area outdoor.
 

--- a/docs/source/naming.rst
+++ b/docs/source/naming.rst
@@ -46,14 +46,13 @@ will create following sensors:
 
 Change full name
 ----------------
-You can also change the base sensor name with the ``name`` option
+You can also change the base sensor name with the ``name`` option in ``sensor:``
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - entity_id: light.patio
-          name: Patio Light
+  - platform: powercalc
+    entity_id: light.patio
+    name: Patio Light
 
 will create:
 

--- a/docs/source/real-power-sensor.rst
+++ b/docs/source/real-power-sensor.rst
@@ -2,16 +2,15 @@
 Real power sensor
 =================
 
-In the yaml configuration (functionality not available through the webUI) you can add the following configuration
-to use an existing power sensor and let powercalc create the energy sensors and utility meters for it:
+To use an existing power sensor and let powercalc create the energy sensors and utility meters for it, 
+you'll have to add a new entry under the ``sensor:`` line in `configuration.yaml` (functionality not available through the webUI).
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - entity_id: light.toilet
-          power_sensor_id: sensor.toilet_light_power
-          force_energy_sensor_creation: true # optional
+  - platform: powercalc
+    entity_id: light.toilet
+    power_sensor_id: sensor.toilet_light_power
+    force_energy_sensor_creation: true # optional
 
 This also enables you to combine virtual power sensors (created with powercalc) and existing power sensors in your HA installation into
 a group. Without this configuration option power_sensor_id that would not be possible.

--- a/docs/source/real-power-sensor.rst
+++ b/docs/source/real-power-sensor.rst
@@ -3,7 +3,7 @@ Real power sensor
 =================
 
 To use an existing power sensor and let powercalc create the energy sensors and utility meters for it, 
-you'll have to add a new entry under the ``sensor:`` line in `configuration.yaml` (functionality not available through the webUI).
+you'll have to add a new entry under ``sensor:`` in `configuration.yaml` (functionality not available through the webUI).
 
 .. code-block:: yaml
 

--- a/docs/source/virtual-power-sensor.rst
+++ b/docs/source/virtual-power-sensor.rst
@@ -46,26 +46,24 @@ Most basic example:
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - entity_id: light.my_light
-          fixed:
-            power: 20
+  - platform: powercalc
+    entity_id: light.my_light
+    fixed:
+      power: 20
 
 Tip: You can also setup multiple sensors in one go using the ``entities`` option.
 
 .. code-block:: yaml
 
-    powercalc:
-      sensors:
-        - entities:
-            - entity_id: light.my_light
-              fixed:
-                power: 20
-            - entity_id: light.my_light2
-              linear:
-                min_power: 2
-                max_power: 9
+  - platform: powercalc
+    entities:
+      - entity_id: light.my_light
+        fixed:
+          power: 20
+      - entity_id: light.my_light2
+        linear:
+          min_power: 2
+          max_power: 9
 
 For all the possible options see the strategy sections as linked above, :doc:`configuration/sensor-configuration` and the rest of the Powercalc documentation.
 


### PR DESCRIPTION
I updated all examples in the docs regarding anything in ``configuration.yaml`` that goes under ``sensor:``. The current format is not supported by home assistant anymore.