### PR TITLE
New model: eq-3 - HM-LC-Sw1-DR

### DIFF
--- a/profile_library/eq-3/HM-LC-Sw1-DR/model.json
+++ b/profile_library/eq-3/HM-LC-Sw1-DR/model.json
@@ -1,0 +1,20 @@
+{
+  "measure_description": "Manually measured",
+  "measure_method": "manual",
+  "measure_device": "From manufacturer specifications",
+  "name": "HM-LC-Sw1-DR",
+  "standby_power": 0.35,
+  "standby_power_on": 0.35,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 0
+  },
+  "created_at": "2024-09-06T18:37:40",
+  "author": "CV",
+  "description": "Homematic DIN rail mount smart switch. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage must be configured by the user since it is possible to connect anything to it."
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information

https://de.elv.com/p/homematic-1-kanal-schaltaktor-im-hutschienengehaeuse-hm-lc-sw1-dr-P141378/?itemId=141378

DIN rail mount device

## Home Assistant Device information

![grafik](https://github.com/user-attachments/assets/bc22f38f-8423-46b4-8d50-918856658422)


## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info

From technical specs of device.

```
13 Technische Daten
Ger�te-Kurzbezeichnung: HM-LC-Sw1-DR
Versorgungsspannung: 230 V/50 Hz
Stromaufnahme: 6 A max.
Leistungsaufnahme Ruhebetrieb: 0,35 W
Schutzart: IP20
Umgebungstemperatur: 5 bis 35 �C
Funk-Frequenzband: 868,0 - 868,6 MHz 
Maximale Funk-Sendeleistung: 10 dBm
Empf�ngerkategorie: SRD category 2
Typ. Funk-Freifeldreichweite: 200 m
Duty Cycle: < 1 % pro h
Leitungsart und -querschnitt: Starre und flexible Leitung, 0,75-2,50 mm2
Relais: Schlie�er, 1-polig, �-Kontakt
Lastart: ohmsche Last
Max. Schaltleistung: 1380 W
Leitungsl�nge an S1 (Tasteranschluss): 30 m
Installation: auf Tragschiene (Hutschiene, DIN-Rail) gem�� EN50022
Abmessungen (B x H x T): 18 x 65 x 87 mm (Standard-Hutschienengeh�use mit 1 TE Breite)
Gewicht: 63 g
```

