### PR TITLE
Ikea Askvader

### DIFF
--- a/custom_components/powercalc/data/ikea/ASKVADER/model.json
+++ b/custom_components/powercalc/data/ikea/ASKVADER/model.json
@@ -12,7 +12,7 @@
  	"device_type": "smart_switch",
  	"calculation_strategy": "fixed",
 	"aliases": [
-		"ASKVADER on/off switch (E1836)",
+		"E1836",
 		"On/Off plug (ASKVADER on/off switch)"
 	]
 }

--- a/custom_components/powercalc/data/ikea/ASKVADER/model.json
+++ b/custom_components/powercalc/data/ikea/ASKVADER/model.json
@@ -1,0 +1,18 @@
+{
+ 	"measure_description": "Manually measured.",
+ 	"measure_method": "manual",
+ 	"measure_device": "Shelly Plus Plug S / AVM FRITZ!DECT 200",
+ 	"name": "ASKVADER",
+ 	"standby_power": 0.21,
+	"standby_power_on": 0.78,
+ 	"sensor_config": {
+ 		"power_sensor_naming": "{} Device Power",
+ 		"energy_sensor_naming": "{} Device Energy"
+   	},
+ 	"device_type": "smart_switch",
+ 	"calculation_strategy": "fixed",
+	"aliases": [
+		"ASKVADER on/off switch (E1836)",
+		"On/Off plug (ASKVADER on/off switch)"
+	]
+}

--- a/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
+++ b/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
@@ -13,8 +13,7 @@
 	"fixed_config": {
 		"power": 1.04
 	},
-	"aliases": [
-		"Plug 01",
-		"Smart+ plug (AB3257001NJ)"
-	]
+    "aliases": [
+        "Plug 01"
+    ]
 }

--- a/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
+++ b/custom_components/powercalc/data/osram/LIGHTIFY Plug 01/model.json
@@ -13,7 +13,8 @@
 	"fixed_config": {
 		"power": 1.04
 	},
-    "aliases": [
-        "Plug 01"
-    ]
+	"aliases": [
+		"Plug 01",
+		"Smart+ plug (AB3257001NJ)"
+	]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
Adding Ikea Askvader

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

via zigbee2mqtt:
ASKVADER on/off switch (E1836)
von IKEA 

via HUE Bridge:
On/Off plug (ASKVADER on/off switch)
von IKEA of Sweden 

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->


Measured with two devices: AVM Dect 200 (manual) and a Shelly Plus Plug S (with measure docker image and avg over at least for 2 minutes)
The last column shows the values I decided to configure in the model.json

| Device | Dect 200 - OFF  | ON | Shelly Plus Plug S - OFF | ON | Configured - Standby | ON |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| IKEA ASKVADER | 0.21 | 0.78 | 0.05 | 0.78 | 0.21 | 0.78 |
