### PR TITLE
Update model.json - added alias to LTC016

### DIFF
--- a/custom_components/powercalc/data/signify/LCT016/model.json
+++ b/custom_components/powercalc/data/signify/LCT016/model.json
@@ -9,5 +9,8 @@
   },
   "name": "Philips Hue 800 Lumen White and Color A19",
   "standby_power": 0.34,
-  "calculation_strategy": "lut"
+  "calculation_strategy": "lut",
+  "aliases": [
+      "3216431P6"
+  ]
 }


### PR DESCRIPTION
detected via z2m;
2024-03-14 21:54:17.781 DEBUG (MainThread) [custom_components.powercalc.discovery] light.living_ceiling: Auto discovered model (manufacturer=Signify Netherlands B.V., model=Hue Aurelle (3216431P6))
2024-03-14 21:54:17.841 DEBUG (MainThread) [custom_components.powercalc.discovery] light.living_ceiling: Model not found in library, skipping discovery
