### PR TITLE
[docs] Measure: don't recommend older Shelly products or Tapo P110 anymore

### DIFF
--- a/docs/source/contributing/measure.md
+++ b/docs/source/contributing/measure.md
@@ -9,7 +9,7 @@
 To start measuring you'll need the following:
 
 - A computer (running Windows, Linux, MacOSX).
-- Supported smartplug which can accurately measure small currents (Shelly Plug S, Shelly 1PM or Tapo P110 recommended)
+- Supported smartplug which can accurately measure small currents (Shelly PM mini Gen3 recommended)
 - A fixture in which you can fit your light and a power plug on the other end which you can connect to your smartplug.
 - Install the measure script as described here: <https://github.com/bramstroker/homeassistant-powercalc/blob/master/utils/measure/README.md>
 


### PR DESCRIPTION
Older Shelly products, like the Shelly Plug S feature a power measuring chip, which sends pulses with different width to the CPU, depending on the consumption. They are pretty inaccurate, compared to laboratory equipment.[1]

We shouldn't recommend them anymore.

The Tapo P110 got refreshed as Tapo P110M and a German Magazine did a test and found out, that they still are very inaccurate on low-end measurements, which is what we're needing for Powercalc.[2]

So we shouldn't recommend them either.

Shelly on the other hand released a new version of their in-wall mounted devices, which turns out to feature a much more accurate measuring chip for all types of loads, which sends its data via UART/SPI.[3]

We should recommend this instead.

Sources (in German, sorry!):

[1] https://www.youtube.com/watch?v=JSET9UTkveI
[2] https://www.chip.de/test/TP-Link-Tapo-P110M-im-Test_185191030.html
[3] https://www.youtube.com/watch?v=ZXC4vft57gU

