### PR TITLE
Added similar bulb model LWA021 as alias

### DIFF
--- a/custom_components/powercalc/data/signify/LWO001/model.json
+++ b/custom_components/powercalc/data/signify/LWO001/model.json
@@ -6,7 +6,8 @@
     "standby_power": 0.35,
     "calculation_strategy": "lut",
     "aliases": [
-        "8718699688882" 
+        "8718699688882",
+        "LWA021",
     ]
 }
 


### PR DESCRIPTION
LWA021 is a presumed similar filament bulb, with (near) identical power consumption. Only difference is that LWA021 has "Thin Filament" written on the box.