### PR TITLE
measure Shelly 3EM

### DIFF
--- a/profile_library/shelly/Shelly 3EM/model.json
+++ b/profile_library/shelly/Shelly 3EM/model.json
@@ -1,0 +1,18 @@
+{
+  "measure_description": "Manually measured. Transcribed from https://www.youtube.com/watch?v=RlSCe9xaUPE",
+  "measure_method": "manual",
+  "measure_device": "GW Instek GPM-8310",
+  "name": "Shelly 3EM",
+  "standby_power": 1.22,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 1.22
+  },
+  "created_at": "2024-12-01T18:27:00",
+  "author": "RubenKelevra <cyrond@gmail.com>"
+}


### PR DESCRIPTION
This device was measured be the YouTuber Channel Zerobrain with a lab power measuring device (GW Instek GPM-8310), which is more precise than the previous measurements.

Source:

https://www.youtube.com/watch?v=RlSCe9xaUPE


## Device information

https://www.shelly.com/de/products/shelly-3em

## Home Assistant Device information
Unknown, but following other Shelly devices, the name in the `model.json` should be correct.

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [x] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
