### PR TITLE
New model: eq-3, HmIP-BDT

### DIFF
--- a/profile_library/eq-3/HmIP-BDT/model.json
+++ b/profile_library/eq-3/HmIP-BDT/model.json
@@ -1,0 +1,20 @@
+{
+  "measure_description": "Manually measured",
+  "measure_method": "manual",
+  "measure_device": "From manufacturer specifications",
+  "name": "HmIP-BDT",
+  "standby_power": 0.4,
+  "standby_power_on": 0.4,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "light",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 0
+  },
+  "created_at": "2024-09-06T18:37:40",
+  "author": "CV",
+  "description": "HomematicIP smart trailing edge dimmer for outlets. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage must be configured by the user since it is possible to connect anything to it."
+}


### PR DESCRIPTION
Manufacturer: eq-3
Model: HmIP

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

- https://de.elv.com/p/homematic-ip-smart-home-dimmaktor-hmip-bdt-fuer-markenschalter-P143166/?itemId=143166
- Dimming actor for outlets

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->

Data taken from technical specs of manufacturer.

```
11 Technische Daten
Geräte-Kurzbezeichnung: HmIP-BDT
Versorgungsspannung: 230 V/50 Hz
Stromaufnahme: 0,35 A 
Minimallast: 3 VA 
Maximale Schaltleistung: 80 VA 
Leistungsaufnahme im
Ruhebetrieb: 0,4 W 
Dimmverfahren: Phasenabschnitt
Lastart: ohmsche und kapazitive Lampenlast
Leitungsart u. -querschnitt: starre und flexible Leitung, 0,75 - 1,5 mm²
Installation: nur in Schalterdosen (Gerätedosen) gemäß DIN 49073-1
Schutzart: IP20
Schutzklasse: II
Geräteschutz: Überlastsicherung, Temperatursicherung
Umgebungstemperatur: 5 bis 35 °C
Abmessung (B x H x T ): 71 x 71 x 37 mm
Gewicht: 47 g
Funk-Frequenzband: 868,0-868,6 MHz
 869,4-869,65 MHz
Max. Funk-Sendeleistung: 10 dBm
Empfängerkategorie: SRD category 2
Typ. Funk-Freifeldreichweite: 270 m
Duty Cycle: < 1% pro h / < 10% pro h
```
