### PR TITLE
measure Shelly PM Mini Gen3

### DIFF
--- a/profile_library/shelly/shelly pm mini gen3/model.json
+++ b/profile_library/shelly/shelly pm mini gen3/model.json
@@ -1,0 +1,18 @@
+{
+  "measure_description": "Manually measured. Transcribed from https://www.youtube.com/watch?v=ZXC4vft57gU",
+  "measure_method": "manual",
+  "measure_device": "GW Instek GPM-8310",
+  "name": "Shelly PM Mini Gen3",
+  "standby_power": 0.642,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 0.642
+  },
+  "created_at": "2024-12-01T16:51:00",
+  "author": "RubenKelevra <cyrond@gmail.com>"
+}


### PR DESCRIPTION

## Device information

https://www.shelly.com/de/products/shelly-pm-mini-gen3


## Home Assistant Device information
``` 
Shelly PM Mini Gen3 (S3PM-001PCEU16)
by Shelly
Firmware: 20241011-114503/1.4.4-g6d2a586
Hardware: gen3
``` 

## Checklist


- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [x] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
Technically not a "smart_switch", but a smart power meter, but there's no such category in the [database](https://github.com/bramstroker/homeassistant-powercalc/blob/00255773313eb90da3ca5fec81261d640c45fca5/custom_components/powercalc/power_profile/power_profile.py#L35).
