### PR TITLE
Use the new smart_dimmer class for the HmIP-BDT device

### DIFF
--- a/profile_library/eq-3/HmIP-BDT/model.json
+++ b/profile_library/eq-3/HmIP-BDT/model.json
@@ -9,11 +9,8 @@
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
   },
-  "device_type": "light",
-  "calculation_strategy": "fixed",
-  "fixed_config": {
-    "power": 0
-  },
+  "device_type": "smart_dimmer",
+  "calculation_strategy": "linear",
   "created_at": "2024-09-06T18:37:40",
   "author": "CV",
   "description": "HomematicIP smart trailing edge dimmer for outlets. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage must be configured by the user since it is possible to connect anything to it."


### PR DESCRIPTION
The device type was `light` before, which meant that no fixed power could be specified by the user in the UI config flow; see #2693 for discussion.

In response, a new device type `smart_dimmer` was created in #2765.

[This comment](https://github.com/bramstroker/homeassistant-powercalc/issues/2754#issuecomment-2524028107) describes how to use the new device type; the changes in this commit follow that pattern.