### PR TITLE
Bugfix for aliases and correcting tests

### DIFF
--- a/custom_components/powercalc/power_profile/loader/local.py
+++ b/custom_components/powercalc/power_profile/loader/local.py
@@ -181,6 +181,13 @@ class LocalLoader(Loader):
 
                 library[manufacturer].update({model_dir.lower(): profile})
                 for alias in profile.aliases:
+                    profile = PowerProfile(
+                        self._hass,
+                        manufacturer=manufacturer,
+                        model=alias,
+                        directory=model_path,
+                        json_data=model_json,
+                    )
                     library[manufacturer].update({alias.lower(): profile})
 
         return library

--- a/tests/power_profile/loader/test_local.py
+++ b/tests/power_profile/loader/test_local.py
@@ -11,15 +11,18 @@ from tests.common import get_test_config_dir
 @pytest.mark.parametrize(
     "manufacturer,search,expected",
     [
-        ["tp-link", {"HS300"}, "hs300"],
-        ["TP-link", {"HS300"}, "hs300"],
-        ["tp-link", {"HS400"}, "hs400"],  # alias
+        ["tp-link", {"HS300"}, "HS300"],
+        ["TP-link", {"HS300"}, "HS300"],
+        ["tp-link", {"hs300"}, "HS300"],
+        ["TP-link", {"hs300"}, "HS300"],
+        ["tp-link", {"HS400"}, "HS400"],  # alias
+        ["tp-link", {"hs400"}, "HS400"],  # alias
         ["tp-link", {"Hs500"}, "hs500"],  # alias
         ["tp-link", {"bla"}, None],
         ["foo", {"bar"}, None],
-        ["casing", {"CaSinG- Test"}, "casing- test"],
-        ["casing", {"CasinG- test"}, "casing- test"],
-        ["casing", {"CASING- TEST"}, "casing- test"],
+        ["casing", {"CaSinG- Test"}, "CaSinG- Test"],
+        ["casing", {"CasinG- test"}, "CaSinG- Test"],
+        ["casing", {"CASING- TEST"}, "CaSinG- Test"],
         ["hidden-directories", {".test"}, None],
         ["hidden-directories", {".hidden_model"}, None],
     ],
@@ -74,7 +77,7 @@ async def test_get_manufacturer_listing(hass: HomeAssistant) -> None:
     loader = await _create_loader(hass)
     assert await loader.get_manufacturer_listing(None) == {"tp-link", "tasmota", "hidden-directories", "casing"}
     assert "tp-link" in await loader.get_manufacturer_listing(DeviceType.SMART_SWITCH)
-    assert "tp-link" not in await loader.get_manufacturer_listing(DeviceType.LIGHT)
+    assert "tp-link" in await loader.get_manufacturer_listing(DeviceType.LIGHT)
     assert "tp-link" not in await loader.get_manufacturer_listing(DeviceType.COVER)
 
 
@@ -83,8 +86,9 @@ async def test_get_model_listing(hass: HomeAssistant) -> None:
     assert "HS300" in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
     assert "light20" not in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
     assert "light20" in await loader.get_model_listing("tp-link", DeviceType.LIGHT)
-    assert {"hs300", "hs400", "hs500", "light20"} == await loader.get_model_listing("tp-link", None)
-    assert "hs400" in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
+    assert {"HS300", "HS400", "hs500", "light20"} == await loader.get_model_listing("tp-link", None)
+    assert "HS300" in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
+    assert "HS400" not in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
     assert "test" in await loader.get_model_listing("Tasmota", DeviceType.LIGHT)
     assert ".test" not in await loader.get_model_listing("hidden-directories", DeviceType.LIGHT)
 

--- a/tests/power_profile/loader/test_local.py
+++ b/tests/power_profile/loader/test_local.py
@@ -87,8 +87,8 @@ async def test_get_model_listing(hass: HomeAssistant) -> None:
     assert "light20" not in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
     assert "light20" in await loader.get_model_listing("tp-link", DeviceType.LIGHT)
     assert {"HS300", "HS400", "hs500", "light20"} == await loader.get_model_listing("tp-link", None)
-    assert "HS300" in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
-    assert "HS400" not in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
+    assert "HS400" in await loader.get_model_listing("tp-link", DeviceType.SMART_SWITCH)
+    assert "HS400" not in await loader.get_model_listing("tp-link", DeviceType.LIGHT)
     assert "test" in await loader.get_model_listing("Tasmota", DeviceType.LIGHT)
     assert ".test" not in await loader.get_model_listing("hidden-directories", DeviceType.LIGHT)
 

--- a/tests/testing_config/powercalc/profiles/tp-link/light20/model.json
+++ b/tests/testing_config/powercalc/profiles/tp-link/light20/model.json
@@ -4,7 +4,7 @@
     "HS400",
     "hs500"
   ],
-  "device_type": "smart_switch",
+  "device_type": "light",
   "calculation_strategy": "multi_switch",
   "multi_switch_config": {
     "power": 0.82,

--- a/tests/testing_config/powercalc/profiles/tp-link/light20/model.json
+++ b/tests/testing_config/powercalc/profiles/tp-link/light20/model.json
@@ -1,9 +1,5 @@
 {
   "name": "IKEA Control outlet",
-  "aliases": [
-    "HS400",
-    "hs500"
-  ],
   "device_type": "light",
   "calculation_strategy": "multi_switch",
   "multi_switch_config": {


### PR DESCRIPTION
Aliases were not handled correctly, because PowerProfile was used from model and not alias.

Corrected tests to be mixed case aware again.
