### PR TITLE
New device: Manufacturer eq-3 - Model HM-ES-PMSw1-DR

### DIFF
--- a/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
+++ b/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
@@ -16,5 +16,5 @@
   },
   "created_at": "2024-09-06T18:37:40",
   "author": "CV",
-  "description": "HomematicIP DIN rail mount smart switch with power measurement integrated for outlets. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage is measured by the smart device."
+  "description": "Homematic DIN rail mount smart switch with power measurement integrated for outlets. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage is measured by the smart device."
 }

--- a/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
+++ b/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
@@ -1,0 +1,20 @@
+{
+  "measure_description": "Manually measured",
+  "measure_method": "manual",
+  "measure_device": "From manufacturer specifications",
+  "name": "HM-ES-PMSw1-DR",
+  "standby_power": 0.3,
+  "standby_power_on": 0.3,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 0
+  },
+  "created_at": "2024-09-06T18:37:40",
+  "author": "CV",
+  "description": "HomematicIP DIN rail mount smart switch with power measurement integrated for outlets. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage is measured by the smart device."
+}


### PR DESCRIPTION
Model for eq-3 device HM-ES-PMSw1-DR.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
https://de.elv.com/p/homematic-hutschienen-schaltaktor-mit-leistungsmessung-hm-es-pmsw1-dr-P150749/

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
```
HM-ES-PMSw1-DR
von eQ-3
Verbunden über <reducted>
Firmware: 2.5
Seriennummer: <reducted>
```

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
Measurements are taken vrom manufacturer technical details.

Relevant copy from the manual

```
15 Technische Daten
Ger�te-Kurzbezeichnung: HM-ES-PMSw1-DR
Versorgungsspannung: 230 V/50 Hz
Stromaufnahme: 16 A max .
Leistungsaufnahme Ruhebetrieb: < 0,3 W
Schutzart: IP20
Umgebungstemperatur: -10 bis +35 �C
Verschmutzungsgrad: 2
Messkategorie: CAT II
Funkfrequenz: 868,3 MHz
Empf�ngerkategorie: SRD Category 2
Typ . Funk-Freifeldreichweite: > 100 m
Duty Cycle: < 1 % pro h
Max. Schaltleistung: 3680 W (ohmsche Last)
Zugelassene Leitungsquerschnitte zum Anschluss an den Aktor:
Starre und flexible Leitung: 0,75�2,5 mm2
Relais: Schlie�er
L�nge der Tasterleitung: max . 30m
Installation: auf Tragschiene (Hutschiene, DIN-Rail) gem�� EN50022
Geh�useabmessungen (B x H x T): 35 x 87 x 64 mm (Standard-Hutschienengeh�use mit 2 TE Breite)
Gewicht: 76 g
```

