### PR TITLE
Add KP115(US) smart plug 

### DIFF
--- a/profile_library/tp-link/KP115/model.json
+++ b/profile_library/tp-link/KP115/model.json
@@ -14,7 +14,8 @@
     "power": 0.9
   },
   "aliases": [
-    "KP115(AU)"
+    "KP115(AU)",
+    "KP115(US)"
   ],
   "created_at": "2022-09-06T08:26:19"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
-->
Kasa Smart WiFi Plug Slim with Energy Monitoring KP115(US) 
  Link: https://www.kasasmart.com/us/products/smart-plugs/kasa-smart-plug-slim-energy-monitoring-kp115
## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
-->
- **Model**: KP115(US)
- **Manufacturer**: TP-Link
- **Firmware**: 1.0.21 Build 231129 Rel.171238
- **Hardware**: 1.0

## Checklist
<!--
  Please check all the boxes when applicable.
-->
- [X] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States.

## Additional info
<!--
  -->
I used another KP115 to measure the power over 5 minutes and got the same wattage results for "standby" and "on" as those for the existing KP115(AU) that was measured with a Kill-a-Watt power meter a while back. So despite the different voltages for each country the power draw measurements appear to be the same. So I guessed we just need to add a KP115(US) alias to the existing model.json file for the KP115. This is my first GitHub PR so please excuse any awkwardness.
