### PR TITLE
Fix linear strategy ValueError

### DIFF
--- a/custom_components/powercalc/strategy/linear.py
+++ b/custom_components/powercalc/strategy/linear.py
@@ -108,7 +108,7 @@ class LinearStrategy(PowerCalculationStrategyInterface):
         calibration_list: list[tuple[int, float]] = []
 
         calibrate = self._config.get(CONF_CALIBRATE)
-        if calibrate is None:
+        if calibrate is None or len(calibrate) == 0:
             full_range = self.get_entity_value_range()
             min_value = full_range[0]
             max_value = full_range[1]


### PR DESCRIPTION
When creating a virtual power sensor with a linear strategy from UI, the calibration in the config can become and empty dictionary, which results in a ValueError, while trying to call `get_min_calibrate`. By creating a fresh `calibration_list`, when either the `CONF_CALIBRATE ` is None or an empty list, this error can not happen anymore.

`self._config={'calibrate': [], 'min_power': 0.0, 'max_power': 10.0, 'gamma_curve': 1.5}`

```
2024-01-06 12:30:06.556 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/config/custom_components/powercalc/sensors/power.py", line 389, in appliance_state_listener
    await self._handle_source_entity_state_change(
  File "/config/custom_components/powercalc/sensors/power.py", line 507, in _handle_source_entity_state_change
    self._power = await self.calculate_power(state)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/powercalc/sensors/power.py", line 566, in calculate_power
    power = await self._strategy_instance.calculate(entity_state)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/powercalc/strategy/linear.py", line 71, in calculate
    min_calibrate = self.get_min_calibrate(value)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/powercalc/strategy/linear.py", line 100, in get_min_calibrate
    return min(self._calibration or (), key=lambda v: (v[0] > value, value - v[0]))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: min() arg is an empty sequence
```
