### PR TITLE
Fix CI/CD for #2288

### DIFF
--- a/.github/workflows/validate-lut-files.yml
+++ b/.github/workflows/validate-lut-files.yml
@@ -44,7 +44,8 @@ jobs:
             const { commits } = context.payload.pull_request
             const rawFiles = execSync(`git diff --name-only HEAD HEAD~${commits}`).toString()
             const files = rawFiles.split('\n').filter(Boolean)
-            core.setOutput('changedFiles', files.join(" "))
+            const list = files.map(item => item.split(" ").join("\\ ")).join(" ")
+            core.setOutput('changedFiles', list)
       - name: Run visualization tool
         run: |
           cd ./utils/visualize


### PR DESCRIPTION
This should fix the problems with the CI/CD in PR #2288. It works by adding correct escape sequences when generating the list of files.