### PR TITLE
OSRAM LIGHTIFY Plug 01 - added alias

### DIFF
--- a/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
+++ b/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
@@ -15,6 +15,6 @@
 	},
 	"aliases": [
 		"Plug 01",
-		"Smart+ plug (AB3257001NJ)"
+		"AB3257001NJ"
 	]
 }

--- a/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
+++ b/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
@@ -13,7 +13,8 @@
 	"fixed_config": {
 		"power": 1.04
 	},
-    "aliases": [
-        "Plug 01"
-    ]
+	"aliases": [
+		"Plug 01",
+		"Smart+ plug (AB3257001NJ)"
+	]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

add alias "Smart+ plug (AB3257001NJ)" for OSRAM LIGHTIFY Plug 01.

<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

Smart+ plug (AB3257001NJ)
von OSRAM 

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States


## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->

Usefull using the plug via zigbee2mqtt



