### PR TITLE
add missing alias for Shelly PM Mini Gen3

### DIFF
--- a/profile_library/shelly/shelly pm mini gen3/model.json
+++ b/profile_library/shelly/shelly pm mini gen3/model.json
@@ -13,6 +13,9 @@
   "fixed_config": {
     "power": 0.642
   },
+  "aliases": [
+    "S3PM-001PCEU16"
+  ],
   "created_at": "2024-12-01T16:51:00",
   "author": "RubenKelevra <cyrond@gmail.com>"
 }


### PR DESCRIPTION
In #2743 I forgot to add the alias for the device to the `model.json`.