### PR TITLE
Fix markdown anchors

### DIFF
--- a/.github/scripts/supported_models/generate_file.py
+++ b/.github/scripts/supported_models/generate_file.py
@@ -45,7 +45,7 @@ def generate_supported_model_list(model_listing: list[dict]):
         ]
         num_devices = len(relevant_models)
 
-        anchor = device_type[1].replace(" ", "-")
+        anchor = device_type[1].lower().replace("/", "").replace(" ", "-")
         toc_links.append(f"- [{device_type[1]}](#{anchor}) ({num_devices})\n")
 
         writer = MarkdownTableWriter()


### PR DESCRIPTION
This fixes the not working anchor for `Smart switches / plugs` in the [supported_models.md](https://github.com/bramstroker/homeassistant-powercalc/blob/c558715/docs/supported_models.md) file.

Currently it links to `#Smart-switches-/-plugs` which does not work.
After this change it will link to `#smart-switches--plugs`.

The double dash looks weird but is correct according to the github anchor link in the UI.

This also lowercases all anchors. This seems also to be the default in github.