### PR TITLE
remeasure Shelly Plus Plug S

### DIFF
--- a/profile_library/shelly/shelly plus plug s/model.json
+++ b/profile_library/shelly/shelly plus plug s/model.json
@@ -1,9 +1,9 @@
 {
-  "measure_description": "Manually measured.",
+  "measure_description": "Manually measured. (LED off). Transcribed from https://www.youtube.com/watch?v=cLtao6yG7ds",
   "measure_method": "manual",
-  "measure_device": "AVM FRITZ!DECT 200",
+  "measure_device": "GW Instek GPM-8310",
   "name": "Shelly Plus Plug S",
-  "standby_power": 0.8,
+  "standby_power": 0.740,
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
@@ -11,8 +11,8 @@
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
   "fixed_config": {
-    "power": 1.1
+    "power": 1.01
   },
-  "created_at": "2023-12-31T08:21:16",
-  "author": "ca-dmin"
+  "created_at": "2024-12-01T18:36:00",
+  "author": "RubenKelevra <cyrond@gmail.com>"
 }

--- a/profile_library/shelly/shelly plus plug s/model.json
+++ b/profile_library/shelly/shelly plus plug s/model.json
@@ -3,7 +3,7 @@
   "measure_method": "manual",
   "measure_device": "GW Instek GPM-8310",
   "name": "Shelly Plus Plug S",
-  "standby_power": 0.740,
+  "standby_power": 0.74,
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"


### PR DESCRIPTION
This device was measured be the YouTuber Channel Zerobrain with a lab power measuring device (GW Instek GPM-8310), which is more precise than the previous measurements.

Source:

https://www.youtube.com/watch?v=cLtao6yG7ds

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [x] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info

This device features an LED, the numbers in the profile are for the LED being turned off, as different colors of the LED will lead to different power consumptions, that would require a HUE measurement, similar to a light. The difference is about 900 mW between white light and off.

