### PR TITLE
fix author

### DIFF
--- a/profile_library/lidl/HG08010/model.json
+++ b/profile_library/lidl/HG08010/model.json
@@ -10,6 +10,6 @@
   },
   "name": "HG08010",
   "standby_power": 0.58,
-  "created_at": "2022-06-26T09:59:41",
-  "author": "Stefan Gries <10342151+stefangries@users.noreply.github.com>"
+  "created_at": "2023-02-08T01:57:00",
+  "author": "@RubenKelevra <cyrond@gmail.com>"
 }


### PR DESCRIPTION
See https://github.com/bramstroker/homeassistant-powercalc/pull/1482

@bramstroker wrote:

> @RubenKelevra Thanks for the contribution. What was the reason to remeasure this light? I did a comparance between the old and new profile, and they are almost identical. Your measurements look slightly better (more narrow on the spectrum), so I think I will merge this PR to override the old profile.

Reason was, that I had two and thought the results would be better given that. :)
