### PR TITLE
Added alias for Osram Plug 01

### DIFF
--- a/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
+++ b/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
@@ -12,5 +12,8 @@
 	"calculation_strategy": "fixed",
 	"fixed_config": {
 		"power": 1.04
-	}
+	},
+    "aliases": [
+        "Plug 01"
+    ]
 }


### PR DESCRIPTION
I have two Osram Lightify Plugs which are just reported as "Plug 01"