### PR TITLE
Add service icons

### DIFF
--- a/custom_components/powercalc/icons.json
+++ b/custom_components/powercalc/icons.json
@@ -1,0 +1,12 @@
+{
+    "services": {
+        "reset_energy": "mdi:restore",
+        "calibrate_utility_meter": "mdi:wrench",
+        "calibrate_energy": "mdi:wrench",
+        "increase_daily_energy": "mdi:numeric",
+        "activate_playbook": "mdi:play",
+        "stop_playbook": "mdi:stop",
+        "switch_sub_profile": "mdi:toggle-switch",
+        "change_gui_config": "mdi:cogs"
+    }
+}


### PR DESCRIPTION
With HA 2024.2 you can now add icons to services with a simple json file, making them stand out nicely.
Here's icons for all the services.

Just like to say I've learnt a lot from your code when developing my own integration so thanks for the great work here.