### PR TITLE
Fix WLED link + explain about segments

### DIFF
--- a/docs/source/strategies/wled.rst
+++ b/docs/source/strategies/wled.rst
@@ -4,15 +4,16 @@ WLED
 
 Supported domains: ``light``
 
-You can use WLED strategy for light strips which are controlled by [WLED](https://github.com/Aircoookie/WLED).
+You can use the manual WLED strategy for light strips which are controlled by `WLED <https://github.com/Aircoookie/WLED>`_.
 WLED calculates estimated current based on brightness levels and the microcontroller (ESP) used.
-Powercalc asks to input the voltage on which the lightstrip is running and optionally a power factor. Based on these factors the wattage is calculated.
+Powercalc asks to input the voltage on which the lightstrip is running and optionally a power factor. Based on these factors, the wattage is calculated.
 
 .. important::
     The brightness limiter must be turned on in WLED for this to work! Otherwise WLED will not provide an estimated current.
 
 You can setup sensors both with YAML or GUI.
-When you use the GUI select :guilabel:`wled` in the calculation_strategy dropdown.
+When you use the GUI, select the "Virtual power (manual)" sensor type, and :guilabel:`wled` in the "Calculation strategy" dropdown.
+If you have multiple segments, select any of them as the source entity; selecting a helper group with all segments will cause a failure to find the current sensor, even if entity IDs match perfectly.
 
 Configuration options
 ---------------------

--- a/docs/source/strategies/wled.rst
+++ b/docs/source/strategies/wled.rst
@@ -12,7 +12,7 @@ Powercalc asks to input the voltage on which the lightstrip is running and optio
     The brightness limiter must be turned on in WLED for this to work! Otherwise WLED will not provide an estimated current.
 
 You can setup sensors both with YAML or GUI.
-When you use the GUI, select the "Virtual power (manual)" sensor type, and :guilabel:`wled` in the "Calculation strategy" dropdown.
+When you use the GUI, select the :guilabel:`Virtual power (manual)` sensor type, and :guilabel:`wled` in the "Calculation strategy" dropdown.
 If you have multiple segments, select any of them as the source entity; selecting a helper group with all segments will cause a failure to find the current sensor, even if entity IDs match perfectly.
 
 Configuration options


### PR DESCRIPTION
Also makes it clearer how to find WLED on the configuration GUI.

>P.S.: should segmented WLEDs also be found automatically by the integration? In my case, it only found a single WLED strip, but the other which was segmented got ignored, and I had to enable it manually (although it also had the brightness limiter off, but I let it rest a few days after enabling that option, to check if the integration would pick it up at some point, but it didn't).