### PR TITLE
Autodiscovery should skip printer ink

### DIFF
--- a/custom_components/powercalc/discovery.py
+++ b/custom_components/powercalc/discovery.py
@@ -31,7 +31,7 @@ from .errors import ModelNotSupportedError
 from .helpers import get_or_create_unique_id
 from .power_profile.factory import get_power_profile
 from .power_profile.library import ModelInfo
-from .power_profile.power_profile import DOMAIN_DEVICE_TYPE, PowerProfile
+from .power_profile.power_profile import DOMAIN_DEVICE_TYPE, DeviceType, PowerProfile
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -156,6 +156,9 @@ class DiscoveryManager:
             return False
 
         if entity_entry.domain not in DOMAIN_DEVICE_TYPE:
+            return False
+
+        if DOMAIN_DEVICE_TYPE[entity_entry.domain] == DeviceType.PRINTER and entity_entry.unit_of_measurement:
             return False
 
         if entity_entry.entity_category in [

--- a/custom_components/powercalc/power_profile/loader/remote.py
+++ b/custom_components/powercalc/power_profile/loader/remote.py
@@ -129,12 +129,12 @@ class RemoteLoader(Loader):
         retry_count: int = 0,
     ) -> tuple[dict, str] | None:
         """Load a model, downloading it if necessary, with retry logic."""
-        model_info = self._get_model_info(manufacturer, model)
-        storage_path = self.get_storage_path(manufacturer, model)
+        model_info = self._get_model_info(manufacturer.lower(), model)
+        storage_path = self.get_storage_path(manufacturer.lower(), model)
         model_path = os.path.join(storage_path, "model.json")
 
         if await self._needs_update(model_info, model_path, force_update):
-            await self._download_profile_with_retry(manufacturer, model, storage_path, model_path)
+            await self._download_profile_with_retry(manufacturer.lower(), model, storage_path, model_path)
 
         try:
             json_data = await self._load_model_json(model_path)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -252,6 +252,24 @@ async def test_autodiscover_skips_diagnostics_entities(
     assert not hass.states.get("sensor.test_device_power")
 
 
+async def test_autodiscover_skips_printer_ink(
+    hass: HomeAssistant,
+    mock_entity_with_model_information: MockEntityWithModel,
+) -> None:
+    """Auto discovery should not consider printer entities with ink in the name"""
+
+    mock_entity_with_model_information(
+        "sensor.epson_et_3760_series_black_ink",
+        "EPSON",
+        "ET-3760 Series",
+        unit_of_measurement="%",
+    )
+
+    await run_powercalc_setup(hass, {})
+
+    assert not hass.states.get("sensor.test_device_power")
+
+
 async def test_autodiscover_skips_unsupported_domains(
     hass: HomeAssistant,
     mock_entity_with_model_information: MockEntityWithModel,


### PR DESCRIPTION
ink entity:
```
state_class: measurement 
marker_high_level: 100 
marker_low_level: 15 
marker_type: ink 
unit_of_measurement: % 
friendly_name: EPSON ET-3760 Series Black ink
```





* [Power profile](?expand=1&template=power_profile.md)
