### PR TITLE
Update model.json for the Play 5 to add an name alias

### DIFF
--- a/custom_components/powercalc/data/sonos/play 5/model.json
+++ b/custom_components/powercalc/data/sonos/play 5/model.json
@@ -26,7 +26,8 @@
         "VERSION": "v1.11.3:docker"
     },
     "aliases": [
-        "Play:5"
+        "Play:5",
+        "Five"
     ],
     "name": "Sonos Play:5",
     "standby_power": 2.15


### PR DESCRIPTION
Hi, thanks for adding the Sonos Play 5 support in the last release, however, the name of mines is slightly different. See log entries:
```
2024-04-05 21:04:08.972 DEBUG (MainThread) [custom_components.powercalc.discovery] media_player.eetkamer: Auto discovered model (manufacturer=Sonos, model=Five)
2024-04-05 21:04:08.972 DEBUG (MainThread) [custom_components.powercalc.discovery] media_player.eetkamer: Model not found in library, skipping discovery
2024-04-05 21:04:08.972 DEBUG (MainThread) [custom_components.powercalc.discovery] media_player.eetkamer: Entity is manually configured, skipping auto configuration
```

Let me know in case this is not the correct way. And thanks a lot for this great component!