### PR TITLE
Added raise exception for double model/alias per manfacturer and more tests

### DIFF
--- a/custom_components/powercalc/power_profile/loader/local.py
+++ b/custom_components/powercalc/power_profile/loader/local.py
@@ -179,8 +179,14 @@ class LocalLoader(Loader):
                     json_data=model_json,
                 )
 
+                if library.get(manufacturer).get(model_dir.lower()):
+                    raise LibraryLoadingError(f"Double entry manufacturer/model by model+alias in custom library: {manufacturer}/{model_dir}")
+
                 library[manufacturer].update({model_dir.lower(): profile})
                 for alias in profile.aliases:
+                    if library[manufacturer].get(alias.lower()):
+                        raise LibraryLoadingError(f"Double entry manufacturer/model by alias+alias in custom library: {manufacturer}/{alias}")
+
                     profile = PowerProfile(
                         self._hass,
                         manufacturer=manufacturer,

--- a/custom_components/powercalc/power_profile/loader/local.py
+++ b/custom_components/powercalc/power_profile/loader/local.py
@@ -179,7 +179,7 @@ class LocalLoader(Loader):
                     json_data=model_json,
                 )
 
-                if library.get(manufacturer).get(model_dir.lower()):
+                if library[manufacturer].get(model_dir.lower()):
                     raise LibraryLoadingError(f"Double entry manufacturer/model by model+alias in custom library: {manufacturer}/{model_dir}")
 
                 library[manufacturer].update({model_dir.lower(): profile})

--- a/tests/power_profile/loader/test_local.py
+++ b/tests/power_profile/loader/test_local.py
@@ -15,11 +15,13 @@ async def test_broken_lib_by_identical_model_alias(hass: HomeAssistant) -> None:
         await loader.initialize()
     assert "Double entry manufacturer/model by model+alias in custom library:" in str(excinfo.value)
 
+
 async def test_broken_lib_by_identical_alias_alias(hass: HomeAssistant) -> None:
     loader = LocalLoader(hass, get_test_config_dir("powercalc/profiles_lib_broken/double-alias"))
     with pytest.raises(LibraryLoadingError) as excinfo:
         await loader.initialize()
     assert "Double entry manufacturer/model by alias+alias in custom library:" in str(excinfo.value)
+
 
 @pytest.mark.parametrize(
     "manufacturer,search,expected",

--- a/tests/power_profile/loader/test_local.py
+++ b/tests/power_profile/loader/test_local.py
@@ -3,10 +3,23 @@ import logging
 import pytest
 from homeassistant.core import HomeAssistant
 
+from custom_components.powercalc.power_profile.error import LibraryLoadingError
 from custom_components.powercalc.power_profile.loader.local import LocalLoader
 from custom_components.powercalc.power_profile.power_profile import DeviceType
 from tests.common import get_test_config_dir
 
+
+async def test_broken_lib_by_identical_model_alias(hass: HomeAssistant) -> None:
+    loader = LocalLoader(hass, get_test_config_dir("powercalc/profiles_lib_broken/double-model"))
+    with pytest.raises(LibraryLoadingError) as excinfo:
+        await loader.initialize()
+    assert "Double entry manufacturer/model by model+alias in custom library:" in str(excinfo.value)
+
+async def test_broken_lib_by_identical_alias_alias(hass: HomeAssistant) -> None:
+    loader = LocalLoader(hass, get_test_config_dir("powercalc/profiles_lib_broken/double-alias"))
+    with pytest.raises(LibraryLoadingError) as excinfo:
+        await loader.initialize()
+    assert "Double entry manufacturer/model by alias+alias in custom library:" in str(excinfo.value)
 
 @pytest.mark.parametrize(
     "manufacturer,search,expected",
@@ -28,13 +41,19 @@ from tests.common import get_test_config_dir
     ],
 )
 async def test_find_model(hass: HomeAssistant, manufacturer: str, search: set[str], expected: str | None) -> None:
-    loader = LocalLoader(hass, get_test_config_dir("powercalc/profiles"))
-    await loader.initialize()
+    loader = await _create_loader(hass)
     found_model = await loader.find_model(manufacturer, search)
     assert found_model == expected
 
 
 # Tests for load_model
+async def test_load_model_raise_no_modeljson_exception(hass: HomeAssistant) -> None:
+    loader = LocalLoader(hass, get_test_config_dir("powercalc/profiles/test/nojson"), is_custom_directory=True)
+    with pytest.raises(LibraryLoadingError) as excinfo:
+        await loader.load_model("test", "nojson")
+    assert "model.json not found for manufacturer" in str(excinfo.value)
+
+
 async def test_load_model_returns_none_when_manufacturer_not_found(hass: HomeAssistant) -> None:
     loader = await _create_loader(hass)
     assert await loader.load_model("foo", "bar") is None

--- a/tests/testing_config/powercalc/profiles_lib_broken/double-alias/test_manu/model1/model.json
+++ b/tests/testing_config/powercalc/profiles_lib_broken/double-alias/test_manu/model1/model.json
@@ -1,0 +1,11 @@
+{
+  "name": "Fixed mode profile",
+  "aliases": [
+    "model3"
+  ],
+  "standby_power": 0.5,
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 50
+  }
+}

--- a/tests/testing_config/powercalc/profiles_lib_broken/double-alias/test_manu/model2/model.json
+++ b/tests/testing_config/powercalc/profiles_lib_broken/double-alias/test_manu/model2/model.json
@@ -1,0 +1,11 @@
+{
+  "name": "Fixed mode profile",
+  "aliases": [
+    "model3"
+  ],
+  "standby_power": 0.5,
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 50
+  }
+}

--- a/tests/testing_config/powercalc/profiles_lib_broken/double-model/test_manu/model1/model.json
+++ b/tests/testing_config/powercalc/profiles_lib_broken/double-model/test_manu/model1/model.json
@@ -1,0 +1,11 @@
+{
+  "name": "Fixed mode profile",
+  "aliases": [
+    "model2"
+  ],
+  "standby_power": 0.5,
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 50
+  }
+}

--- a/tests/testing_config/powercalc/profiles_lib_broken/double-model/test_manu/model2/model.json
+++ b/tests/testing_config/powercalc/profiles_lib_broken/double-model/test_manu/model2/model.json
@@ -1,0 +1,8 @@
+{
+  "name": "Fixed mode profile",
+  "standby_power": 0.5,
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 50
+  }
+}


### PR DESCRIPTION
Double entries of identically named models or aliases were "hiding" prior entries causing unpredictable outcome of model requests. Hence, exception will be raised if such problem is identified.
Added tests for this.

Also added test for still existing load_model with loader `is_custom_directory == True` for LocalLoader.
