### PR TITLE
Cleanup code of the config flow

### DIFF
--- a/custom_components/powercalc/config_flow.py
+++ b/custom_components/powercalc/config_flow.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any, Callable, Coroutine, cast
 
 import voluptuous as vol
 from homeassistant.components.sensor import SensorDeviceClass
@@ -132,12 +132,14 @@ _LOGGER = logging.getLogger(__name__)
 CONF_CONFIRM_AUTODISCOVERED_MODEL = "confirm_autodisovered_model"
 
 
-class Steps(StrEnum):
+class Step(StrEnum):
     ADVANCED_OPTIONS = "advanced_options"
     BASIC_OPTIONS = "basic_options"
-    DOMAIN_GROUP = "domain_group"
-    GROUP = "group"
+    GROUP_CUSTOM = "group_custom"
+    GROUP_DOMAIN = "group_domain"
+    GROUP_SUBTRACT = "group_subtract"
     LIBRARY = "library"
+    POST_LIBRARY = "post_library"
     LIBRARY_MULTI_PROFILE = "library_multi_profile"
     LIBRARY_OPTIONS = "library_options"
     VIRTUAL_POWER = "virtual_power"
@@ -156,7 +158,6 @@ class Steps(StrEnum):
     SUB_PROFILE = "sub_profile"
     USER = "user"
     SMART_SWITCH = "smart_switch"
-    SUBTRACT_GROUP = "subtract_group"
     INIT = "init"
     UTILITY_METER_OPTIONS = "utility_meter_options"
     GLOBAL_CONFIGURATION = "global_configuration"
@@ -165,35 +166,42 @@ class Steps(StrEnum):
 
 
 MENU_SENSOR_TYPE = {
-    Steps.VIRTUAL_POWER: "Virtual power (manual)",
-    Steps.MENU_LIBRARY: "Virtual power (library)",
-    Steps.MENU_GROUP: "Group",
-    Steps.DAILY_ENERGY: "Daily energy",
-    Steps.REAL_POWER: "Energy from real power sensor",
+    Step.VIRTUAL_POWER: "Virtual power (manual)",
+    Step.MENU_LIBRARY: "Virtual power (library)",
+    Step.MENU_GROUP: "Group",
+    Step.DAILY_ENERGY: "Daily energy",
+    Step.REAL_POWER: "Energy from real power sensor",
 }
 
 MENU_GROUP = {
-    Steps.GROUP: "Standard group",
-    Steps.DOMAIN_GROUP: "Domain based group",
-    Steps.SUBTRACT_GROUP: "Subtract group",
+    Step.GROUP_CUSTOM: "Standard group",
+    Step.GROUP_DOMAIN: "Domain based group",
+    Step.GROUP_SUBTRACT: "Subtract group",
 }
 
 MENU_OPTIONS = {
-    Steps.FIXED: "Fixed options",
-    Steps.LINEAR: "Linear options",
-    Steps.MULTI_SWITCH: "Multi switch options",
-    Steps.PLAYBOOK: "Playbook options",
-    Steps.WLED: "WLED options",
+    Step.FIXED: "Fixed options",
+    Step.LINEAR: "Linear options",
+    Step.MULTI_SWITCH: "Multi switch options",
+    Step.PLAYBOOK: "Playbook options",
+    Step.WLED: "WLED options",
 }
 
 LIBRARY_URL = "https://library.powercalc.nl"
 
 STRATEGY_STEP_MAPPING = {
-    CalculationStrategy.FIXED: Steps.FIXED,
-    CalculationStrategy.LINEAR: Steps.LINEAR,
-    CalculationStrategy.MULTI_SWITCH: Steps.MULTI_SWITCH,
-    CalculationStrategy.PLAYBOOK: Steps.PLAYBOOK,
-    CalculationStrategy.WLED: Steps.WLED,
+    CalculationStrategy.FIXED: Step.FIXED,
+    CalculationStrategy.LINEAR: Step.LINEAR,
+    CalculationStrategy.MULTI_SWITCH: Step.MULTI_SWITCH,
+    CalculationStrategy.PLAYBOOK: Step.PLAYBOOK,
+    CalculationStrategy.WLED: Step.WLED,
+}
+
+GROUP_STEP_MAPPING = {
+    GroupType.CUSTOM: Step.GROUP_CUSTOM,
+    GroupType.DOMAIN: Step.GROUP_DOMAIN,
+    GroupType.STANDBY: Step.GROUP_DOMAIN,
+    GroupType.SUBTRACT: Step.GROUP_SUBTRACT,
 }
 
 SCHEMA_UTILITY_METER_TOGGLE = vol.Schema(
@@ -510,15 +518,37 @@ SCHEMA_GLOBAL_CONFIGURATION_ENERGY_SENSOR = vol.Schema(
     },
 )
 
+GROUP_SCHEMAS = {
+    GroupType.CUSTOM: SCHEMA_GROUP,
+    GroupType.DOMAIN: SCHEMA_GROUP_DOMAIN,
+    GroupType.SUBTRACT: SCHEMA_GROUP_SUBTRACT,
+}
+
 
 @dataclass(slots=True)
 class PowercalcFormStep(SchemaFlowFormStep):
-    step: Steps = None
+    schema: (
+        vol.Schema
+        | Callable[[], Coroutine[Any, Any, vol.Schema | None]]
+        | None
+    ) = None
 
-    extra_form_args: dict[str, Any] = None
+    validate_user_input: (
+        Callable[
+            [dict[str, Any]],
+            Coroutine[Any, Any, dict[str, Any]],
+        ]
+        | None
+    ) = None
+
+    next_step: Step | None = None
+    step: Step | None = None
+    continue_utility_meter_options_step: bool = False
+    continue_advanced_step: bool = False
+    form_kwarg: dict[str, Any] | None = None
 
 
-class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
+class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow):
     def __init__(self) -> None:
         """Initialize options flow."""
         self.sensor_config: ConfigType = {}
@@ -529,6 +559,8 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
         self.is_library_flow: bool = False
         self.skip_advanced_step: bool = False
         self.is_options_flow: bool = isinstance(self, OptionsFlow)
+        self.name: str | None = None
+        super().__init__()
 
     @abstractmethod
     @callback
@@ -541,69 +573,50 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
             self.sensor_config.get(CONF_MODE) or self.selected_profile.calculation_strategy,  # type: ignore
         )
         factory = PowerCalculatorStrategyFactory(self.hass)
-        strategy = await factory.create(user_input or self.sensor_config, strategy_name, self.selected_profile, self.source_entity)  # type: ignore
+        strategy = await factory.create(user_input or self.sensor_config, strategy_name, self.selected_profile,
+                                        self.source_entity)  # type: ignore
         try:
             await strategy.validate_config()
         except StrategyConfigurationError as error:
-            translation = error.get_config_flow_translate_key()
-            if translation is None:
-                translation = "unknown"
             _LOGGER.error(str(error))
-            raise SchemaFlowError(translation)
-            # return {"base": translation}
-        # return {}
+            raise SchemaFlowError(error.get_config_flow_translate_key() or "unknown")
 
     @staticmethod
-    def validate_group_input(user_input: dict[str, Any] | None = None) -> dict:
+    def validate_group_input(user_input: dict[str, Any] | None = None) -> None:
         """Validate the group form."""
-        if not user_input:
-            return {}
-        errors: dict[str, str] = {}
+        required_keys = {
+            CONF_SUB_GROUPS,
+            CONF_GROUP_POWER_ENTITIES,
+            CONF_GROUP_ENERGY_ENTITIES,
+            CONF_GROUP_MEMBER_SENSORS,
+            CONF_AREA,
+        }
 
-        if (
-            CONF_SUB_GROUPS not in user_input
-            and CONF_GROUP_POWER_ENTITIES not in user_input
-            and CONF_GROUP_ENERGY_ENTITIES not in user_input
-            and CONF_GROUP_MEMBER_SENSORS not in user_input
-            and CONF_AREA not in user_input
-        ):
-            errors["base"] = "group_mandatory"
-
-        return errors
-
-    @staticmethod
-    def validate_daily_energy_input(user_input: dict[str, Any] | None) -> dict:
-        """Validates the daily energy form."""
-        if not user_input:
-            return {}
-        errors: dict[str, str] = {}
-
-        if CONF_VALUE not in user_input and CONF_VALUE_TEMPLATE not in user_input:
-            errors["base"] = "daily_energy_mandatory"
-
-        return errors
+        if not any(key in user_input or {} for key in required_keys):
+            raise SchemaFlowError("group_mandatory")
 
     def create_strategy_schema(self, strategy: CalculationStrategy, source_entity_id: str) -> vol.Schema:
         """Get the config schema for a given power calculation strategy."""
         if strategy == CalculationStrategy.LINEAR:
-            return self.create_schema_linear(source_entity_id)
+            return SCHEMA_POWER_LINEAR.extend(  # type: ignore
+                {
+                    vol.Optional(CONF_ATTRIBUTE): selector.AttributeSelector(
+                        selector.AttributeSelectorConfig(
+                            entity_id=source_entity_id,
+                            hide_attributes=[],
+                        ),
+                    ),
+                },
+            )
         if strategy == CalculationStrategy.PLAYBOOK:
             return SCHEMA_POWER_PLAYBOOK
         if strategy == CalculationStrategy.MULTI_SWITCH:
-            return self.create_schema_multi_switch()
+            return SCHEMA_POWER_MULTI_SWITCH if self.is_library_flow else SCHEMA_POWER_MULTI_SWITCH_MANUAL
         if strategy == CalculationStrategy.WLED:
             return SCHEMA_POWER_WLED
         return SCHEMA_POWER_FIXED
 
-    def create_daily_energy_schema(self) -> vol.Schema:
-        """Create the config schema for daily energy sensor."""
-        return SCHEMA_DAILY_ENERGY.extend(  # type: ignore
-            {
-                vol.Optional(CONF_GROUP): self.create_group_selector(),
-            },
-        )
-
-    def create_schema_group(
+    def create_schema_group_custom(
         self,
         config_entry: ConfigEntry | None = None,
         is_option_flow: bool = False,
@@ -613,8 +626,8 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
             selector.SelectOptionDict(value=config_entry.entry_id, label=config_entry.title)
             for config_entry in self.hass.config_entries.async_entries(DOMAIN)
             if config_entry.data.get(CONF_SENSOR_TYPE) in [SensorType.VIRTUAL_POWER, SensorType.REAL_POWER]
-            and config_entry.unique_id is not None
-            and config_entry.title is not None
+               and config_entry.unique_id is not None
+               and config_entry.title is not None
         ]
         member_sensor_selector = selector.SelectSelector(
             selector.SelectSelectorConfig(
@@ -663,24 +676,6 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
 
         return schema
 
-    @staticmethod
-    def create_schema_linear(source_entity_id: str) -> vol.Schema:
-        """Create the config schema for linear strategy."""
-        return SCHEMA_POWER_LINEAR.extend(  # type: ignore
-            {
-                vol.Optional(CONF_ATTRIBUTE): selector.AttributeSelector(
-                    selector.AttributeSelectorConfig(
-                        entity_id=source_entity_id,
-                        hide_attributes=[],
-                    ),
-                ),
-            },
-        )
-
-    def create_schema_multi_switch(self) -> vol.Schema:
-        """Create the config schema for multi switch strategy."""
-        return SCHEMA_POWER_MULTI_SWITCH if self.is_library_flow else SCHEMA_POWER_MULTI_SWITCH_MANUAL
-
     def create_schema_virtual_power(
         self,
     ) -> vol.Schema:
@@ -710,71 +705,6 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
         )
         return schema.extend(power_options.schema)  # type: ignore
 
-    async def create_schema_manufacturer(self) -> vol.Schema:
-        """Create manufacturer schema."""
-        library = await ProfileLibrary.factory(self.hass)
-        manufacturers = [
-            selector.SelectOptionDict(value=manufacturer, label=manufacturer)
-            for manufacturer in await library.get_manufacturer_listing(self.source_entity.domain)  # type: ignore
-        ]
-        return vol.Schema(
-            {
-                vol.Required(CONF_MANUFACTURER, default=self.sensor_config.get(CONF_MANUFACTURER)): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=manufacturers,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    ),
-                ),
-            },
-        )
-
-    async def create_schema_model(self) -> vol.Schema:
-        """Create model schema."""
-        manufacturer = str(self.sensor_config.get(CONF_MANUFACTURER))
-        library = await ProfileLibrary.factory(self.hass)
-        models = [
-            selector.SelectOptionDict(value=model, label=model)
-            for model in await library.get_model_listing(manufacturer, self.source_entity.domain)  # type: ignore
-        ]
-        return vol.Schema(
-            {
-                vol.Required(CONF_MODEL, default=self.sensor_config.get(CONF_MODEL)): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=models,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    ),
-                ),
-            },
-        )
-
-    async def create_schema_sub_profile(
-        self,
-        model_info: ModelInfo,
-    ) -> vol.Schema:
-        """Create sub profile schema."""
-        library = await ProfileLibrary.factory(self.hass)
-        profile = await library.get_profile(model_info)
-        sub_profiles = [selector.SelectOptionDict(value=sub_profile, label=sub_profile) for sub_profile in await profile.get_sub_profiles()]
-        return vol.Schema(
-            {
-                vol.Required(CONF_SUB_PROFILE): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=sub_profiles,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    ),
-                ),
-            },
-        )
-
-    def create_schema_advanced(self) -> vol.Schema:
-        """Create the advanced options schema."""
-        schema = SCHEMA_POWER_ADVANCED
-
-        if self.sensor_config.get(CONF_CREATE_ENERGY_SENSOR):
-            schema = schema.extend(SCHEMA_ENERGY_OPTIONS.schema)
-
-        return schema
-
     def create_source_entity_selector(
         self,
     ) -> selector.EntitySelector:
@@ -798,7 +728,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
             )
             for config_entry in self.hass.config_entries.async_entries(DOMAIN)
             if config_entry.data.get(CONF_SENSOR_TYPE) == SensorType.GROUP
-            and (current_entry is None or config_entry.entry_id != current_entry.entry_id)
+               and (current_entry is None or config_entry.entry_id != current_entry.entry_id)
         ]
 
         return selector.SelectSelector(
@@ -879,7 +809,8 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
         """Get the fixed power config for smart switch."""
         if self.selected_profile is None:
             return {CONF_POWER: 0}  # pragma: no cover
-        self_usage_on = self.selected_profile.fixed_mode_config.get(CONF_POWER, 0) if self.selected_profile.fixed_mode_config else 0
+        self_usage_on = self.selected_profile.fixed_mode_config.get(CONF_POWER,
+                                                                    0) if self.selected_profile.fixed_mode_config else 0
         power = user_input.get(CONF_POWER, 0)
         self_usage_included = user_input.get(CONF_SELF_USAGE_INCLUDED, True)
         if self_usage_included:
@@ -890,43 +821,83 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
         self,
         form_step: PowercalcFormStep,
         user_input: dict[str, Any] | None = None,
-    ):
+    ) -> FlowResult:
         """Handle the current step."""
         if user_input is not None:
             if form_step.validate_user_input is not None:
                 try:
-                    user_input = await form_step.validate_user_input(self, user_input)
+                    user_input = await form_step.validate_user_input(user_input)
                 except SchemaFlowError as exc:
                     return await self._show_form(form_step, exc)
 
+            if CONF_NAME in user_input:
+                self.name = user_input[CONF_NAME]
             self.sensor_config.update(user_input)
+
+            if not form_step.next_step:
+                if form_step.continue_utility_meter_options_step and self.sensor_config.get(CONF_CREATE_UTILITY_METERS):
+                    return await self.async_step_utility_meter_options()
+                return self.persist_config_entry()
+
             return await getattr(self, f"async_step_{form_step.next_step}")()
 
         return await self._show_form(form_step)
 
-    async def _show_form(self, form_step: PowercalcFormStep, error: SchemaFlowError | None = None) -> ConfigFlowResult:
+    async def _show_form(self, form_step: PowercalcFormStep, error: SchemaFlowError | None = None) -> FlowResult:
         # Show form for next step
         last_step = None
         if not callable(form_step.next_step):
             last_step = form_step.next_step is None
 
+        schema = await self._get_schema(form_step)
         return self.async_show_form(
             step_id=form_step.step,
-            data_schema=form_step.schema,
+            data_schema=self.fill_schema_defaults(
+                schema,
+                self.get_global_powercalc_config(),
+            ),
             errors={"base": str(error)} if error else {},
             last_step=last_step,
+            **(form_step.form_kwarg or {}),
         )
+
+    async def _get_schema(self, form_step: PowercalcFormStep) -> vol.Schema | None:
+        if form_step.schema is None:
+            return None
+        if isinstance(form_step.schema, vol.Schema):
+            return form_step.schema
+        return await form_step.schema()
 
     async def async_step_manufacturer(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Ask the user to select the manufacturer."""
+
+        async def _create_schema() -> vol.Schema:
+            """Create manufacturer schema."""
+            library = await ProfileLibrary.factory(self.hass)
+            manufacturers = [
+                selector.SelectOptionDict(value=manufacturer, label=manufacturer)
+                for manufacturer in await library.get_manufacturer_listing(self.source_entity.domain)  # type: ignore
+            ]
+            return vol.Schema(
+                {
+                    vol.Required(CONF_MANUFACTURER,
+                                 default=self.sensor_config.get(CONF_MANUFACTURER)): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=manufacturers,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        ),
+                    ),
+                },
+            )
+
         return await self.handle_form_step(
             PowercalcFormStep(
-                step=Steps.MANUFACTURER,
-                schema=await self.create_schema_manufacturer(),
-                next_step=Steps.MODEL,
+                step=Step.MANUFACTURER,
+                schema=_create_schema,
+                next_step=Step.MODEL,
             ),
             user_input,
         )
@@ -937,7 +908,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
     ) -> FlowResult:
         """Ask the user to select the model."""
 
-        async def _validate(_, user_input: dict[str, Any]) -> dict[str, str]:
+        async def _validate(user_input: dict[str, Any]) -> dict[str, str]:
             library = await ProfileLibrary.factory(self.hass)
             profile = await library.get_profile(
                 ModelInfo(
@@ -950,11 +921,30 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
                 await self.validate_strategy_config()
             return user_input
 
+        async def _create_schema() -> vol.Schema:
+            """Create model schema."""
+            manufacturer = str(self.sensor_config.get(CONF_MANUFACTURER))
+            library = await ProfileLibrary.factory(self.hass)
+            models = [
+                selector.SelectOptionDict(value=model, label=model)
+                for model in await library.get_model_listing(manufacturer, self.source_entity.domain)  # type: ignore
+            ]
+            return vol.Schema(
+                {
+                    vol.Required(CONF_MODEL, default=self.sensor_config.get(CONF_MODEL)): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=models,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        ),
+                    ),
+                },
+            )
+
         return await self.handle_form_step(
             PowercalcFormStep(
-                step=Steps.MODEL,
-                schema=await self.create_schema_model(),
-                next_step="post_library",
+                step=Step.MODEL,
+                schema=_create_schema,
+                next_step=Step.POST_LIBRARY,
                 validate_user_input=_validate,
             ),
             user_input,
@@ -995,21 +985,40 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
     ) -> FlowResult:
         """Handle the flow for sub profile selection."""
 
-        async def _validate(_, input: dict[str, Any]) -> dict[str, str]:
+        async def _validate(input: dict[str, Any]) -> dict[str, str]:
             input[CONF_MODEL] = f"{self.sensor_config.get(CONF_MODEL)}/{input.get(CONF_SUB_PROFILE)}"
             del input[CONF_SUB_PROFILE]
             return user_input
 
+        async def _create_schema(
+            model_info: ModelInfo,
+        ) -> vol.Schema:
+            """Create sub profile schema."""
+            library = await ProfileLibrary.factory(self.hass)
+            profile = await library.get_profile(model_info)
+            sub_profiles = [selector.SelectOptionDict(value=sub_profile, label=sub_profile) for sub_profile in
+                            await profile.get_sub_profiles()]
+            return vol.Schema(
+                {
+                    vol.Required(CONF_SUB_PROFILE): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=sub_profiles,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        ),
+                    ),
+                },
+            )
+
         return await self.handle_form_step(
             PowercalcFormStep(
-                step=Steps.SUB_PROFILE,
-                schema=await self.create_schema_sub_profile(
+                step=Step.SUB_PROFILE,
+                schema=await _create_schema(
                     ModelInfo(
                         str(self.sensor_config.get(CONF_MANUFACTURER)),
                         str(self.sensor_config.get(CONF_MODEL)),
                     ),
                 ),
-                next_step=Steps.POWER_ADVANCED,
+                next_step=Step.POWER_ADVANCED,
                 validate_user_input=_validate,
             ),
             user_input,
@@ -1030,10 +1039,14 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
                 return await self.async_step_utility_meter_options()
             return self.persist_config_entry()
 
+        schema = SCHEMA_POWER_ADVANCED
+        if self.sensor_config.get(CONF_CREATE_ENERGY_SENSOR):
+            schema = schema.extend(SCHEMA_ENERGY_OPTIONS.schema)
+
         return self.async_show_form(
-            step_id=Steps.POWER_ADVANCED,
+            step_id=Step.POWER_ADVANCED,
             data_schema=self.fill_schema_defaults(
-                self.create_schema_advanced(),
+                schema,
                 self.get_global_powercalc_config(),
             ),
             errors={},
@@ -1044,25 +1057,50 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Asks the user for the power of connect appliance for the smart switch."""
-        if user_input is not None:
-            self.sensor_config.update(
-                {
-                    CONF_SELF_USAGE_INCLUDED: user_input.get(CONF_SELF_USAGE_INCLUDED),
-                    CONF_MODE: CalculationStrategy.FIXED,
-                    CONF_FIXED: self.get_fixed_power_config_for_smart_switch(user_input),
-                },
-            )
-            return await self.async_step_power_advanced()
+
+        async def _validate(user_input: dict[str, Any]) -> dict[str, Any]:
+            return {
+                CONF_SELF_USAGE_INCLUDED: user_input.get(CONF_SELF_USAGE_INCLUDED),
+                CONF_MODE: CalculationStrategy.FIXED,
+                CONF_FIXED: self.get_fixed_power_config_for_smart_switch(user_input),
+            }
 
         self_usage_on = 0
         if self.selected_profile and self.selected_profile.fixed_mode_config:
             self_usage_on = self.selected_profile.fixed_mode_config.get(CONF_POWER, 0)
-        return self.async_show_form(
-            step_id=Steps.SMART_SWITCH,
-            data_schema=SCHEMA_POWER_SMART_SWITCH,
-            description_placeholders={"self_usage_power": str(self_usage_on)},
-            errors={},
-            last_step=False,
+        return await self.handle_form_step(
+            PowercalcFormStep(
+                step=Step.SMART_SWITCH,
+                schema=SCHEMA_POWER_SMART_SWITCH,
+                validate_user_input=_validate,
+                next_step=Step.POWER_ADVANCED,
+                form_kwarg={"description_placeholders": {"self_usage_power": str(self_usage_on)}},
+            ),
+            user_input
+        )
+
+    async def handle_strategy_step(
+        self,
+        strategy: CalculationStrategy,
+        user_input: dict[str, Any] | None = None,
+        validate: Callable[[dict[str, Any]], None] | None = None,
+    ) -> FlowResult:
+        async def _validate(user_input: dict[str, Any]) -> dict[str, Any]:
+            if validate:
+                validate(user_input)
+            await self.validate_strategy_config({strategy: user_input})
+            return {strategy: user_input}
+
+        schema = self.create_strategy_schema(strategy, self.source_entity_id)
+
+        return await self.handle_form_step(
+            PowercalcFormStep(
+                step=STRATEGY_STEP_MAPPING[strategy],
+                schema=schema,
+                next_step=Step.POWER_ADVANCED,
+                validate_user_input=_validate,
+            ),
+            user_input,
         )
 
     async def async_step_fixed(
@@ -1070,81 +1108,52 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle the flow for fixed sensor."""
-
-        async def validate(_, user_input):
-            user_input = {CONF_FIXED: user_input}
-            await self.validate_strategy_config(user_input)
-            return user_input
-
-        return await self.handle_form_step(
-            PowercalcFormStep(
-                step=Steps.FIXED,
-                schema=SCHEMA_POWER_FIXED,
-                next_step=Steps.POWER_ADVANCED,
-                validate_user_input=validate,
-            ),
-            user_input,
-        )
+        return await self.handle_strategy_step(CalculationStrategy.FIXED, user_input)
 
     async def async_step_linear(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
-        """Handle the flow for linear sensor."""
-
-        async def validate(_, user_input):
-            user_input = {CONF_LINEAR: user_input}
-            await self.validate_strategy_config(user_input)
-            return user_input
-
-        return await self.handle_form_step(
-            PowercalcFormStep(
-                step=Steps.LINEAR,
-                schema=self.create_schema_linear(self.source_entity_id),
-                next_step=Steps.POWER_ADVANCED,
-                validate_user_input=validate,
-            ),
-            user_input,
-        )
+        """Handle the flow for fixed sensor."""
+        return await self.handle_strategy_step(CalculationStrategy.LINEAR, user_input)
 
     async def async_step_multi_switch(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle the flow for multi switch strategy."""
-        errors = {}
-        if user_input is not None:
-            self.sensor_config.update({CONF_MULTI_SWITCH: user_input})
-            try:
-                await self.validate_strategy_config()
-            except SchemaFlowError as exc:
-                errors["base"] = str(exc)
-            if not errors:
-                return await self.async_step_power_advanced()
+        return await self.handle_strategy_step(CalculationStrategy.MULTI_SWITCH, user_input)
 
-        return self.async_show_form(
-            step_id=Steps.MULTI_SWITCH,
-            data_schema=self.create_schema_multi_switch(),
-            errors=errors,
-            last_step=False,
-        )
+    async def async_step_playbook(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle the flow for playbook sensor."""
+
+        def _validate(user_input):
+            if user_input.get(CONF_PLAYBOOKS) is None or len(user_input.get(CONF_PLAYBOOKS)) == 0:
+                raise SchemaFlowError("playbook_mandatory")
+
+        return await self.handle_strategy_step(CalculationStrategy.PLAYBOOK, user_input, _validate)
+
+    async def async_step_wled(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle the flow for WLED sensor."""
+        return await self.handle_strategy_step(CalculationStrategy.WLED, user_input)
 
     async def async_step_utility_meter_options(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle the flow for utility meter options."""
-        if user_input is not None:
-            self.sensor_config.update(user_input or {})
-            return self.persist_config_entry()
-
-        return self.async_show_form(
-            step_id=Steps.UTILITY_METER_OPTIONS,
-            data_schema=self.fill_schema_defaults(
-                SCHEMA_UTILITY_METER_OPTIONS,
-                self.get_global_powercalc_config(),
+        return await self.handle_form_step(
+            PowercalcFormStep(
+                step=Step.UTILITY_METER_OPTIONS,
+                schema=SCHEMA_UTILITY_METER_OPTIONS,
             ),
-            errors={},
+            user_input,
         )
 
     async def async_step_global_configuration_energy(self, user_input: dict[str, Any] | None = None) -> FlowResult:
@@ -1159,7 +1168,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
             return await self.async_step_global_configuration_utility_meter()
 
         return self.async_show_form(
-            step_id=Steps.GLOBAL_CONFIGURATION_ENERGY,
+            step_id=Step.GLOBAL_CONFIGURATION_ENERGY,
             data_schema=self.fill_schema_defaults(
                 SCHEMA_GLOBAL_CONFIGURATION_ENERGY_SENSOR,
                 self.global_config,
@@ -1167,7 +1176,8 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
             errors={},
         )
 
-    async def async_step_global_configuration_utility_meter(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_global_configuration_utility_meter(self,
+                                                            user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the global configuration step."""
 
         if user_input is not None:
@@ -1182,7 +1192,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
             )
 
         return self.async_show_form(
-            step_id=Steps.GLOBAL_CONFIGURATION_UTILITY_METER,
+            step_id=Step.GLOBAL_CONFIGURATION_UTILITY_METER,
             data_schema=self.fill_schema_defaults(
                 SCHEMA_UTILITY_METER_OPTIONS,
                 self.global_config,
@@ -1200,7 +1210,6 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
         """Initialize options flow."""
         self.selected_sensor_type: str | None = None
         self.discovered_profiles: dict[str, PowerProfile] = {}
-        self.name: str | None = None
         super().__init__()
 
     @staticmethod
@@ -1266,11 +1275,11 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
             ENTRY_GLOBAL_CONFIG_UNIQUE_ID,
         )
         if not global_config_entry:
-            menu = {Steps.GLOBAL_CONFIGURATION: "Global configuration", **menu}
+            menu = {Step.GLOBAL_CONFIGURATION: "Global configuration", **menu}
 
         await self.async_set_unique_id(str(uuid.uuid4()))
 
-        return self.async_show_menu(step_id=Steps.USER, menu_options=menu)
+        return self.async_show_menu(step_id=Step.USER, menu_options=menu)
 
     async def async_step_menu_library(
         self,
@@ -1293,7 +1302,7 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
             return await self.async_step_global_configuration_energy()
 
         return self.async_show_form(
-            step_id=Steps.GLOBAL_CONFIGURATION,
+            step_id=Step.GLOBAL_CONFIGURATION,
             data_schema=self.fill_schema_defaults(
                 SCHEMA_GLOBAL_CONFIGURATION,
                 self.global_config,
@@ -1313,7 +1322,8 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_MODE) or CalculationStrategy.LUT,
             )
             entity_id = user_input.get(CONF_ENTITY_ID)
-            if selected_strategy is not CalculationStrategy.PLAYBOOK and user_input.get(CONF_NAME) is None and entity_id is None:
+            if selected_strategy is not CalculationStrategy.PLAYBOOK and user_input.get(
+                CONF_NAME) is None and entity_id is None:
                 errors[CONF_ENTITY_ID] = "entity_mandatory"
 
             if not errors:
@@ -1330,7 +1340,7 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
                 return await self.forward_to_strategy_step(selected_strategy)
 
         return self.async_show_form(
-            step_id=Steps.VIRTUAL_POWER,
+            step_id=Step.VIRTUAL_POWER,
             data_schema=self.create_schema_virtual_power(),
             errors=errors,
             last_step=False,
@@ -1352,22 +1362,27 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle the flow for daily energy sensor."""
-        errors = self.validate_daily_energy_input(user_input)
+        self.selected_sensor_type = SensorType.DAILY_ENERGY
 
-        schema = self.create_daily_energy_schema()
-        if user_input is not None and not errors:
-            self.selected_sensor_type = SensorType.DAILY_ENERGY
-            self.name = user_input.get(CONF_NAME)
+        schema = SCHEMA_DAILY_ENERGY.extend(  # type: ignore
+            {
+                vol.Optional(CONF_GROUP): self.create_group_selector(),
+            },
+        )
 
-            self.sensor_config.update(self.build_daily_energy_config(user_input, schema))
-            if self.sensor_config.get(CONF_CREATE_UTILITY_METERS):
-                return await self.async_step_utility_meter_options()
-            return self.persist_config_entry()
+        async def _validate(user_input):
+            if CONF_VALUE not in user_input and CONF_VALUE_TEMPLATE not in user_input:
+                raise SchemaFlowError("daily_energy_mandatory")
+            return self.build_daily_energy_config(user_input, schema)
 
-        return self.async_show_form(
-            step_id=Steps.DAILY_ENERGY,
-            data_schema=schema,
-            errors=errors,
+        return await self.handle_form_step(
+            PowercalcFormStep(
+                step=Step.DAILY_ENERGY,
+                schema=schema,
+                validate_user_input=_validate,
+                continue_utility_meter_options_step=True
+            ),
+            user_input
         )
 
     async def async_step_menu_group(
@@ -1375,127 +1390,55 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle the group choice step."""
-        return self.async_show_menu(step_id=Steps.MENU_GROUP, menu_options=MENU_GROUP)
+        return self.async_show_menu(step_id=Step.MENU_GROUP, menu_options=MENU_GROUP)
 
-    async def async_step_group(
+    async def handle_group_step(
         self,
+        group_type: GroupType,
         user_input: dict[str, Any] | None = None,
+        schema: vol.Schema | None = None,
     ) -> FlowResult:
-        """Handle the flow for group sensor."""
-        errors = self.validate_group_input(user_input)
-        if user_input is not None and not errors:
-            self.name = user_input.get(CONF_NAME)
-            self.sensor_config.update(user_input)
-            return await self.async_handle_group_creation()
+        """Generic step to handle different group types."""
 
-        group_schema = SCHEMA_GROUP.extend(
-            self.create_schema_group().schema,
-        )
-        return self.async_show_form(
-            step_id=Steps.GROUP,
-            data_schema=self.fill_schema_defaults(
-                group_schema,
-                self.get_global_powercalc_config(),
-            ),
-            errors=errors,
-        )
+        async def _validate(user_input: dict[str, Any]) -> dict[str, str]:
+            if group_type == GroupType.CUSTOM:
+                self.validate_group_input(user_input)
 
-    async def async_step_domain_group(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Handle the flow for domain based group sensor."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
             self.name = user_input.get(CONF_NAME)
             self.sensor_config.update(user_input)
             self.sensor_config.update(
                 {
-                    CONF_GROUP_TYPE: GroupType.DOMAIN,
+                    CONF_GROUP_TYPE: group_type,
                 },
             )
-            return await self.async_handle_group_creation()
+            return user_input
 
-        return self.async_show_form(
-            step_id=Steps.DOMAIN_GROUP,
-            data_schema=self.fill_schema_defaults(
-                SCHEMA_GROUP_DOMAIN,
-                self.get_global_powercalc_config(),
-            ),
-            errors=errors,
-        )
-
-    async def async_step_subtract_group(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Handle the flow for subtract group sensor."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            self.name = user_input.get(CONF_NAME)
-            self.sensor_config.update(user_input)
-            self.sensor_config.update(
-                {
-                    CONF_GROUP_TYPE: GroupType.SUBTRACT,
-                },
-            )
-            return await self.async_handle_group_creation()
-
-        return self.async_show_form(
-            step_id=Steps.SUBTRACT_GROUP,
-            data_schema=self.fill_schema_defaults(
-                SCHEMA_GROUP_SUBTRACT,
-                self.get_global_powercalc_config(),
-            ),
-            errors=errors,
-        )
-
-    async def async_handle_group_creation(self) -> FlowResult:
-        """Handle the group creation."""
         self.selected_sensor_type = SensorType.GROUP
+        return await self.handle_form_step(
+            PowercalcFormStep(
+                step=GROUP_STEP_MAPPING[group_type],
+                schema=schema or GROUP_SCHEMAS[group_type],
+                validate_user_input=_validate,
+                continue_utility_meter_options_step=True
+            ),
+            user_input
+        )
 
-        if self.sensor_config.get(CONF_CREATE_UTILITY_METERS):
-            return await self.async_step_utility_meter_options()
-        return self.persist_config_entry()
-
-    async def async_step_playbook(
+    async def async_step_group_custom(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
-        """Handle the flow for playbook sensor."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            self.sensor_config.update({CONF_PLAYBOOK: user_input})
+        """Handle the flow for custom group sensor."""
+        schema = SCHEMA_GROUP.extend(self.create_schema_group_custom().schema)
+        return await self.handle_group_step(GroupType.CUSTOM, user_input, schema)
 
-            playbooks = user_input.get(CONF_PLAYBOOKS)
-            if playbooks is None or len(playbooks) == 0:
-                errors["base"] = "playbook_mandatory"
+    async def async_step_group_domain(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Handle the flow for domain based group sensor."""
+        return await self.handle_group_step(GroupType.DOMAIN, user_input)
 
-            if not errors:
-                return await self.async_step_power_advanced()
-
-        return self.async_show_form(
-            step_id=Steps.PLAYBOOK,
-            data_schema=SCHEMA_POWER_PLAYBOOK,
-            errors=errors,
-            last_step=False,
-        )
-
-    async def async_step_wled(
-        self,
-        user_input: dict[str, Any] | None = None,
-    ) -> ConfigFlowResult:
-        """Handle the flow for WLED sensor."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            self.sensor_config.update({CONF_WLED: user_input})
-            try:
-                await self.validate_strategy_config()
-            except SchemaFlowError as exc:
-                errors["base"] = str(exc)
-            if not errors:
-                return cast(ConfigFlowResult, await self.async_step_power_advanced())
-
-        return self.async_show_form(
-            step_id=Steps.WLED,
-            data_schema=SCHEMA_POWER_WLED,
-            errors=errors,
-            last_step=False,
-        )
+    async def async_step_group_subtract(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Handle the flow for subtract group sensor."""
+        return await self.handle_group_step(GroupType.SUBTRACT, user_input)
 
     async def async_step_library_multi_profile(
         self,
@@ -1536,7 +1479,7 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
         manufacturer = str(self.sensor_config.get(CONF_MANUFACTURER))
         model = str(self.sensor_config.get(CONF_MODEL))
         return self.async_show_form(
-            step_id=Steps.LIBRARY_MULTI_PROFILE,
+            step_id=Step.LIBRARY_MULTI_PROFILE,
             data_schema=schema,
             description_placeholders={
                 "library_link": f"{LIBRARY_URL}/?manufacturer={manufacturer}",
@@ -1572,7 +1515,7 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
             if remarks:
                 remarks = "\n\n" + remarks
             return self.async_show_form(
-                step_id=Steps.LIBRARY,
+                step_id=Step.LIBRARY,
                 description_placeholders={
                     "remarks": remarks,  # type: ignore
                     "manufacturer": self.selected_profile.manufacturer,
@@ -1592,18 +1535,13 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
         """Handle the flow for real power sensor"""
 
         self.selected_sensor_type = SensorType.REAL_POWER
-        if user_input is not None:
-            self.name = user_input.get(CONF_NAME)
-            self.sensor_config.update(user_input)
-            if self.sensor_config.get(CONF_CREATE_UTILITY_METERS):
-                return await self.async_step_utility_meter_options()
-            return self.persist_config_entry()
-
-        return self.async_show_form(
-            step_id=Steps.REAL_POWER,
-            data_schema=SCHEMA_REAL_POWER,
-            errors={},
-            last_step=False,
+        return await self.handle_form_step(
+            PowercalcFormStep(
+                step=Step.REAL_POWER,
+                schema=SCHEMA_REAL_POWER,
+                continue_utility_meter_options_step=True,
+            ),
+            user_input,
         )
 
     @callback
@@ -1636,7 +1574,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
         """Handle options flow."""
         if self.config_entry.unique_id == ENTRY_GLOBAL_CONFIG_UNIQUE_ID:
             self.global_config = self.get_global_powercalc_config()
-            return self.async_show_menu(step_id=Steps.INIT, menu_options=self.build_global_config_menu())
+            return self.async_show_menu(step_id=Step.INIT, menu_options=self.build_global_config_menu())
 
         self.sensor_config = dict(self.config_entry.data)
         if self.source_entity_id:
@@ -1648,7 +1586,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             if result:
                 return result
 
-        return self.async_show_menu(step_id=Steps.INIT, menu_options=self.build_menu())
+        return self.async_show_menu(step_id=Step.INIT, menu_options=self.build_menu())
 
     async def initialize_library_profile(self) -> FlowResult | None:
         """Initialize the library profile, when manufacturer and model are set."""
@@ -1670,42 +1608,42 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             return self.async_abort(reason="model_not_supported")
         return None
 
-    def build_global_config_menu(self) -> dict[Steps, str]:
+    def build_global_config_menu(self) -> dict[Step, str]:
         """Build menu for global configuration"""
         menu = {
-            Steps.GLOBAL_CONFIGURATION: "Basic options",
+            Step.GLOBAL_CONFIGURATION: "Basic options",
         }
         if self.global_config.get(CONF_CREATE_ENERGY_SENSORS):
-            menu[Steps.GLOBAL_CONFIGURATION_ENERGY] = "Energy options"
+            menu[Step.GLOBAL_CONFIGURATION_ENERGY] = "Energy options"
         if self.global_config.get(CONF_CREATE_UTILITY_METERS):
-            menu[Steps.GLOBAL_CONFIGURATION_UTILITY_METER] = "Utility meter options"
+            menu[Step.GLOBAL_CONFIGURATION_UTILITY_METER] = "Utility meter options"
         return menu
 
-    def build_menu(self) -> dict[Steps, str]:
+    def build_menu(self) -> dict[Step, str]:
         """Build the options menu."""
         menu = {
-            Steps.BASIC_OPTIONS: "Basic options",
+            Step.BASIC_OPTIONS: "Basic options",
         }
         if self.sensor_type == SensorType.VIRTUAL_POWER:
             if self.strategy and self.strategy != CalculationStrategy.LUT:
                 strategy_step = STRATEGY_STEP_MAPPING[self.strategy]
                 menu[strategy_step] = MENU_OPTIONS[strategy_step]
             if self.selected_profile:
-                menu[Steps.LIBRARY_OPTIONS] = "Library options"
-            menu[Steps.ADVANCED_OPTIONS] = "Advanced options"
+                menu[Step.LIBRARY_OPTIONS] = "Library options"
+            menu[Step.ADVANCED_OPTIONS] = "Advanced options"
         if self.sensor_type == SensorType.DAILY_ENERGY:
-            menu[Steps.DAILY_ENERGY] = "Daily energy options"
+            menu[Step.DAILY_ENERGY] = "Daily energy options"
         if self.sensor_type == SensorType.REAL_POWER:
-            menu[Steps.REAL_POWER] = "Real power options"
+            menu[Step.REAL_POWER] = "Real power options"
         if self.sensor_type == SensorType.GROUP:
             group_type = self.sensor_config.get(CONF_GROUP_TYPE, GroupType.CUSTOM)
             if group_type == GroupType.CUSTOM:
-                menu[Steps.GROUP] = "Group options"
+                menu[Step.GROUP_CUSTOM] = "Group options"
             if group_type == GroupType.SUBTRACT:
-                menu[Steps.SUBTRACT_GROUP] = "Group options"
+                menu[Step.GROUP_SUBTRACT] = "Group options"
 
         if self.sensor_config.get(CONF_CREATE_UTILITY_METERS):
-            menu[Steps.UTILITY_METER_OPTIONS] = "Utility meter options"
+            menu[Step.UTILITY_METER_OPTIONS] = "Utility meter options"
 
         return menu
 
@@ -1717,7 +1655,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             return self.persist_config_entry()
 
         return self.async_show_form(
-            step_id=Steps.GLOBAL_CONFIGURATION,
+            step_id=Step.GLOBAL_CONFIGURATION,
             data_schema=self.fill_schema_defaults(
                 SCHEMA_GLOBAL_CONFIGURATION,
                 self.global_config,
@@ -1731,7 +1669,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             self.build_basic_options_schema(),
             self.sensor_config,
         )
-        return await self.async_handle_options_step(user_input, schema, Steps.BASIC_OPTIONS)
+        return await self.async_handle_options_step(user_input, schema, Step.BASIC_OPTIONS)
 
     async def async_step_advanced_options(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the basic options flow."""
@@ -1739,7 +1677,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             SCHEMA_POWER_ADVANCED,
             self.sensor_config,
         )
-        return await self.async_handle_options_step(user_input, schema, Steps.ADVANCED_OPTIONS)
+        return await self.async_handle_options_step(user_input, schema, Step.ADVANCED_OPTIONS)
 
     async def async_step_utility_meter_options(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the basic options flow."""
@@ -1747,7 +1685,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             SCHEMA_UTILITY_METER_OPTIONS,
             self.sensor_config,
         )
-        return await self.async_handle_options_step(user_input, schema, Steps.UTILITY_METER_OPTIONS)
+        return await self.async_handle_options_step(user_input, schema, Step.UTILITY_METER_OPTIONS)
 
     async def async_step_daily_energy(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the daily energy options flow."""
@@ -1755,7 +1693,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             SCHEMA_DAILY_ENERGY_OPTIONS,
             self.sensor_config[CONF_DAILY_FIXED_ENERGY],
         )
-        return await self.async_handle_options_step(user_input, schema, Steps.DAILY_ENERGY)
+        return await self.async_handle_options_step(user_input, schema, Step.DAILY_ENERGY)
 
     async def async_step_real_power(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the real power options flow."""
@@ -1763,23 +1701,23 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             SCHEMA_REAL_POWER_OPTIONS,
             self.sensor_config,
         )
-        return await self.async_handle_options_step(user_input, schema, Steps.REAL_POWER)
+        return await self.async_handle_options_step(user_input, schema, Step.REAL_POWER)
 
-    async def async_step_group(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_group_custom(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the group options flow."""
         schema = self.fill_schema_defaults(
-            self.create_schema_group(self.config_entry, True),
+            self.create_schema_group_custom(self.config_entry, True),
             self.sensor_config,
         )
-        return await self.async_handle_options_step(user_input, schema, Steps.GROUP)
+        return await self.async_handle_options_step(user_input, schema, Step.GROUP_CUSTOM)
 
-    async def async_step_subtract_group(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_group_subtract(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the group options flow."""
         schema = self.fill_schema_defaults(
             SCHEMA_GROUP_SUBTRACT_OPTIONS,
             self.sensor_config,
         )
-        return await self.async_handle_options_step(user_input, schema, Steps.SUBTRACT_GROUP)
+        return await self.async_handle_options_step(user_input, schema, Step.GROUP_SUBTRACT)
 
     async def async_step_fixed(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the basic options flow."""
@@ -1808,7 +1746,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             return await self.async_step_manufacturer()
 
         return self.async_show_form(
-            step_id=Steps.LIBRARY_OPTIONS,
+            step_id=Step.LIBRARY_OPTIONS,
             description_placeholders={
                 "manufacturer": self.selected_profile.manufacturer,  # type: ignore
                 "model": self.selected_profile.model,  # type: ignore
@@ -1821,7 +1759,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
         if not self.strategy:
             return self.async_abort(reason="no_strategy_selected")  # pragma: no cover
 
-        step = STRATEGY_STEP_MAPPING.get(self.strategy, Steps.FIXED)
+        step = STRATEGY_STEP_MAPPING.get(self.strategy, Step.FIXED)
 
         schema = self.create_strategy_schema(self.strategy, self.source_entity_id)
         if self.selected_profile and self.selected_profile.device_type == DeviceType.SMART_SWITCH:
@@ -1835,7 +1773,8 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
         schema = self.fill_schema_defaults(schema, merged_options)
         return await self.async_handle_options_step(user_input, schema, step)
 
-    async def async_handle_options_step(self, user_input: dict[str, Any] | None, schema: vol.Schema, step: Steps) -> FlowResult:
+    async def async_handle_options_step(self, user_input: dict[str, Any] | None, schema: vol.Schema,
+                                        step: Step) -> FlowResult:
         """
         Generic handler for all the option steps.
         processes user input against the select schema.
@@ -1850,7 +1789,8 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
 
     def persist_config_entry(self) -> FlowResult:
         """Persist changed options on the config entry."""
-        data = (self.config_entry.unique_id == ENTRY_GLOBAL_CONFIG_UNIQUE_ID and self.global_config) or self.sensor_config
+        data = (
+                   self.config_entry.unique_id == ENTRY_GLOBAL_CONFIG_UNIQUE_ID and self.global_config) or self.sensor_config
 
         self.hass.config_entries.async_update_entry(
             self.config_entry,
@@ -1865,7 +1805,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
         """
 
         assert self.cur_step is not None
-        current_step: Steps = Steps(str(self.cur_step["step_id"]))
+        current_step: Step = Step(str(self.cur_step["step_id"]))
         is_strategy_step = current_step in STRATEGY_STEP_MAPPING.values()
         if self.strategy and is_strategy_step:
             if self.selected_profile and self.selected_profile.device_type == DeviceType.SMART_SWITCH:
@@ -1883,12 +1823,13 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
 
             try:
                 await self.validate_strategy_config()
+                return None
             except SchemaFlowError as exc:
                 return {"base": str(exc)}
 
         self._process_user_input(user_input, schema)
 
-        if self.sensor_type == SensorType.DAILY_ENERGY and current_step == Steps.DAILY_ENERGY:
+        if self.sensor_type == SensorType.DAILY_ENERGY and current_step == Step.DAILY_ENERGY:
             self.sensor_config.update(self.build_daily_energy_config(user_input, SCHEMA_DAILY_ENERGY_OPTIONS))
 
         if CONF_ENTITY_ID in user_input:
@@ -1915,10 +1856,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
 
     def build_basic_options_schema(self) -> vol.Schema:
         """Build the basic options schema. depending on the selected sensor type."""
-        if self.sensor_type == SensorType.REAL_POWER:
-            return SCHEMA_UTILITY_METER_TOGGLE
-
-        if self.sensor_type == SensorType.DAILY_ENERGY:
+        if self.sensor_type in [SensorType.REAL_POWER, SensorType.DAILY_ENERGY]:
             return SCHEMA_UTILITY_METER_TOGGLE
 
         if self.sensor_type == SensorType.GROUP:

--- a/custom_components/powercalc/config_flow.py
+++ b/custom_components/powercalc/config_flow.py
@@ -9,10 +9,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import StrEnum
-from typing import Any, Callable, Coroutine, cast
+from typing import Any, cast
 
 import voluptuous as vol
-from homeassistant.components.random.config_flow import validate_user_input
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.utility_meter import CONF_METER_TYPE, METER_TYPES
 from homeassistant.config_entries import ConfigEntry, ConfigEntryBaseFlow, ConfigFlow, ConfigFlowResult, OptionsFlow
@@ -32,7 +31,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import SchemaCommonFlowHandler, SchemaFlowError, SchemaFlowFormStep
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -512,6 +510,7 @@ SCHEMA_GLOBAL_CONFIGURATION_ENERGY_SENSOR = vol.Schema(
     },
 )
 
+
 @dataclass(slots=True)
 class PowercalcFormStep(SchemaFlowFormStep):
     step: Steps = None
@@ -520,7 +519,6 @@ class PowercalcFormStep(SchemaFlowFormStep):
 
 
 class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
-
     def __init__(self) -> None:
         """Initialize options flow."""
         self.sensor_config: ConfigType = {}
@@ -552,8 +550,8 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
                 translation = "unknown"
             _LOGGER.error(str(error))
             raise SchemaFlowError(translation)
-            #return {"base": translation}
-        #return {}
+            # return {"base": translation}
+        # return {}
 
     @staticmethod
     def validate_group_input(user_input: dict[str, Any] | None = None) -> dict:
@@ -957,11 +955,10 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
                 step=Steps.MODEL,
                 schema=await self.create_schema_model(),
                 next_step="post_library",
-                validate_user_input=_validate
+                validate_user_input=_validate,
             ),
             user_input,
         )
-
 
     async def async_step_post_library(
         self,
@@ -1000,7 +997,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
 
         async def _validate(_, input: dict[str, Any]) -> dict[str, str]:
             input[CONF_MODEL] = f"{self.sensor_config.get(CONF_MODEL)}/{input.get(CONF_SUB_PROFILE)}"
-            del(input[CONF_SUB_PROFILE])
+            del input[CONF_SUB_PROFILE]
             return user_input
 
         return await self.handle_form_step(
@@ -1015,7 +1012,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
                 next_step=Steps.POWER_ADVANCED,
                 validate_user_input=_validate,
             ),
-            user_input
+            user_input,
         )
 
     async def async_step_power_advanced(
@@ -1086,7 +1083,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
                 next_step=Steps.POWER_ADVANCED,
                 validate_user_input=validate,
             ),
-            user_input
+            user_input,
         )
 
     async def async_step_linear(
@@ -1107,7 +1104,7 @@ class PowercalcCommonFlow(ABC, ConfigEntryBaseFlow, SchemaCommonFlowHandler):
                 next_step=Steps.POWER_ADVANCED,
                 validate_user_input=validate,
             ),
-            user_input
+            user_input,
         )
 
     async def async_step_multi_switch(

--- a/custom_components/powercalc/config_flow.py
+++ b/custom_components/powercalc/config_flow.py
@@ -162,27 +162,27 @@ class Step(StrEnum):
     GLOBAL_CONFIGURATION_UTILITY_METER = "global_configuration_utility_meter"
 
 
-MENU_SENSOR_TYPE = {
-    Step.VIRTUAL_POWER: "Virtual power (manual)",
-    Step.MENU_LIBRARY: "Virtual power (library)",
-    Step.MENU_GROUP: "Group",
-    Step.DAILY_ENERGY: "Daily energy",
-    Step.REAL_POWER: "Energy from real power sensor",
-}
+MENU_SENSOR_TYPE = [
+    Step.VIRTUAL_POWER,
+    Step.MENU_LIBRARY,
+    Step.MENU_GROUP,
+    Step.DAILY_ENERGY,
+    Step.REAL_POWER,
+]
 
-MENU_GROUP = {
-    Step.GROUP_CUSTOM: "Standard group",
-    Step.GROUP_DOMAIN: "Domain based group",
-    Step.GROUP_SUBTRACT: "Subtract group",
-}
+MENU_GROUP = [
+    Step.GROUP_CUSTOM,
+    Step.GROUP_DOMAIN,
+    Step.GROUP_SUBTRACT,
+]
 
-MENU_OPTIONS = {
-    Step.FIXED: "Fixed options",
-    Step.LINEAR: "Linear options",
-    Step.MULTI_SWITCH: "Multi switch options",
-    Step.PLAYBOOK: "Playbook options",
-    Step.WLED: "WLED options",
-}
+MENU_OPTIONS = [
+    Step.FIXED,
+    Step.LINEAR,
+    Step.MULTI_SWITCH,
+    Step.PLAYBOOK,
+    Step.WLED,
+]
 
 LIBRARY_URL = "https://library.powercalc.nl"
 
@@ -1252,14 +1252,13 @@ class PowercalcConfigFlow(PowercalcCommonFlow, ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
 
-        menu = MENU_SENSOR_TYPE
-
         global_config_entry = self.hass.config_entries.async_entry_for_domain_unique_id(
             DOMAIN,
             ENTRY_GLOBAL_CONFIG_UNIQUE_ID,
         )
+        menu = MENU_SENSOR_TYPE.copy()
         if not global_config_entry:
-            menu = {Step.GLOBAL_CONFIGURATION: "Global configuration", **menu}
+            menu.insert(0, Step.GLOBAL_CONFIGURATION)
 
         await self.async_set_unique_id(str(uuid.uuid4()))
 
@@ -1602,31 +1601,29 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
             menu[Step.GLOBAL_CONFIGURATION_UTILITY_METER] = "Utility meter options"
         return menu
 
-    def build_menu(self) -> dict[Step, str]:
+    def build_menu(self) -> list[Step]:
         """Build the options menu."""
-        menu = {
-            Step.BASIC_OPTIONS: "Basic options",
-        }
+        menu = [Step.BASIC_OPTIONS]
         if self.sensor_type == SensorType.VIRTUAL_POWER:
             if self.strategy and self.strategy != CalculationStrategy.LUT:
                 strategy_step = STRATEGY_STEP_MAPPING[self.strategy]
-                menu[strategy_step] = MENU_OPTIONS[strategy_step]
+                menu.append(strategy_step)
             if self.selected_profile:
-                menu[Step.LIBRARY_OPTIONS] = "Library options"
-            menu[Step.ADVANCED_OPTIONS] = "Advanced options"
+                menu.append(Step.LIBRARY_OPTIONS)
+            menu.append(Step.ADVANCED_OPTIONS)
         if self.sensor_type == SensorType.DAILY_ENERGY:
-            menu[Step.DAILY_ENERGY] = "Daily energy options"
+            menu.append(Step.DAILY_ENERGY)
         if self.sensor_type == SensorType.REAL_POWER:
-            menu[Step.REAL_POWER] = "Real power options"
+            menu.append(Step.REAL_POWER)
         if self.sensor_type == SensorType.GROUP:
             group_type = self.sensor_config.get(CONF_GROUP_TYPE, GroupType.CUSTOM)
             if group_type == GroupType.CUSTOM:
-                menu[Step.GROUP_CUSTOM] = "Group options"
+                menu.append(Step.GROUP_CUSTOM)
             if group_type == GroupType.SUBTRACT:
-                menu[Step.GROUP_SUBTRACT] = "Group options"
+                menu.append(Step.GROUP_SUBTRACT)
 
         if self.sensor_config.get(CONF_CREATE_UTILITY_METERS):
-            menu[Step.UTILITY_METER_OPTIONS] = "Utility meter options"
+            menu.append(Step.UTILITY_METER_OPTIONS)
 
         return menu
 

--- a/custom_components/powercalc/translations/cz.json
+++ b/custom_components/powercalc/translations/cz.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Create utility meters",
-          "group_custom": "Add to group",
+          "group": "Add to group",
           "name": "Název",
           "on_time": "On time",
           "start_time": "Start time",
@@ -35,7 +35,7 @@
           "value_template": "Šablona hodnoty"
         },
         "data_description": {
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "on_time": "When left empty defaults to 1 day. always on",
           "update_frequency": "time in seconds between state updates of the sensor"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standard group",
+          "group": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Denní energie",
-          "group_custom": "Skupina",
+          "group": "Skupina",
           "menu_library": "Virtual power (library)",
           "real_power": "Energy from real power sensor",
           "virtual_power": "Virtual power (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
           "entity_id": "Source entity",
-          "group_custom": "Přidat do skupiny",
+          "group": "Přidat do skupiny",
           "mode": "Výpočetní strategie",
           "name": "Název",
           "standby_power": "Standby power"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Whether powercalc needs to create a kWh sensor",
           "create_utility_meters": "Let powercalc create utility meters, which cycle daily, hourly etc.",
           "entity_id": "entity the virtual power is based on, the power sensor will listen to state changes of this entity to be updated",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Leaving blank will take the name from the source entity",
           "standby_power": "Define the amount of power the device is consuming when in an OFF state"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/cz.json
+++ b/custom_components/powercalc/translations/cz.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Create utility meters",
-          "group": "Add to group",
+          "group_custom": "Add to group",
           "name": "Název",
           "on_time": "On time",
           "start_time": "Start time",
@@ -35,13 +35,13 @@
           "value_template": "Šablona hodnoty"
         },
         "data_description": {
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "on_time": "When left empty defaults to 1 day. always on",
           "update_frequency": "time in seconds between state updates of the sensor"
         },
         "title": "Create a daily fixed sensor"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Name",
           "create_energy_sensor": "Create energy sensor",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Oblast",
           "create_energy_sensor": "Create energy sensor",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
-          "domain_group": "Domain based group"
+          "group_custom": "Standard group",
+          "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "Currently specific settings can only be configured globally",
         "title": "Create an energy sensor for an existing power sensor"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Denní energie",
-          "group": "Skupina",
+          "group_custom": "Skupina",
           "menu_library": "Virtual power (library)",
           "real_power": "Energy from real power sensor",
           "virtual_power": "Virtual power (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
           "entity_id": "Source entity",
-          "group": "Přidat do skupiny",
+          "group_custom": "Přidat do skupiny",
           "mode": "Výpočetní strategie",
           "name": "Název",
           "standby_power": "Standby power"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Whether powercalc needs to create a kWh sensor",
           "create_utility_meters": "Let powercalc create utility meters, which cycle daily, hourly etc.",
           "entity_id": "entity the virtual power is based on, the power sensor will listen to state changes of this entity to be updated",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Leaving blank will take the name from the source entity",
           "standby_power": "Define the amount of power the device is consuming when in an OFF state"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Oblast",
@@ -507,12 +507,12 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/cz.json
+++ b/custom_components/powercalc/translations/cz.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
+          "group_custom": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",

--- a/custom_components/powercalc/translations/de.json
+++ b/custom_components/powercalc/translations/de.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Utilitymeter erstellen",
-          "group": "Zur Gruppe hinzufügen",
+          "group_custom": "Zur Gruppe hinzufügen",
           "name": "Name",
           "on_time": "Dauer",
           "start_time": "Startzeit",
@@ -35,13 +35,13 @@
           "value_template": "Wert-Template"
         },
         "data_description": {
-          "group": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
+          "group_custom": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
           "on_time": "Wenn leer, ist der Standardwert 1 Tag, d.h. immer an",
           "update_frequency": "Zeit in Sekunden zwischen den Zustandsaktualisierungen des Sensors"
         },
         "title": "Einen daily fixed-Sensor erstellen"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Name",
           "create_energy_sensor": "Energiesensor erstellen",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Bereich",
           "create_energy_sensor": "Energiesensor erstellen",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standardgruppe",
-          "domain_group": "Domänenbasierte Gruppe"
+          "group_custom": "Standardgruppe",
+          "group_domain": "Domänenbasierte Gruppe"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "Derzeit können bestimmte Einstellungen nur global konfiguriert werden",
         "title": "Erstellen eines Energiesensors für einen vorhandenen Leistungssensor"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Energiesensor erstellen",
           "create_utility_meters": "Verbrauchszähler erstellen",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Tägliche Leistung/Energie",
-          "group": "Gruppe",
+          "group_custom": "Gruppe",
           "menu_library": "Virtuelle Leistung (Bibliothek)",
           "real_power": "Energie des Quell-Energiesensors",
           "virtual_power": "Virtuelle Leistung (manuell)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Energiesensor erstellen",
           "create_utility_meters": "Utilitymeter erstellen",
           "entity_id": "Quell-Entität",
-          "group": "Zur Gruppe hinzufügen",
+          "group_custom": "Zur Gruppe hinzufügen",
           "mode": "Berechnungsstrategie",
           "name": "Name",
           "standby_power": "Standby-Leistung"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Ob powercalc einen kWh-Sensor erstellen soll",
           "create_utility_meters": "Powercalc soll utility-Meter erstellen, die täglich, stündlich usw. zyklisch sind",
           "entity_id": "Entität, auf der die virtuelle Leistung basiert; der Leistungssensore wird auf Zustandsänderungen dieser Entität reagieren, um aktualisiert zu werden",
-          "group": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
+          "group_custom": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
           "name": "Leer lassen wird den Namen von der Quell-Entität übernehmen",
           "standby_power": "Definieren Sie die Leistung, die das Gerät im ausgeschalteten Zustand verbraucht"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Bereich",
@@ -507,12 +507,12 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Gruppeneinstellungen",
+          "group_subtract": "Gruppeneinstellungen",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/de.json
+++ b/custom_components/powercalc/translations/de.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Utilitymeter erstellen",
-          "group_custom": "Zur Gruppe hinzufügen",
+          "group": "Zur Gruppe hinzufügen",
           "name": "Name",
           "on_time": "Dauer",
           "start_time": "Startzeit",
@@ -35,7 +35,7 @@
           "value_template": "Wert-Template"
         },
         "data_description": {
-          "group_custom": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
+          "group": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
           "on_time": "Wenn leer, ist der Standardwert 1 Tag, d.h. immer an",
           "update_frequency": "Zeit in Sekunden zwischen den Zustandsaktualisierungen des Sensors"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standardgruppe",
+          "group": "Standardgruppe",
           "group_domain": "Domänenbasierte Gruppe"
         },
         "title": "Choose the group type",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Tägliche Leistung/Energie",
-          "group_custom": "Gruppe",
+          "group": "Gruppe",
           "menu_library": "Virtuelle Leistung (Bibliothek)",
           "real_power": "Energie des Quell-Energiesensors",
           "virtual_power": "Virtuelle Leistung (manuell)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Energiesensor erstellen",
           "create_utility_meters": "Utilitymeter erstellen",
           "entity_id": "Quell-Entität",
-          "group_custom": "Zur Gruppe hinzufügen",
+          "group": "Zur Gruppe hinzufügen",
           "mode": "Berechnungsstrategie",
           "name": "Name",
           "standby_power": "Standby-Leistung"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Ob powercalc einen kWh-Sensor erstellen soll",
           "create_utility_meters": "Powercalc soll utility-Meter erstellen, die täglich, stündlich usw. zyklisch sind",
           "entity_id": "Entität, auf der die virtuelle Leistung basiert; der Leistungssensore wird auf Zustandsänderungen dieser Entität reagieren, um aktualisiert zu werden",
-          "group_custom": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
+          "group": "Geben Sie einen benutzerdefinierten Gruppennamen ein, um eine neue Gruppe zu erstellen",
           "name": "Leer lassen wird den Namen von der Quell-Entität übernehmen",
           "standby_power": "Definieren Sie die Leistung, die das Gerät im ausgeschalteten Zustand verbraucht"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/de.json
+++ b/custom_components/powercalc/translations/de.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standardgruppe",
+          "group_custom": "Standardgruppe",
           "group_domain": "Domänenbasierte Gruppe"
         },
         "title": "Choose the group type",

--- a/custom_components/powercalc/translations/en.json
+++ b/custom_components/powercalc/translations/en.json
@@ -184,8 +184,9 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
-          "group_domain": "Domain based group"
+          "group_custom": "Standard",
+          "group_domain": "Domain based",
+          "group_subtract": "Subtract"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensor. Choose standard group otherwise"

--- a/custom_components/powercalc/translations/en.json
+++ b/custom_components/powercalc/translations/en.json
@@ -296,6 +296,8 @@
         "menu_options": {
           "daily_energy": "Daily energy",
           "group": "group",
+          "global_configuration": "Global configuration",
+          "menu_group": "Group",
           "menu_library": "Virtual power (library)",
           "real_power": "Energy from real power sensor",
           "virtual_power": "Virtual power (manual)"

--- a/custom_components/powercalc/translations/en.json
+++ b/custom_components/powercalc/translations/en.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Create utility meters",
-          "group": "Add to group",
+          "group_custom": "Add to group",
           "name": "Name",
           "on_time": "On time",
           "start_time": "Start time",
@@ -35,13 +35,13 @@
           "value_template": "Value template"
         },
         "data_description": {
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "on_time": "When left empty defaults to 1 day. always on",
           "update_frequency": "time in seconds between state updates of the sensor"
         },
         "title": "Create a daily fixed sensor"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Name",
           "create_energy_sensor": "Create energy sensor",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Area",
           "create_energy_sensor": "Create energy sensor",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
-          "domain_group": "Domain based group"
+          "group_custom": "Standard group",
+          "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensor. Choose standard group otherwise"
@@ -255,7 +255,7 @@
         "description": "Currently specific settings can only be configured globally",
         "title": "Create an energy sensor for an existing power sensor"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Daily energy",
-          "group": "Group",
+          "group_custom": "group_custom",
           "menu_library": "Virtual power (library)",
           "real_power": "Energy from real power sensor",
           "virtual_power": "Virtual power (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
           "entity_id": "Source entity",
-          "group": "Add to group",
+          "group_custom": "Add to group",
           "mode": "Calculation strategy",
           "name": "Name",
           "standby_power": "Standby power"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Whether powercalc needs to create a kWh sensor",
           "create_utility_meters": "Let powercalc create utility meters, which cycle daily, hourly etc.",
           "entity_id": "entity the virtual power is based on, the power sensor will listen to state changes of this entity to be updated",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Leaving blank will take the name from the source entity",
           "standby_power": "Define the amount of power the device is consuming when in an OFF state"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Area",
@@ -507,12 +507,12 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/en.json
+++ b/custom_components/powercalc/translations/en.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Create utility meters",
-          "group_custom": "Add to group",
+          "group": "Add to group",
           "name": "Name",
           "on_time": "On time",
           "start_time": "Start time",
@@ -35,7 +35,7 @@
           "value_template": "Value template"
         },
         "data_description": {
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "on_time": "When left empty defaults to 1 day. always on",
           "update_frequency": "time in seconds between state updates of the sensor"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standard group",
+          "group": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Daily energy",
-          "group_custom": "group_custom",
+          "group": "group",
           "menu_library": "Virtual power (library)",
           "real_power": "Energy from real power sensor",
           "virtual_power": "Virtual power (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
           "entity_id": "Source entity",
-          "group_custom": "Add to group",
+          "group": "Add to group",
           "mode": "Calculation strategy",
           "name": "Name",
           "standby_power": "Standby power"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Whether powercalc needs to create a kWh sensor",
           "create_utility_meters": "Let powercalc create utility meters, which cycle daily, hourly etc.",
           "entity_id": "entity the virtual power is based on, the power sensor will listen to state changes of this entity to be updated",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Leaving blank will take the name from the source entity",
           "standby_power": "Define the amount of power the device is consuming when in an OFF state"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/fr.json
+++ b/custom_components/powercalc/translations/fr.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Créer des compteurs de services publics",
-          "group_custom": "Add to group",
+          "group": "Add to group",
           "name": "Nom",
           "on_time": "Temps de fonctionnement",
           "start_time": "Heure de début",
@@ -35,7 +35,7 @@
           "value_template": "Modèle de valeur"
         },
         "data_description": {
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "on_time": "Lorsqu'il est laissé vide, la valeur par défaut est 1 jour. Toujours allumé",
           "update_frequency": "Temps en secondes entre les mises à jour d'état du capteur"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standard group",
+          "group": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Énergie quotidienne",
-          "group_custom": "Groupe",
+          "group": "Groupe",
           "menu_library": "Puissance virtuelle (bibliothèque)",
           "real_power": "Énergie du capteur de puissance réelle",
           "virtual_power": "Alimentation virtuelle (manuel)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Créer un capteur d'énergie",
           "create_utility_meters": "Créer un compteur d'électricité",
           "entity_id": "Entité source",
-          "group_custom": "Ajouter au groupe",
+          "group": "Ajouter au groupe",
           "mode": "Stratégie de calcul",
           "name": "Nom",
           "standby_power": "Consommation en veille"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Si powercalc doit créer un capteur kWh",
           "create_utility_meters": "Laissez powercalc créer des compteurs de services publics, qui effectuent un cycle quotidien, horaire, etc.",
           "entity_id": "Entité sur laquelle la puissance virtuelle est basée, le capteur de puissance écoutera les changements d'état de cette entité à mettre à jour",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Laisser vide prendra le nom de l'entité source",
           "standby_power": "Définir la quantité d'énergie que l'appareil consomme lorsqu'il est à l'état OFF"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/fr.json
+++ b/custom_components/powercalc/translations/fr.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
+          "group_custom": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",

--- a/custom_components/powercalc/translations/fr.json
+++ b/custom_components/powercalc/translations/fr.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Créer des compteurs de services publics",
-          "group": "Add to group",
+          "group_custom": "Add to group",
           "name": "Nom",
           "on_time": "Temps de fonctionnement",
           "start_time": "Heure de début",
@@ -35,13 +35,13 @@
           "value_template": "Modèle de valeur"
         },
         "data_description": {
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "on_time": "Lorsqu'il est laissé vide, la valeur par défaut est 1 jour. Toujours allumé",
           "update_frequency": "Temps en secondes entre les mises à jour d'état du capteur"
         },
         "title": "Créer un capteur fixe quotidien"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Name",
           "create_energy_sensor": "Create energy sensor",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Zone",
           "create_energy_sensor": "Create energy sensor",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
-          "domain_group": "Domain based group"
+          "group_custom": "Standard group",
+          "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "Actuellement, les paramètres spécifiques ne peuvent être configurés que globalement",
         "title": "Créer un capteur d'énergie pour un capteur de puissance existant"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Énergie quotidienne",
-          "group": "Groupe",
+          "group_custom": "Groupe",
           "menu_library": "Puissance virtuelle (bibliothèque)",
           "real_power": "Énergie du capteur de puissance réelle",
           "virtual_power": "Alimentation virtuelle (manuel)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Créer un capteur d'énergie",
           "create_utility_meters": "Créer un compteur d'électricité",
           "entity_id": "Entité source",
-          "group": "Ajouter au groupe",
+          "group_custom": "Ajouter au groupe",
           "mode": "Stratégie de calcul",
           "name": "Nom",
           "standby_power": "Consommation en veille"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Si powercalc doit créer un capteur kWh",
           "create_utility_meters": "Laissez powercalc créer des compteurs de services publics, qui effectuent un cycle quotidien, horaire, etc.",
           "entity_id": "Entité sur laquelle la puissance virtuelle est basée, le capteur de puissance écoutera les changements d'état de cette entité à mettre à jour",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Laisser vide prendra le nom de l'entité source",
           "standby_power": "Définir la quantité d'énergie que l'appareil consomme lorsqu'il est à l'état OFF"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Zone",
@@ -507,12 +507,12 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/it.json
+++ b/custom_components/powercalc/translations/it.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Gruppo standard",
+          "group_custom": "Gruppo standard",
           "group_domain": "Domain based group"
         },
         "title": "Scegli il tipo di gruppo",

--- a/custom_components/powercalc/translations/it.json
+++ b/custom_components/powercalc/translations/it.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Crea contatori (utility meters)",
-          "group_custom": "Aggiungi al gruppo",
+          "group": "Aggiungi al gruppo",
           "name": "Nome",
           "on_time": "On time",
           "start_time": "Orario d'inizio",
@@ -35,7 +35,7 @@
           "value_template": "Value template"
         },
         "data_description": {
-          "group_custom": "Inserisci un nome personalizzato per creare un nuovo gruppo",
+          "group": "Inserisci un nome personalizzato per creare un nuovo gruppo",
           "on_time": "Quando lasciato vuoto predefinito a 1 giorno. Sempre acceso",
           "update_frequency": "tempo in secondi tra gli aggiornamenti di stato del sensore"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Gruppo standard",
+          "group": "Gruppo standard",
           "group_domain": "Domain based group"
         },
         "title": "Scegli il tipo di gruppo",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Energia giornaliera",
-          "group_custom": "Gruppo",
+          "group": "Gruppo",
           "menu_library": "Virtual power (library)",
           "real_power": "Energia da sensore di potenza reale",
           "virtual_power": "Potenza virtuale (manuale)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Crea sensore di energia",
           "create_utility_meters": "Crea contatori (utility meters)",
           "entity_id": "Source entity",
-          "group_custom": "Aggiungi al gruppo",
+          "group": "Aggiungi al gruppo",
           "mode": "Calculation strategy",
           "name": "Nome",
           "standby_power": "Potenza in standby"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Indica se powercalc deve creare un sensore kWh",
           "create_utility_meters": "Let powercalc create utility meters, which cycle daily, hourly etc.",
           "entity_id": "entity the virtual power is based on, the power sensor will listen to state changes of this entity to be updated",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Lasciando vuoto prenderà il nome dal dispositivo di origine",
           "standby_power": "Definire la quantità di potenza che il dispositivo sta consumando quando è in uno stato OFF"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Opzioni di base",
           "daily_energy": "Opzioni energetiche giornaliere",
           "fixed": "Fixed options",
-          "group_custom": "Opzioni del gruppo",
+          "group": "Opzioni del gruppo",
           "linear": "Opzioni lineari",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/it.json
+++ b/custom_components/powercalc/translations/it.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Crea contatori (utility meters)",
-          "group": "Aggiungi al gruppo",
+          "group_custom": "Aggiungi al gruppo",
           "name": "Nome",
           "on_time": "On time",
           "start_time": "Orario d'inizio",
@@ -35,13 +35,13 @@
           "value_template": "Value template"
         },
         "data_description": {
-          "group": "Inserisci un nome personalizzato per creare un nuovo gruppo",
+          "group_custom": "Inserisci un nome personalizzato per creare un nuovo gruppo",
           "on_time": "Quando lasciato vuoto predefinito a 1 giorno. Sempre acceso",
           "update_frequency": "tempo in secondi tra gli aggiornamenti di stato del sensore"
         },
         "title": "Crea un sensore fisso giornaliero"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Nome",
           "create_energy_sensor": "Crea report energetico",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Area",
           "create_energy_sensor": "Crea sensore di energia",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Gruppo standard",
-          "domain_group": "Domain based group"
+          "group_custom": "Gruppo standard",
+          "group_domain": "Domain based group"
         },
         "title": "Scegli il tipo di gruppo",
         "description": "Seleziona il tipo di sensore di gruppo che vuoi creare. Scegliere un gruppo basato sul dominio se si desidera raggruppare tutte le entità di un dominio specifico, o creare un sensore che sommi tutti i sensori di energia. Scegli il gruppo standard altrimenti"
@@ -255,7 +255,7 @@
         "description": "Currently specific settings can only be configured globally",
         "title": "Crea un sensore di energia per un sensore di potenza esistente"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Crea sensore di energia",
           "create_utility_meters": "Crea contatori (utility meters)",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Energia giornaliera",
-          "group": "Gruppo",
+          "group_custom": "Gruppo",
           "menu_library": "Virtual power (library)",
           "real_power": "Energia da sensore di potenza reale",
           "virtual_power": "Potenza virtuale (manuale)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Crea sensore di energia",
           "create_utility_meters": "Crea contatori (utility meters)",
           "entity_id": "Source entity",
-          "group": "Aggiungi al gruppo",
+          "group_custom": "Aggiungi al gruppo",
           "mode": "Calculation strategy",
           "name": "Nome",
           "standby_power": "Potenza in standby"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Indica se powercalc deve creare un sensore kWh",
           "create_utility_meters": "Let powercalc create utility meters, which cycle daily, hourly etc.",
           "entity_id": "entity the virtual power is based on, the power sensor will listen to state changes of this entity to be updated",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Lasciando vuoto prenderà il nome dal dispositivo di origine",
           "standby_power": "Definire la quantità di potenza che il dispositivo sta consumando quando è in uno stato OFF"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Opzioni gruppo",
         "data": {
           "area": "Area",
@@ -507,12 +507,12 @@
           "basic_options": "Opzioni di base",
           "daily_energy": "Opzioni energetiche giornaliere",
           "fixed": "Fixed options",
-          "group": "Opzioni del gruppo",
+          "group_custom": "Opzioni del gruppo",
           "linear": "Opzioni lineari",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Aggiungi il sensore di energia creato a un dispositivo specifico"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/nl.json
+++ b/custom_components/powercalc/translations/nl.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Creëer utiliteit meters",
-          "group_custom": "Aan groep toevoegen",
+          "group": "Aan groep toevoegen",
           "name": "Naam",
           "on_time": "Tijd aan per dag",
           "start_time": "Begintijd",
@@ -35,7 +35,7 @@
           "value_template": "Waarde template"
         },
         "data_description": {
-          "group_custom": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
+          "group": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
           "on_time": "Standaard 1 dag indien niet gedefinieerd. altijd aan",
           "update_frequency": "tijd in seconden tussen status updates van de sensor"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standaard groep",
+          "group": "Standaard groep",
           "group_domain": "Domein gebaseerde groep"
         },
         "title": "Kies het type groep",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Dagelijkse energie",
-          "group_custom": "Groep",
+          "group": "Groep",
           "menu_library": "Virtueel vermogen (bibliotheek)",
           "real_power": "Energie gebaseerd op bestaande vermogen sensor",
           "virtual_power": "Virtueel vermogen (handmatig)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Creëer energie sensoren",
           "create_utility_meters": "Creëer utiliteit meters",
           "entity_id": "Bron entiteit",
-          "group_custom": "Aan groep toevoegen",
+          "group": "Aan groep toevoegen",
           "mode": "Calculatie strategie",
           "name": "Naam",
           "standby_power": "Stand-by vermogen"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Laat Powercalc een kWh meter maken",
           "create_utility_meters": "Laat powercalc utiliteit meters maken. Deze resetten dagelijks, uurlijks etc.",
           "entity_id": "entiteit waarop de virtuele energie sensor is gebaseerd, de energiesensor update zichzelf wanneer deze entiteit van status wijzigt",
-          "group_custom": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
+          "group": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
           "name": "Indien dit leeg gelaten wordt dan wordt de naam van de bron entiteit overgenomen",
           "standby_power": "Definieer het vermogen wanneer het apparaat uit staat (OFF status in Home Assistant)"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basisopties",
           "daily_energy": "Dagelijkse energie opties",
           "fixed": "Fixed opties",
-          "group_custom": "Groep opties",
+          "group": "Groep opties",
           "linear": "Lineaire opties",
           "playbook": "Playbook opties",
           "multi_switch": "Multi switch opties",

--- a/custom_components/powercalc/translations/nl.json
+++ b/custom_components/powercalc/translations/nl.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Creëer utiliteit meters",
-          "group": "Aan groep toevoegen",
+          "group_custom": "Aan groep toevoegen",
           "name": "Naam",
           "on_time": "Tijd aan per dag",
           "start_time": "Begintijd",
@@ -35,13 +35,13 @@
           "value_template": "Waarde template"
         },
         "data_description": {
-          "group": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
+          "group_custom": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
           "on_time": "Standaard 1 dag indien niet gedefinieerd. altijd aan",
           "update_frequency": "tijd in seconden tussen status updates van de sensor"
         },
         "title": "Maak een dagelijkse energieverbruik sensor"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Naam",
           "create_energy_sensor": "Creëer energie sensoren",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Nutsmeter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Ruimte",
           "create_energy_sensor": "Creëer energie sensoren",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standaard groep",
-          "domain_group": "Domein gebaseerde groep"
+          "group_custom": "Standaard groep",
+          "group_domain": "Domein gebaseerde groep"
         },
         "title": "Kies het type groep",
         "description": "Selecteer het type groepssensor dat je wilt aanmaken. Kies een domein gebaseerde groep als u alle entiteiten van een specifiek domein wilt groeperen of een sensor opsomming wilt maken van al uw energie sensoren."
@@ -255,7 +255,7 @@
         "description": "Momenteel kunnen specifieke instellingen alleen globaal worden geconfigureerd",
         "title": "Maak een energiesensor voor een bestaande stroomsensor"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Creëer energie sensoren",
           "create_utility_meters": "Creëer utiliteit meters",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Dagelijkse energie",
-          "group": "Groep",
+          "group_custom": "Groep",
           "menu_library": "Virtueel vermogen (bibliotheek)",
           "real_power": "Energie gebaseerd op bestaande vermogen sensor",
           "virtual_power": "Virtueel vermogen (handmatig)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Creëer energie sensoren",
           "create_utility_meters": "Creëer utiliteit meters",
           "entity_id": "Bron entiteit",
-          "group": "Aan groep toevoegen",
+          "group_custom": "Aan groep toevoegen",
           "mode": "Calculatie strategie",
           "name": "Naam",
           "standby_power": "Stand-by vermogen"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Laat Powercalc een kWh meter maken",
           "create_utility_meters": "Laat powercalc utiliteit meters maken. Deze resetten dagelijks, uurlijks etc.",
           "entity_id": "entiteit waarop de virtuele energie sensor is gebaseerd, de energiesensor update zichzelf wanneer deze entiteit van status wijzigt",
-          "group": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
+          "group_custom": "Vul een eigen groepsnaam in om een nieuwe groep aan te maken",
           "name": "Indien dit leeg gelaten wordt dan wordt de naam van de bron entiteit overgenomen",
           "standby_power": "Definieer het vermogen wanneer het apparaat uit staat (OFF status in Home Assistant)"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Nutsmeter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Groep opties",
         "data": {
           "area": "Ruimte",
@@ -507,12 +507,12 @@
           "basic_options": "Basisopties",
           "daily_energy": "Dagelijkse energie opties",
           "fixed": "Fixed opties",
-          "group": "Groep opties",
+          "group_custom": "Groep opties",
           "linear": "Lineaire opties",
           "playbook": "Playbook opties",
           "multi_switch": "Multi switch opties",
           "real_power": "Real power opties",
-          "subtract_group": "Groep opties",
+          "group_subtract": "Groep opties",
           "utility_meter_options": "Nutsmeter opties",
           "wled": "WLED opties"
         }
@@ -572,7 +572,7 @@
           "device": "Voeg de gecreëerde energiesensor toe aan een specifiek apparaat"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Basis entiteit",
           "subtract_entities": "Entiteiten aftrekken"

--- a/custom_components/powercalc/translations/nl.json
+++ b/custom_components/powercalc/translations/nl.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standaard groep",
+          "group_custom": "Standaard groep",
           "group_domain": "Domein gebaseerde groep"
         },
         "title": "Kies het type groep",

--- a/custom_components/powercalc/translations/pl.json
+++ b/custom_components/powercalc/translations/pl.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standardowa grupa",
+          "group_custom": "Standardowa grupa",
           "group_domain": "Grupa oparta na domenie"
         },
         "title": "Wybierz typ grupy",

--- a/custom_components/powercalc/translations/pl.json
+++ b/custom_components/powercalc/translations/pl.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Utwórz liczniki mediów (utility meter)",
-          "group_custom": "Dodaj do grupy",
+          "group": "Dodaj do grupy",
           "name": "Nazwa",
           "on_time": "Sumaryczny czas włączenia",
           "start_time": "Moment uruchomienia",
@@ -35,7 +35,7 @@
           "value_template": "Szablon wartości"
         },
         "data_description": {
-          "group_custom": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
+          "group": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
           "on_time": "Gdy pole pozostanie puste, to wartość domyślna wyniesie 1 dzień = zawsze włączone",
           "update_frequency": "Czas w sekundach między aktualizacjami stanu sensora"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standardowa grupa",
+          "group": "Standardowa grupa",
           "group_domain": "Grupa oparta na domenie"
         },
         "title": "Wybierz typ grupy",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Dzienna energia",
-          "group_custom": "Grupa",
+          "group": "Grupa",
           "menu_library": "Moc wirtualna (biblioteka)",
           "real_power": "Energia z rzeczywistego sensora mocy",
           "virtual_power": "Moc wirtualna (ręcznie)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Utwórz sensor energii",
           "create_utility_meters": "Utwórz liczniki mediów (utility meter)",
           "entity_id": "Encja źródłowa",
-          "group_custom": "Dodaj do grupy",
+          "group": "Dodaj do grupy",
           "mode": "Strategia obliczeniowa",
           "name": "Nazwa",
           "standby_power": "Moc w trybie czuwania"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Czy Powercalc musi utworzyć sensor kWh",
           "create_utility_meters": "Pozwól Powercalc stworzyć liczniki mediów, które pracują w cyklach dziennych, godzinowych itp.",
           "entity_id": "Encja źródłowa, na której opiera się wirtualna moc; sensor mocy, który ma być aktualizowany będzie nasłuchiwał zmian stanu tej encji",
-          "group_custom": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
+          "group": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
           "name": "Pozostawienie pustego pola spowoduje pobranie nazwy z encji źródłowej",
           "standby_power": "Określ ilość energii zużywanej przez urządzenie w trybie czuwania (standby)"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Opcje podstawowe",
           "daily_energy": "Dzienne opcje energii",
           "fixed": "Opcje stałe",
-          "group_custom": "Opcje grupy",
+          "group": "Opcje grupy",
           "linear": "Opcje liniowe",
           "playbook": "Opcje playbook",
           "multi_switch": "Opcje wieloprzełącznika",

--- a/custom_components/powercalc/translations/pl.json
+++ b/custom_components/powercalc/translations/pl.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Utwórz liczniki mediów (utility meter)",
-          "group": "Dodaj do grupy",
+          "group_custom": "Dodaj do grupy",
           "name": "Nazwa",
           "on_time": "Sumaryczny czas włączenia",
           "start_time": "Moment uruchomienia",
@@ -35,13 +35,13 @@
           "value_template": "Szablon wartości"
         },
         "data_description": {
-          "group": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
+          "group_custom": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
           "on_time": "Gdy pole pozostanie puste, to wartość domyślna wyniesie 1 dzień = zawsze włączone",
           "update_frequency": "Czas w sekundach między aktualizacjami stanu sensora"
         },
         "title": "Utwórz dzienny czujnik stały"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Nazwa",
           "create_energy_sensor": "Utwórz czujnik energii",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Typy licznika mediów"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Obszar",
           "create_energy_sensor": "Utwórz czujnik energii",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standardowa grupa",
-          "domain_group": "Grupa oparta na domenie"
+          "group_custom": "Standardowa grupa",
+          "group_domain": "Grupa oparta na domenie"
         },
         "title": "Wybierz typ grupy",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "Obecnie określone ustawienia można konfigurować wyłącznie globalnie",
         "title": "Utwórz sensor energii dla istniejącego sensora mocy"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Utwórz czujnik energii",
           "create_utility_meters": "Utwórz liczniki mediów",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Dzienna energia",
-          "group": "Grupa",
+          "group_custom": "Grupa",
           "menu_library": "Moc wirtualna (biblioteka)",
           "real_power": "Energia z rzeczywistego sensora mocy",
           "virtual_power": "Moc wirtualna (ręcznie)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Utwórz sensor energii",
           "create_utility_meters": "Utwórz liczniki mediów (utility meter)",
           "entity_id": "Encja źródłowa",
-          "group": "Dodaj do grupy",
+          "group_custom": "Dodaj do grupy",
           "mode": "Strategia obliczeniowa",
           "name": "Nazwa",
           "standby_power": "Moc w trybie czuwania"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Czy Powercalc musi utworzyć sensor kWh",
           "create_utility_meters": "Pozwól Powercalc stworzyć liczniki mediów, które pracują w cyklach dziennych, godzinowych itp.",
           "entity_id": "Encja źródłowa, na której opiera się wirtualna moc; sensor mocy, który ma być aktualizowany będzie nasłuchiwał zmian stanu tej encji",
-          "group": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
+          "group_custom": "Wpisz własną nazwę grupy, aby utworzyć nową grupę",
           "name": "Pozostawienie pustego pola spowoduje pobranie nazwy z encji źródłowej",
           "standby_power": "Określ ilość energii zużywanej przez urządzenie w trybie czuwania (standby)"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Typy licznika mediów"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Opcje grupy",
         "data": {
           "area": "Obszar",
@@ -507,12 +507,12 @@
           "basic_options": "Opcje podstawowe",
           "daily_energy": "Dzienne opcje energii",
           "fixed": "Opcje stałe",
-          "group": "Opcje grupy",
+          "group_custom": "Opcje grupy",
           "linear": "Opcje liniowe",
           "playbook": "Opcje playbook",
           "multi_switch": "Opcje wieloprzełącznika",
           "real_power": "Opcje rzeczywistej mocy",
-          "subtract_group": "Opcje grupy",
+          "group_subtract": "Opcje grupy",
           "utility_meter_options": "Opcje licznika mediów",
           "wled": "Opcje WLED"
         }
@@ -572,7 +572,7 @@
           "device": "Dodaj utworzony czujnik energii do konkretnego urządzenia"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Główny obiekt",
           "subtract_entities": "Odejmujące obiekty"

--- a/custom_components/powercalc/translations/pt-BR.json
+++ b/custom_components/powercalc/translations/pt-BR.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Criar medidores de utilidade",
-          "group_custom": "Adicionar ao grupo",
+          "group": "Adicionar ao grupo",
           "name": "Nome",
           "on_time": "Na hora",
           "start_time": "Hora de início",
@@ -35,7 +35,7 @@
           "value_template": "Modelo de valor"
         },
         "data_description": {
-          "group_custom": "Preencha um nome de grupo personalizado para criar um novo grupo",
+          "group": "Preencha um nome de grupo personalizado para criar um novo grupo",
           "on_time": "Quando deixado vazio, o padrão é 1 dia. sempre",
           "update_frequency": "tempo em segundos entre as atualizações de estado do sensor"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Grupo padrão",
+          "group": "Grupo padrão",
           "group_domain": "Grupo baseado em domínio"
         },
         "title": "Escolha o tipo de grupo",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Consumo diário",
-          "group_custom": "Grupo",
+          "group": "Grupo",
           "menu_library": "Potência virtual (biblioteca)",
           "real_power": "Consumo de um sensor de potência real",
           "virtual_power": "Potência virtual (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Criar sensor de consumo",
           "create_utility_meters": "Criar medidores de utilidade",
           "entity_id": "Entidade de origem",
-          "group_custom": "Adicionar ao grupo",
+          "group": "Adicionar ao grupo",
           "mode": "Estratégia de cálculo",
           "name": "Nome",
           "standby_power": "Potência em standby"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Se o powercalc precisa criar um sensor kWh",
           "create_utility_meters": "Deixe o powercalc criar medidores de utilidade que ciclam diariamente, de hora em hora etc.",
           "entity_id": "entidade na qual a energia virtual é baseada, o sensor de energia escutará as mudanças de estado desta entidade para serem atualizadas",
-          "group_custom": "Preencha um nome de grupo personalizado para criar um novo grupo",
+          "group": "Preencha um nome de grupo personalizado para criar um novo grupo",
           "name": "Deixar em branco levará o nome da entidade de origem",
           "standby_power": "Defina a quantidade de potência que o dispositivo está consumindo quando estiver DESLIGADO"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Opções básicas",
           "daily_energy": "Opções de consumo diário",
           "fixed": "Opções de Fixo",
-          "group_custom": "Opções de grupo",
+          "group": "Opções de grupo",
           "linear": "Opções linear",
           "playbook": "Opções do playbook",
           "multi_switch": "Opções de multi-interruptor",

--- a/custom_components/powercalc/translations/pt-BR.json
+++ b/custom_components/powercalc/translations/pt-BR.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Grupo padrão",
+          "group_custom": "Grupo padrão",
           "group_domain": "Grupo baseado em domínio"
         },
         "title": "Escolha o tipo de grupo",

--- a/custom_components/powercalc/translations/pt-BR.json
+++ b/custom_components/powercalc/translations/pt-BR.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Criar medidores de utilidade",
-          "group": "Adicionar ao grupo",
+          "group_custom": "Adicionar ao grupo",
           "name": "Nome",
           "on_time": "Na hora",
           "start_time": "Hora de início",
@@ -35,13 +35,13 @@
           "value_template": "Modelo de valor"
         },
         "data_description": {
-          "group": "Preencha um nome de grupo personalizado para criar um novo grupo",
+          "group_custom": "Preencha um nome de grupo personalizado para criar um novo grupo",
           "on_time": "Quando deixado vazio, o padrão é 1 dia. sempre",
           "update_frequency": "tempo em segundos entre as atualizações de estado do sensor"
         },
         "title": "Criar um sensor fixo diário"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Nome",
           "create_energy_sensor": "Criar sensor de consumo",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Área",
           "create_energy_sensor": "Criar sensor de consumo",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Grupo padrão",
-          "domain_group": "Grupo baseado em domínio"
+          "group_custom": "Grupo padrão",
+          "group_domain": "Grupo baseado em domínio"
         },
         "title": "Escolha o tipo de grupo",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "Atualmente configurações específicas só podem ser configuradas globalmente",
         "title": "Criar um sensor de consumo para um sensor de potência existente"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Criar sensor de consumo",
           "create_utility_meters": "Criar medidores de utilidade",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Consumo diário",
-          "group": "Grupo",
+          "group_custom": "Grupo",
           "menu_library": "Potência virtual (biblioteca)",
           "real_power": "Consumo de um sensor de potência real",
           "virtual_power": "Potência virtual (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Criar sensor de consumo",
           "create_utility_meters": "Criar medidores de utilidade",
           "entity_id": "Entidade de origem",
-          "group": "Adicionar ao grupo",
+          "group_custom": "Adicionar ao grupo",
           "mode": "Estratégia de cálculo",
           "name": "Nome",
           "standby_power": "Potência em standby"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Se o powercalc precisa criar um sensor kWh",
           "create_utility_meters": "Deixe o powercalc criar medidores de utilidade que ciclam diariamente, de hora em hora etc.",
           "entity_id": "entidade na qual a energia virtual é baseada, o sensor de energia escutará as mudanças de estado desta entidade para serem atualizadas",
-          "group": "Preencha um nome de grupo personalizado para criar um novo grupo",
+          "group_custom": "Preencha um nome de grupo personalizado para criar um novo grupo",
           "name": "Deixar em branco levará o nome da entidade de origem",
           "standby_power": "Defina a quantidade de potência que o dispositivo está consumindo quando estiver DESLIGADO"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Tipos do medidor de utilidade"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Opções do grupo",
         "data": {
           "area": "Área",
@@ -507,12 +507,12 @@
           "basic_options": "Opções básicas",
           "daily_energy": "Opções de consumo diário",
           "fixed": "Opções de Fixo",
-          "group": "Opções de grupo",
+          "group_custom": "Opções de grupo",
           "linear": "Opções linear",
           "playbook": "Opções do playbook",
           "multi_switch": "Opções de multi-interruptor",
           "real_power": "Opções de potência real",
-          "subtract_group": "Opções de grupo",
+          "group_subtract": "Opções de grupo",
           "utility_meter_options": "Opções do medidor de utilidade",
           "wled": "Opções de WLED"
         }
@@ -572,7 +572,7 @@
           "device": "Adicionar o sensor de energia criado a um dispositivo específico"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Entidade base",
           "subtract_entities": "Subtrair entidades"

--- a/custom_components/powercalc/translations/pt.json
+++ b/custom_components/powercalc/translations/pt.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Create utility meters",
-          "group": "Add to group",
+          "group_custom": "Add to group",
           "name": "Nome",
           "on_time": "Na hora",
           "start_time": "Hora de início",
@@ -35,13 +35,13 @@
           "value_template": "Modelo de valor"
         },
         "data_description": {
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "on_time": "Quando deixado vazio, o padrão é 1 dia. Sempre ligado",
           "update_frequency": "tempo em segundos entre as atualizações de estado do sensor"
         },
         "title": "Criar um sensor fixo diário"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Name",
           "create_energy_sensor": "Create energy sensor",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Área",
           "create_energy_sensor": "Create energy sensor",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
-          "domain_group": "Domain based group"
+          "group_custom": "Standard group",
+          "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "As definições especificadas só podem ser configuradas globalmente",
         "title": "Criar um sensor de energia a partir de um sensor de potência existente"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Energia diáriay",
-          "group": "Grupo",
+          "group_custom": "Grupo",
           "menu_library": "Potência virtual (biblioteca)",
           "real_power": "Energia de um sensor de potência real",
           "virtual_power": "Potência virtual (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Criar sensor de energia",
           "create_utility_meters": "Criar medidores de utilidade",
           "entity_id": "Entidade de origem",
-          "group": "Adicionar ao grupo",
+          "group_custom": "Adicionar ao grupo",
           "mode": "Estratégia de cálculo",
           "name": "Nome",
           "standby_power": "Energia em espera"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Se o powercalc precisa criar um sensor kWh",
           "create_utility_meters": "Deixe o powercalc criar medidores de utilidade, que circulam diariamente, de hora em hora, etc.",
           "entity_id": "entidade na qual a energia virtual é baseada, o sensor de energia escutará as mudanças de estado desta entidade para serem atualizadas",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Deixar em branco levará o nome da entidade de origem",
           "standby_power": "Defina a quantidade de energia que o dispositivo está consumindo quando em estado desligado"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Área",
@@ -507,12 +507,12 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/pt.json
+++ b/custom_components/powercalc/translations/pt.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
+          "group_custom": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",

--- a/custom_components/powercalc/translations/pt.json
+++ b/custom_components/powercalc/translations/pt.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Create utility meters",
-          "group_custom": "Add to group",
+          "group": "Add to group",
           "name": "Nome",
           "on_time": "Na hora",
           "start_time": "Hora de início",
@@ -35,7 +35,7 @@
           "value_template": "Modelo de valor"
         },
         "data_description": {
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "on_time": "Quando deixado vazio, o padrão é 1 dia. Sempre ligado",
           "update_frequency": "tempo em segundos entre as atualizações de estado do sensor"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standard group",
+          "group": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Energia diáriay",
-          "group_custom": "Grupo",
+          "group": "Grupo",
           "menu_library": "Potência virtual (biblioteca)",
           "real_power": "Energia de um sensor de potência real",
           "virtual_power": "Potência virtual (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Criar sensor de energia",
           "create_utility_meters": "Criar medidores de utilidade",
           "entity_id": "Entidade de origem",
-          "group_custom": "Adicionar ao grupo",
+          "group": "Adicionar ao grupo",
           "mode": "Estratégia de cálculo",
           "name": "Nome",
           "standby_power": "Energia em espera"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Se o powercalc precisa criar um sensor kWh",
           "create_utility_meters": "Deixe o powercalc criar medidores de utilidade, que circulam diariamente, de hora em hora, etc.",
           "entity_id": "entidade na qual a energia virtual é baseada, o sensor de energia escutará as mudanças de estado desta entidade para serem atualizadas",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Deixar em branco levará o nome da entidade de origem",
           "standby_power": "Defina a quantidade de energia que o dispositivo está consumindo quando em estado desligado"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/ro.json
+++ b/custom_components/powercalc/translations/ro.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Creați contoare",
-          "group": "Add to group",
+          "group_custom": "Add to group",
           "name": "Nume",
           "on_time": "Timp pornit",
           "start_time": "Timpul de pornire",
@@ -35,13 +35,13 @@
           "value_template": "Șablon de valoare"
         },
         "data_description": {
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "on_time": "Când este lăsat gol, valoarea implicită este 1 zi. mereu pornit",
           "update_frequency": "timpul în secunde între actualizările stării senzorului"
         },
         "title": "Creați un senzor fix zilnic"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Name",
           "create_energy_sensor": "Create energy sensor",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Zonă",
           "create_energy_sensor": "Create energy sensor",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
-          "domain_group": "Domain based group"
+          "group_custom": "Standard group",
+          "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "În prezent, setările specifice pot fi configurate numai global",
         "title": "Creați un senzor de energie pentru un senzor de putere existent"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Energie zilnică",
-          "group": "Grup",
+          "group_custom": "Grup",
           "menu_library": "Putere virtuală (biblioteca)",
           "real_power": "Energie de la senzorul de putere reală",
           "virtual_power": "Putere virtuală (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Creați un senzor de energie",
           "create_utility_meters": "Creați contoare",
           "entity_id": "Entitatea sursă",
-          "group": "Adăugați la grup",
+          "group_custom": "Adăugați la grup",
           "mode": "Strategia de calcul",
           "name": "Nume",
           "standby_power": "Putere in Standby"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Dacă powercalc trebuie să creeze un senzor kWh",
           "create_utility_meters": "Lăsați powercalc să creeze contoare, cu ciclu zilnic, pe oră etc.",
           "entity_id": "entitate pe care se bazează puterea virtuală, senzorul de putere va asculta modificările de stare ale acestei entități pentru a fi actualizate",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Dacă lăsați necompletat, numele va fi preluat de la entitatea sursă",
           "standby_power": "Definiți cantitatea de energie pe care o consumă dispozitivul în starea OPRIT"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Zona",
@@ -507,12 +507,12 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/ro.json
+++ b/custom_components/powercalc/translations/ro.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Creați contoare",
-          "group_custom": "Add to group",
+          "group": "Add to group",
           "name": "Nume",
           "on_time": "Timp pornit",
           "start_time": "Timpul de pornire",
@@ -35,7 +35,7 @@
           "value_template": "Șablon de valoare"
         },
         "data_description": {
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "on_time": "Când este lăsat gol, valoarea implicită este 1 zi. mereu pornit",
           "update_frequency": "timpul în secunde între actualizările stării senzorului"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standard group",
+          "group": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Energie zilnică",
-          "group_custom": "Grup",
+          "group": "Grup",
           "menu_library": "Putere virtuală (biblioteca)",
           "real_power": "Energie de la senzorul de putere reală",
           "virtual_power": "Putere virtuală (manual)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Creați un senzor de energie",
           "create_utility_meters": "Creați contoare",
           "entity_id": "Entitatea sursă",
-          "group_custom": "Adăugați la grup",
+          "group": "Adăugați la grup",
           "mode": "Strategia de calcul",
           "name": "Nume",
           "standby_power": "Putere in Standby"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Dacă powercalc trebuie să creeze un senzor kWh",
           "create_utility_meters": "Lăsați powercalc să creeze contoare, cu ciclu zilnic, pe oră etc.",
           "entity_id": "entitate pe care se bazează puterea virtuală, senzorul de putere va asculta modificările de stare ale acestei entități pentru a fi actualizate",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Dacă lăsați necompletat, numele va fi preluat de la entitatea sursă",
           "standby_power": "Definiți cantitatea de energie pe care o consumă dispozitivul în starea OPRIT"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/ro.json
+++ b/custom_components/powercalc/translations/ro.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
+          "group_custom": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",

--- a/custom_components/powercalc/translations/sk.json
+++ b/custom_components/powercalc/translations/sk.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Vytvorenie meracích prístrojov",
-          "group": "Add to group",
+          "group_custom": "Add to group",
           "name": "Názov",
           "on_time": "V čase",
           "start_time": "Štart čas",
@@ -35,13 +35,13 @@
           "value_template": "Šablóna hodnoty"
         },
         "data_description": {
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "on_time": "Keď ponecháte prázdne, predvolene je 1 deň. vždy zapnutý",
           "update_frequency": "čas v sekundách medzi aktualizáciami stavu snímača"
         },
         "title": "Vytvorte denný pevný snímač"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Name",
           "create_energy_sensor": "Create energy sensor",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Oblasť",
           "create_energy_sensor": "Vytvoriť snímač energie",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
-          "domain_group": "Domain based group"
+          "group_custom": "Standard group",
+          "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
         "description": "Select the type of group sensor you want to create. Choose domain based group if you want to group all entities of a specific domain, or create a sensor summing all your energy sensors. Choose standard group otherwise."
@@ -255,7 +255,7 @@
         "description": "V súčasnosti možno špecifické nastavenia konfigurovať len globálne",
         "title": "Vytvorenie snímača energie pre existujúci snímač energie"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Create energy sensor",
           "create_utility_meters": "Create utility meters",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Denná energia",
-          "group": "Skupiny",
+          "group_custom": "Skupiny",
           "menu_library": "Virtuálny výkon (knižnica)",
           "real_power": "Energia zo snímača skutočného výkonu",
           "virtual_power": "Virtuálne napájanie (manuálne)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Vytvoriť snímač energie",
           "create_utility_meters": "Vytvorte merače spotreby",
           "entity_id": "Zdrojová entita",
-          "group": "Pridať do skupiny",
+          "group_custom": "Pridať do skupiny",
           "mode": "Stratégia výpočtu",
           "name": "Názov",
           "standby_power": "Napájanie v pohotovostnom režime"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Či potrebuje powercalc vytvoriť kWh snímač",
           "create_utility_meters": "Nechajte powercalc vytvoriť merače spotreby, ktoré cyklujú denne, každú hodinu atď.",
           "entity_id": "entita, na ktorej je založená virtuálna sila, bude snímač výkonu počúvať zmeny stavu tejto entity, aby sa aktualizoval",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Ak ponecháte prázdne, názov sa prevezme zo zdrojovej entity",
           "standby_power": "Definujte množstvo energie, ktoré zariadenie spotrebuje, keď je vo vypnutom stave"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Oblasť",
@@ -507,12 +507,12 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED options"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Base entity",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/sk.json
+++ b/custom_components/powercalc/translations/sk.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standard group",
+          "group_custom": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",

--- a/custom_components/powercalc/translations/sk.json
+++ b/custom_components/powercalc/translations/sk.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Vytvorenie meracích prístrojov",
-          "group_custom": "Add to group",
+          "group": "Add to group",
           "name": "Názov",
           "on_time": "V čase",
           "start_time": "Štart čas",
@@ -35,7 +35,7 @@
           "value_template": "Šablóna hodnoty"
         },
         "data_description": {
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "on_time": "Keď ponecháte prázdne, predvolene je 1 deň. vždy zapnutý",
           "update_frequency": "čas v sekundách medzi aktualizáciami stavu snímača"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standard group",
+          "group": "Standard group",
           "group_domain": "Domain based group"
         },
         "title": "Choose the group type",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Denná energia",
-          "group_custom": "Skupiny",
+          "group": "Skupiny",
           "menu_library": "Virtuálny výkon (knižnica)",
           "real_power": "Energia zo snímača skutočného výkonu",
           "virtual_power": "Virtuálne napájanie (manuálne)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Vytvoriť snímač energie",
           "create_utility_meters": "Vytvorte merače spotreby",
           "entity_id": "Zdrojová entita",
-          "group_custom": "Pridať do skupiny",
+          "group": "Pridať do skupiny",
           "mode": "Stratégia výpočtu",
           "name": "Názov",
           "standby_power": "Napájanie v pohotovostnom režime"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Či potrebuje powercalc vytvoriť kWh snímač",
           "create_utility_meters": "Nechajte powercalc vytvoriť merače spotreby, ktoré cyklujú denne, každú hodinu atď.",
           "entity_id": "entita, na ktorej je založená virtuálna sila, bude snímač výkonu počúvať zmeny stavu tejto entity, aby sa aktualizoval",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Ak ponecháte prázdne, názov sa prevezme zo zdrojovej entity",
           "standby_power": "Definujte množstvo energie, ktoré zariadenie spotrebuje, keď je vo vypnutom stave"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Basic options",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/custom_components/powercalc/translations/sv.json
+++ b/custom_components/powercalc/translations/sv.json
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standardgrupp",
+          "group_custom": "Standardgrupp",
           "group_domain": "Domänbaserad grupp"
         },
         "title": "Välj grupptyp",

--- a/custom_components/powercalc/translations/sv.json
+++ b/custom_components/powercalc/translations/sv.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Skapa bruksmätare",
-          "group": "Lägg till i grupp",
+          "group_custom": "Lägg till i grupp",
           "name": "Namn",
           "on_time": "Igång tid",
           "start_time": "Starttid",
@@ -35,13 +35,13 @@
           "value_template": "Värdesmall"
         },
         "data_description": {
-          "group": "Fyll i ett eget gruppnamn för att skapa en ny grupp",
+          "group_custom": "Fyll i ett eget gruppnamn för att skapa en ny grupp",
           "on_time": "Om lämnas tomt är standard 1 dag. Alltid på",
           "update_frequency": "Tid i sekunder mellan uppdatering av sensor"
         },
         "title": "Skapar en fast daglig sensor"
       },
-      "domain_group": {
+      "group_domain": {
         "data": {
           "name": "Namn",
           "create_energy_sensor": "Skapa energisensor",
@@ -109,7 +109,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "data": {
           "area": "Område",
           "create_energy_sensor": "Skapa energisensor",
@@ -184,8 +184,8 @@
       },
       "menu_group": {
         "menu_options": {
-          "group": "Standardgrupp",
-          "domain_group": "Domänbaserad grupp"
+          "group_custom": "Standardgrupp",
+          "group_domain": "Domänbaserad grupp"
         },
         "title": "Välj grupptyp",
         "description": "Välj vilken typ av gruppsensor du vill skapa. Välj domänbaserad grupp om du vill gruppera alla enheter i en specifik domän eller skapa en sensor som summerar all din energisensor. Välj standardgrupp annars"
@@ -255,7 +255,7 @@
         "description": "Nuvarande specifik inställning kan bara konfigureras globalt",
         "title": "Skapa en energisensor för en befintlig effektsensor"
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "create_energy_sensor": "Skapa energisensor",
           "create_utility_meters": "Skapa bruksmätare",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Daglig energi",
-          "group": "Grupp",
+          "group_custom": "Grupp",
           "menu_library": "Virtuell effekt (bibliotek)",
           "real_power": "Energi från riktig effektsensor",
           "virtual_power": "Virtuell effekt (manuell)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Skapa energisensor",
           "create_utility_meters": "Skapa bruksmätare",
           "entity_id": "Källentitet",
-          "group": "Lägg till i grupp",
+          "group_custom": "Lägg till i grupp",
           "mode": "Beräkningsstrategi",
           "name": "Namn",
           "standby_power": "Standby effekt"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Ska powercalc skapa en kWh sensor",
           "create_utility_meters": "Låt powercalc skapa bruksmätare, vilken cykel dag, timme etc.",
           "entity_id": "Entitet den virtuella effekten är baserad på, effektsensorn kommer lyssna på förändringar på denna entitet",
-          "group": "Fill in a custom group name to create a new group",
+          "group_custom": "Fill in a custom group name to create a new group",
           "name": "Lämnas tom kommer namn tas från källentiteten",
           "standby_power": "Ange effekten som enheten förbrukar i avstängt läge"
         },
@@ -477,7 +477,7 @@
           "utility_meter_types": "Utility meter types"
         }
       },
-      "group": {
+      "group_custom": {
         "title": "Group options",
         "data": {
           "area": "Område",
@@ -507,12 +507,12 @@
           "basic_options": "Grundläggande inställningar",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group": "Group options",
+          "group_custom": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",
           "real_power": "Real power options",
-          "subtract_group": "Group options",
+          "group_subtract": "Group options",
           "utility_meter_options": "Utility meter options",
           "wled": "WLED alternativ"
         }
@@ -572,7 +572,7 @@
           "device": "Add the created energy sensor to an specific device"
         }
       },
-      "subtract_group": {
+      "group_subtract": {
         "data": {
           "entity_id": "Basentiteten",
           "subtract_entities": "Subtract entities"

--- a/custom_components/powercalc/translations/sv.json
+++ b/custom_components/powercalc/translations/sv.json
@@ -25,7 +25,7 @@
       "daily_energy": {
         "data": {
           "create_utility_meters": "Skapa bruksmätare",
-          "group_custom": "Lägg till i grupp",
+          "group": "Lägg till i grupp",
           "name": "Namn",
           "on_time": "Igång tid",
           "start_time": "Starttid",
@@ -35,7 +35,7 @@
           "value_template": "Värdesmall"
         },
         "data_description": {
-          "group_custom": "Fyll i ett eget gruppnamn för att skapa en ny grupp",
+          "group": "Fyll i ett eget gruppnamn för att skapa en ny grupp",
           "on_time": "Om lämnas tomt är standard 1 dag. Alltid på",
           "update_frequency": "Tid i sekunder mellan uppdatering av sensor"
         },
@@ -184,7 +184,7 @@
       },
       "menu_group": {
         "menu_options": {
-          "group_custom": "Standardgrupp",
+          "group": "Standardgrupp",
           "group_domain": "Domänbaserad grupp"
         },
         "title": "Välj grupptyp",
@@ -294,7 +294,7 @@
         },
         "menu_options": {
           "daily_energy": "Daglig energi",
-          "group_custom": "Grupp",
+          "group": "Grupp",
           "menu_library": "Virtuell effekt (bibliotek)",
           "real_power": "Energi från riktig effektsensor",
           "virtual_power": "Virtuell effekt (manuell)"
@@ -320,7 +320,7 @@
           "create_energy_sensor": "Skapa energisensor",
           "create_utility_meters": "Skapa bruksmätare",
           "entity_id": "Källentitet",
-          "group_custom": "Lägg till i grupp",
+          "group": "Lägg till i grupp",
           "mode": "Beräkningsstrategi",
           "name": "Namn",
           "standby_power": "Standby effekt"
@@ -329,7 +329,7 @@
           "create_energy_sensor": "Ska powercalc skapa en kWh sensor",
           "create_utility_meters": "Låt powercalc skapa bruksmätare, vilken cykel dag, timme etc.",
           "entity_id": "Entitet den virtuella effekten är baserad på, effektsensorn kommer lyssna på förändringar på denna entitet",
-          "group_custom": "Fill in a custom group name to create a new group",
+          "group": "Fill in a custom group name to create a new group",
           "name": "Lämnas tom kommer namn tas från källentiteten",
           "standby_power": "Ange effekten som enheten förbrukar i avstängt läge"
         },
@@ -507,7 +507,7 @@
           "basic_options": "Grundläggande inställningar",
           "daily_energy": "Daily energy options",
           "fixed": "Fixed options",
-          "group_custom": "Group options",
+          "group": "Group options",
           "linear": "Linear options",
           "playbook": "Playbook options",
           "multi_switch": "Multi switch options",

--- a/tests/config_flow/common.py
+++ b/tests/config_flow/common.py
@@ -15,7 +15,7 @@ from custom_components.powercalc.common import SourceEntity
 from custom_components.powercalc.config_flow import (
     CONF_CONFIRM_AUTODISCOVERED_MODEL,
     DOMAIN,
-    Steps,
+    Step,
 )
 from custom_components.powercalc.const import (
     CONF_CREATE_ENERGY_SENSOR,
@@ -40,8 +40,8 @@ DEFAULT_UNIQUE_ID = "7c009ef6829f"
 
 async def select_menu_item(
     hass: HomeAssistant,
-    menu_item: Steps,
-    next_step_id: Steps | None = None,
+    menu_item: Step,
+    next_step_id: Step | None = None,
 ) -> FlowResult:
     """Select a sensor type from the menu"""
     result = await hass.config_entries.flow.async_init(
@@ -54,7 +54,7 @@ async def select_menu_item(
         {"next_step_id": menu_item},
     )
 
-    if menu_item == Steps.MENU_GROUP:
+    if menu_item == Step.MENU_GROUP:
         assert result["type"] == data_entry_flow.FlowResultType.MENU
     else:
         assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -73,7 +73,7 @@ async def select_menu_item(
 async def initialize_options_flow(
     hass: HomeAssistant,
     entry: config_entries.ConfigEntry,
-    selected_menu_item: Steps,
+    selected_menu_item: Step,
 ) -> FlowResult:
     if entry.state != config_entries.ConfigEntryState.LOADED:
         await hass.config_entries.async_setup(entry.entry_id)
@@ -84,7 +84,7 @@ async def initialize_options_flow(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.MENU
-    assert result["step_id"] == Steps.INIT
+    assert result["step_id"] == Step.INIT
     assert selected_menu_item in result["menu_options"]
 
     return await hass.config_entries.options.async_configure(
@@ -159,7 +159,7 @@ async def goto_virtual_power_strategy_step(
     elif CONF_MODE not in user_input:
         user_input[CONF_MODE] = strategy
 
-    result = await select_menu_item(hass, Steps.VIRTUAL_POWER)
+    result = await select_menu_item(hass, Step.VIRTUAL_POWER)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input,

--- a/tests/config_flow/test_daily_energy.py
+++ b/tests/config_flow/test_daily_energy.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from custom_components.powercalc import SensorType
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_CREATE_UTILITY_METERS,
     CONF_DAILY_FIXED_ENERGY,
@@ -31,7 +31,7 @@ from tests.config_flow.common import (
 
 
 async def test_daily_energy_mandatory_fields_not_supplied(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.DAILY_ENERGY)
+    result = await select_menu_item(hass, Step.DAILY_ENERGY)
 
     user_input = {CONF_NAME: "My daily energy sensor"}
     result = await hass.config_entries.flow.async_configure(
@@ -44,7 +44,7 @@ async def test_daily_energy_mandatory_fields_not_supplied(hass: HomeAssistant) -
 
 
 async def test_create_daily_energy_entry(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.DAILY_ENERGY)
+    result = await select_menu_item(hass, Step.DAILY_ENERGY)
 
     user_input = {
         CONF_NAME: "My daily energy sensor",
@@ -83,7 +83,7 @@ async def test_daily_energy_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.DAILY_ENERGY)
+    result = await initialize_options_flow(hass, entry, Step.DAILY_ENERGY)
 
     user_input = {CONF_VALUE: 75, CONF_UNIT_OF_MEASUREMENT: UnitOfPower.WATT}
     result = await hass.config_entries.options.async_configure(
@@ -97,7 +97,7 @@ async def test_daily_energy_options_flow(hass: HomeAssistant) -> None:
 
 
 async def test_on_time_option(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.DAILY_ENERGY)
+    result = await select_menu_item(hass, Step.DAILY_ENERGY)
 
     user_input = {
         CONF_NAME: "My daily energy sensor",
@@ -123,7 +123,7 @@ async def test_on_time_option(hass: HomeAssistant) -> None:
 
 
 async def test_utility_meter_options(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.DAILY_ENERGY)
+    result = await select_menu_item(hass, Step.DAILY_ENERGY)
 
     user_input = {
         CONF_NAME: "My daily energy sensor",
@@ -146,7 +146,7 @@ async def test_utility_meter_options(hass: HomeAssistant) -> None:
     config_entry: ConfigEntry = result["result"]
     assert config_entry.data[CONF_DAILY_FIXED_ENERGY][CONF_VALUE] == 10
 
-    result = await initialize_options_flow(hass, config_entry, Steps.UTILITY_METER_OPTIONS)
+    result = await initialize_options_flow(hass, config_entry, Step.UTILITY_METER_OPTIONS)
 
     user_input = {
         CONF_UTILITY_METER_TARIFFS: ["peak"],
@@ -171,7 +171,7 @@ async def test_add_to_group(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await select_menu_item(hass, Steps.DAILY_ENERGY)
+    result = await select_menu_item(hass, Step.DAILY_ENERGY)
 
     user_input = {
         CONF_NAME: "My daily energy sensor",
@@ -201,7 +201,7 @@ async def test_can_set_basic_options(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.BASIC_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.BASIC_OPTIONS)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_CREATE_UTILITY_METERS: True},
@@ -211,7 +211,7 @@ async def test_can_set_basic_options(hass: HomeAssistant) -> None:
     assert entry.data[CONF_CREATE_UTILITY_METERS]
 
     # Make sure the value is not overwritten when using other option dialog
-    result = await initialize_options_flow(hass, entry, Steps.DAILY_ENERGY)
+    result = await initialize_options_flow(hass, entry, Step.DAILY_ENERGY)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_VALUE: 75},

--- a/tests/config_flow/test_discovery.py
+++ b/tests/config_flow/test_discovery.py
@@ -6,7 +6,7 @@ from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
 
 from custom_components.powercalc.common import create_source_entity
-from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Steps
+from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Step
 from custom_components.powercalc.const import (
     CONF_CREATE_ENERGY_SENSOR,
     CONF_MANUFACTURER,
@@ -90,7 +90,7 @@ async def test_discovery_flow_with_subprofile_selection(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.SUB_PROFILE
+    assert result["step_id"] == Step.SUB_PROFILE
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_SUB_PROFILE: "length_6"},
@@ -125,7 +125,7 @@ async def test_discovery_flow_multi_profiles(
     ]
     result = await initialize_discovery_flow(hass, source_entity, power_profiles)
 
-    assert result["step_id"] == Steps.LIBRARY_MULTI_PROFILE
+    assert result["step_id"] == Step.LIBRARY_MULTI_PROFILE
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     data_schema: vol.Schema = result["data_schema"]
@@ -166,7 +166,7 @@ async def test_autodiscovered_option_flow(hass: HomeAssistant) -> None:
         config_entries.SOURCE_INTEGRATION_DISCOVERY,
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.BASIC_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.BASIC_OPTIONS)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     user_input = {CONF_CREATE_ENERGY_SENSOR: False}

--- a/tests/config_flow/test_global_configuration.py
+++ b/tests/config_flow/test_global_configuration.py
@@ -9,7 +9,7 @@ from homeassistant.const import CONF_ENTITY_ID, CONF_NAME, CONF_UNIQUE_ID, STATE
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_CREATE_DOMAIN_GROUPS,
     CONF_CREATE_ENERGY_SENSORS,
@@ -64,7 +64,7 @@ async def test_config_flow(hass: HomeAssistant) -> None:
     """Test full configuration flow."""
     await run_powercalc_setup(hass, {}, {})
 
-    result = await select_menu_item(hass, Steps.GLOBAL_CONFIGURATION)
+    result = await select_menu_item(hass, Step.GLOBAL_CONFIGURATION)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -78,7 +78,7 @@ async def test_config_flow(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.GLOBAL_CONFIGURATION_ENERGY
+    assert result["step_id"] == Step.GLOBAL_CONFIGURATION_ENERGY
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -88,7 +88,7 @@ async def test_config_flow(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.GLOBAL_CONFIGURATION_UTILITY_METER
+    assert result["step_id"] == Step.GLOBAL_CONFIGURATION_UTILITY_METER
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -134,15 +134,15 @@ async def test_config_flow(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "user_input,expected_step",
     [
-        ({CONF_CREATE_ENERGY_SENSORS: False, CONF_CREATE_UTILITY_METERS: True}, Steps.GLOBAL_CONFIGURATION_UTILITY_METER),
-        ({CONF_CREATE_ENERGY_SENSORS: True, CONF_CREATE_UTILITY_METERS: True}, Steps.GLOBAL_CONFIGURATION_ENERGY),
-        ({CONF_CREATE_ENERGY_SENSORS: True, CONF_CREATE_UTILITY_METERS: False}, Steps.GLOBAL_CONFIGURATION_ENERGY),
+        ({CONF_CREATE_ENERGY_SENSORS: False, CONF_CREATE_UTILITY_METERS: True}, Step.GLOBAL_CONFIGURATION_UTILITY_METER),
+        ({CONF_CREATE_ENERGY_SENSORS: True, CONF_CREATE_UTILITY_METERS: True}, Step.GLOBAL_CONFIGURATION_ENERGY),
+        ({CONF_CREATE_ENERGY_SENSORS: True, CONF_CREATE_UTILITY_METERS: False}, Step.GLOBAL_CONFIGURATION_ENERGY),
         ({CONF_CREATE_ENERGY_SENSORS: False, CONF_CREATE_UTILITY_METERS: False}, None),
     ],
 )
-async def test_energy_and_utility_options_skipped(hass: HomeAssistant, user_input: dict[str, Any], expected_step: Steps | None) -> None:
+async def test_energy_and_utility_options_skipped(hass: HomeAssistant, user_input: dict[str, Any], expected_step: Step | None) -> None:
     """Test the energy and utility_meter options are only shown when relevant."""
-    result = await select_menu_item(hass, Steps.GLOBAL_CONFIGURATION)
+    result = await select_menu_item(hass, Step.GLOBAL_CONFIGURATION)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -165,7 +165,7 @@ async def test_initialize_options_succeeds_with_yaml_sensors_in_config(hass: Hom
 
     await run_powercalc_setup(hass, get_simple_fixed_config("input_boolean.test", 50), {})
 
-    result = await initialize_options_flow(hass, entry, Steps.GLOBAL_CONFIGURATION)
+    result = await initialize_options_flow(hass, entry, Step.GLOBAL_CONFIGURATION)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
@@ -180,7 +180,7 @@ async def test_global_configuration_can_only_be_configured_once(hass: HomeAssist
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
     )
-    assert Steps.GLOBAL_CONFIGURATION not in result["menu_options"]
+    assert Step.GLOBAL_CONFIGURATION not in result["menu_options"]
 
 
 async def test_basic_options_flow(hass: HomeAssistant) -> None:
@@ -190,7 +190,7 @@ async def test_basic_options_flow(hass: HomeAssistant) -> None:
         {},
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.GLOBAL_CONFIGURATION)
+    result = await initialize_options_flow(hass, entry, Step.GLOBAL_CONFIGURATION)
 
     user_input = {
         CONF_POWER_SENSOR_PRECISION: 4,
@@ -236,7 +236,7 @@ async def test_energy_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.GLOBAL_CONFIGURATION_ENERGY)
+    result = await initialize_options_flow(hass, entry, Step.GLOBAL_CONFIGURATION_ENERGY)
 
     user_input = {
         CONF_ENERGY_INTEGRATION_METHOD: ENERGY_INTEGRATION_METHOD_TRAPEZODIAL,
@@ -266,7 +266,7 @@ async def test_utility_meter_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.GLOBAL_CONFIGURATION_UTILITY_METER)
+    result = await initialize_options_flow(hass, entry, Step.GLOBAL_CONFIGURATION_UTILITY_METER)
 
     user_input = {
         CONF_UTILITY_METER_TYPES: [DAILY],
@@ -328,7 +328,7 @@ async def test_entities_are_reloaded_reflecting_changes(hass: HomeAssistant) -> 
 
     assert hass.states.get("sensor.test_power").state == "50.00"
 
-    result = await initialize_options_flow(hass, global_config_entry, Steps.GLOBAL_CONFIGURATION)
+    result = await initialize_options_flow(hass, global_config_entry, Step.GLOBAL_CONFIGURATION)
 
     user_input = {
         CONF_POWER_SENSOR_PRECISION: 4,

--- a/tests/config_flow/test_group.py
+++ b/tests/config_flow/test_group.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.selector import SelectSelector
 from pytest_homeassistant_custom_component.common import MockConfigEntry, mock_registry
 
 from custom_components.powercalc import SensorType, async_migrate_entry
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     ATTR_ENTITIES,
     CONF_AREA,
@@ -67,7 +67,7 @@ from tests.config_flow.common import (
 
 
 async def test_create_group_entry(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     user_input = {
         CONF_NAME: "My group sensor",
         CONF_UNIQUE_ID: DEFAULT_UNIQUE_ID,
@@ -84,6 +84,7 @@ async def test_create_group_entry(hass: HomeAssistant) -> None:
         CONF_HIDE_MEMBERS: False,
         CONF_FORCE_CALCULATE_GROUP_ENERGY: False,
         CONF_GROUP_POWER_ENTITIES: ["sensor.balcony_power", "sensor.bedroom1_power"],
+        CONF_GROUP_TYPE: GroupType.CUSTOM,
         CONF_UNIQUE_ID: DEFAULT_UNIQUE_ID,
         CONF_INCLUDE_NON_POWERCALC_SENSORS: True,
         CONF_CREATE_ENERGY_SENSOR: True,
@@ -95,7 +96,7 @@ async def test_create_group_entry(hass: HomeAssistant) -> None:
 
 
 async def test_create_group_entry_without_unique_id(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     user_input = {
         CONF_NAME: "My group sensor",
         CONF_GROUP_POWER_ENTITIES: ["sensor.balcony_power"],
@@ -110,6 +111,7 @@ async def test_create_group_entry_without_unique_id(hass: HomeAssistant) -> None
         CONF_NAME: "My group sensor",
         CONF_HIDE_MEMBERS: False,
         CONF_GROUP_POWER_ENTITIES: ["sensor.balcony_power"],
+        CONF_GROUP_TYPE: GroupType.CUSTOM,
         CONF_FORCE_CALCULATE_GROUP_ENERGY: False,
         CONF_INCLUDE_NON_POWERCALC_SENSORS: True,
         CONF_CREATE_ENERGY_SENSOR: True,
@@ -127,7 +129,7 @@ async def test_create_energy_sensor_enabled(hass: HomeAssistant) -> None:
     """
     await run_powercalc_setup(hass, {}, {CONF_CREATE_ENERGY_SENSORS: False})
 
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     user_input = {
         CONF_NAME: "My group sensor",
         CONF_GROUP_POWER_ENTITIES: ["sensor.balcony_power"],
@@ -166,7 +168,7 @@ async def test_group_include_area(
         {CONF_STATES_POWER: {"playing": 1.8}},
     )
 
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     user_input = {
         CONF_NAME: "My group sensor",
         CONF_AREA: area.id,
@@ -188,6 +190,7 @@ async def test_group_include_area(
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_SENSOR_TYPE: SensorType.GROUP,
+        CONF_GROUP_TYPE: GroupType.CUSTOM,
         CONF_NAME: "My group sensor",
         CONF_HIDE_MEMBERS: False,
         CONF_FORCE_CALCULATE_GROUP_ENERGY: False,
@@ -235,7 +238,7 @@ async def test_can_unset_area(hass: HomeAssistant, area_registry: AreaRegistry) 
         CONF_AREA: "My area",
     }
 
-    result = await initialize_options_flow(hass, config_entry, Steps.GROUP)
+    result = await initialize_options_flow(hass, config_entry, Step.GROUP_CUSTOM)
 
     user_input = {}
     await hass.config_entries.options.async_configure(
@@ -280,7 +283,7 @@ async def test_include_area_powercalc_only(
 
     await setup_config_entry(hass, {CONF_ENTITY_ID: "switch.switch", CONF_NAME: "Test", CONF_FIXED: {CONF_POWER: 5}})
 
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     user_input = {
         CONF_NAME: "My group sensor",
         CONF_AREA: area.id,
@@ -335,7 +338,7 @@ async def test_can_select_existing_powercalc_entry_as_group_member(
     assert await hass.config_entries.async_setup(config_entry_3.entry_id)
     await hass.async_block_till_done()
 
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     data_schema: vol.Schema = result["data_schema"]
     select: SelectSelector = data_schema.schema[CONF_GROUP_MEMBER_SENSORS]
@@ -356,6 +359,7 @@ async def test_can_select_existing_powercalc_entry_as_group_member(
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_SENSOR_TYPE: SensorType.GROUP,
+        CONF_GROUP_TYPE: GroupType.CUSTOM,
         CONF_NAME: "My group sensor",
         CONF_FORCE_CALCULATE_GROUP_ENERGY: False,
         CONF_HIDE_MEMBERS: False,
@@ -392,7 +396,7 @@ async def test_real_power_entry_selectable_as_group_member(
     assert await hass.config_entries.async_setup(config_entry_2.entry_id)
     await hass.async_block_till_done()
 
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     data_schema: vol.Schema = result["data_schema"]
     select: SelectSelector = data_schema.schema[CONF_GROUP_MEMBER_SENSORS]
@@ -420,7 +424,7 @@ async def test_real_power_entry_selectable_as_group_member(
 
 
 async def test_group_error_mandatory(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
     user_input = {CONF_NAME: "My group sensor"}
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -449,7 +453,7 @@ async def test_subgroup_selector(hass: HomeAssistant) -> None:
     )
 
     # Initialize a new config flow
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
 
     # Assert the two existing groups can be selected as subgroup
     data_schema: vol.Schema = result["data_schema"]
@@ -471,7 +475,7 @@ async def test_subgroup_selector(hass: HomeAssistant) -> None:
 
     # Initialize the options flow for the newly created group
     new_entry: ConfigEntry = result["result"]
-    result = await initialize_options_flow(hass, new_entry, Steps.GROUP)
+    result = await initialize_options_flow(hass, new_entry, Step.GROUP_CUSTOM)
 
     # Assert that the group itself is not selectable as subgroup
     data_schema: vol.Schema = result["data_schema"]
@@ -494,13 +498,13 @@ async def test_group_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.BASIC_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.BASIC_OPTIONS)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_CREATE_UTILITY_METERS: True},
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.GROUP)
+    result = await initialize_options_flow(hass, entry, Step.GROUP_CUSTOM)
 
     new_entities = ["sensor.fridge_power", "sensor.kitchen_lights_power"]
     user_input = {CONF_GROUP_POWER_ENTITIES: new_entities}
@@ -520,7 +524,7 @@ async def test_field_defaults_from_global_powercalc_config(hass: HomeAssistant) 
     """Check that the toggle is default disabled when we set include_non_powercalc_sensors globally to false"""
     await run_powercalc_setup(hass, {}, {CONF_INCLUDE_NON_POWERCALC_SENSORS: False})
 
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_CUSTOM)
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
@@ -591,7 +595,7 @@ async def test_no_group_created_when_group_null(hass: HomeAssistant) -> None:
 
 async def test_domain_group_flow(hass: HomeAssistant) -> None:
     """Test the group flow for a domain."""
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.DOMAIN_GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_DOMAIN)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     user_input = {
@@ -622,6 +626,6 @@ async def test_domain_group_flow(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.MENU
-    assert Steps.BASIC_OPTIONS in result["menu_options"]
-    assert Steps.GROUP not in result["menu_options"]
-    assert Steps.UTILITY_METER_OPTIONS not in result["menu_options"]
+    assert Step.BASIC_OPTIONS in result["menu_options"]
+    assert Step.GROUP_CUSTOM not in result["menu_options"]
+    assert Step.UTILITY_METER_OPTIONS not in result["menu_options"]

--- a/tests/config_flow/test_group_subtract.py
+++ b/tests/config_flow/test_group_subtract.py
@@ -8,7 +8,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from custom_components.powercalc import SensorType
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_CREATE_ENERGY_SENSOR,
     CONF_CREATE_UTILITY_METERS,
@@ -25,7 +25,7 @@ from tests.config_flow.common import (
 
 async def test_subtract_group_flow(hass: HomeAssistant) -> None:
     """Test the subtract group flow."""
-    result = await select_menu_item(hass, Steps.MENU_GROUP, Steps.SUBTRACT_GROUP)
+    result = await select_menu_item(hass, Step.MENU_GROUP, Step.GROUP_SUBTRACT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     user_input = {
@@ -59,9 +59,9 @@ async def test_subtract_group_flow(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.MENU
-    assert Steps.BASIC_OPTIONS in result["menu_options"]
-    assert Steps.GROUP not in result["menu_options"]
-    assert Steps.UTILITY_METER_OPTIONS not in result["menu_options"]
+    assert Step.BASIC_OPTIONS in result["menu_options"]
+    assert Step.GROUP_CUSTOM not in result["menu_options"]
+    assert Step.UTILITY_METER_OPTIONS not in result["menu_options"]
 
 
 async def test_options_flow(hass: HomeAssistant) -> None:
@@ -76,7 +76,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.SUBTRACT_GROUP)
+    result = await initialize_options_flow(hass, entry, Step.GROUP_SUBTRACT)
 
     user_input = {
         CONF_ENTITY_ID: "sensor.outlet2",

--- a/tests/config_flow/test_menu.py
+++ b/tests/config_flow/test_menu.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from custom_components.powercalc import DOMAIN
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from tests.config_flow.common import select_menu_item
 
 
@@ -17,15 +17,15 @@ async def test_sensor_type_menu_displayed(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.MENU
-    assert result["step_id"] == Steps.USER
+    assert result["step_id"] == Step.USER
 
 
 @pytest.mark.parametrize(
     "menu_item",
-    [Steps.VIRTUAL_POWER, Steps.DAILY_ENERGY, Steps.MENU_GROUP],
+    [Step.VIRTUAL_POWER, Step.DAILY_ENERGY, Step.MENU_GROUP],
 )
 async def test_sensor_type_form_displayed(
     hass: HomeAssistant,
-    menu_item: Steps,
+    menu_item: Step,
 ) -> None:
     await select_menu_item(hass, menu_item)

--- a/tests/config_flow/test_real_power.py
+++ b/tests/config_flow/test_real_power.py
@@ -11,7 +11,7 @@ from pytest_homeassistant_custom_component.common import (
 )
 
 from custom_components.powercalc import CONF_CREATE_UTILITY_METERS, CONF_UTILITY_METER_TARIFFS, CONF_UTILITY_METER_TYPES, SensorType
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from tests.config_flow.common import (
     create_mock_entry,
     initialize_options_flow,
@@ -20,7 +20,7 @@ from tests.config_flow.common import (
 
 
 async def test_real_power(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.REAL_POWER)
+    result = await select_menu_item(hass, Step.REAL_POWER)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
@@ -73,7 +73,7 @@ async def test_energy_sensor_is_bound_to_power_device(hass: HomeAssistant) -> No
         },
     )
 
-    result = await select_menu_item(hass, Steps.REAL_POWER)
+    result = await select_menu_item(hass, Step.REAL_POWER)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
@@ -107,13 +107,13 @@ async def test_real_power_options(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.BASIC_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.BASIC_OPTIONS)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_CREATE_UTILITY_METERS: True},
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.REAL_POWER)
+    result = await initialize_options_flow(hass, entry, Step.REAL_POWER)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_ENTITY_ID: "sensor.my_new_real_power"},
@@ -159,7 +159,7 @@ async def test_attach_to_custom_device(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await select_menu_item(hass, Steps.REAL_POWER)
+    result = await select_menu_item(hass, Step.REAL_POWER)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     await hass.config_entries.flow.async_configure(
@@ -178,7 +178,7 @@ async def test_attach_to_custom_device(hass: HomeAssistant) -> None:
 
 
 async def test_no_error_is_raised_when_device_not_exists(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.REAL_POWER)
+    result = await select_menu_item(hass, Step.REAL_POWER)
     await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -194,7 +194,7 @@ async def test_no_error_is_raised_when_device_not_exists(hass: HomeAssistant) ->
 
 
 async def test_create_utility_meter_tariff_sensors(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.REAL_POWER)
+    result = await select_menu_item(hass, Step.REAL_POWER)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -206,7 +206,7 @@ async def test_create_utility_meter_tariff_sensors(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.UTILITY_METER_OPTIONS
+    assert result["step_id"] == Step.UTILITY_METER_OPTIONS
 
     await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/config_flow/test_smart_switch.py
+++ b/tests/config_flow/test_smart_switch.py
@@ -7,7 +7,7 @@ from homeassistant.const import CONF_ENTITY_ID, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from custom_components.powercalc import CONF_POWER
-from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Steps
+from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Step
 from custom_components.powercalc.const import (
     CONF_CREATE_ENERGY_SENSOR,
     CONF_CREATE_UTILITY_METERS,
@@ -51,7 +51,7 @@ async def test_smart_switch_flow(
         unique_id=DEFAULT_UNIQUE_ID,
     )
 
-    result = await select_menu_item(hass, Steps.MENU_LIBRARY)
+    result = await select_menu_item(hass, Step.MENU_LIBRARY)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -63,7 +63,7 @@ async def test_smart_switch_flow(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.LIBRARY
+    assert result["step_id"] == Step.LIBRARY
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -71,7 +71,7 @@ async def test_smart_switch_flow(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.SMART_SWITCH
+    assert result["step_id"] == Step.SMART_SWITCH
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -79,7 +79,7 @@ async def test_smart_switch_flow(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.POWER_ADVANCED
+    assert result["step_id"] == Step.POWER_ADVANCED
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -111,7 +111,7 @@ async def test_smart_switch_options(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.FIXED)
+    result = await initialize_options_flow(hass, entry, Step.FIXED)
 
     user_input = {CONF_POWER: 50, CONF_SELF_USAGE_INCLUDED: True}
     result = await hass.config_entries.options.async_configure(
@@ -140,7 +140,7 @@ async def test_smart_switch_options_correctly_loaded(hass: HomeAssistant) -> Non
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.FIXED)
+    result = await initialize_options_flow(hass, entry, Step.FIXED)
 
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys[schema_keys.index(CONF_SELF_USAGE_INCLUDED)].description == {

--- a/tests/config_flow/test_virtual_power_fixed.py
+++ b/tests/config_flow/test_virtual_power_fixed.py
@@ -6,7 +6,7 @@ from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
 
 from custom_components.powercalc import CONF_FIXED, CONF_POWER_TEMPLATE
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_CALCULATION_ENABLED_CONDITION,
     CONF_CREATE_UTILITY_METERS,
@@ -103,13 +103,13 @@ async def test_fixed_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.BASIC_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.BASIC_OPTIONS)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_ENTITY_ID: "light.test", CONF_CREATE_UTILITY_METERS: True},
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.FIXED)
+    result = await initialize_options_flow(hass, entry, Step.FIXED)
 
     user_input = {CONF_POWER: 50}
     await hass.config_entries.options.async_configure(
@@ -117,7 +117,7 @@ async def test_fixed_options_flow(hass: HomeAssistant) -> None:
         user_input=user_input,
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.ADVANCED_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.ADVANCED_OPTIONS)
     user_input = {CONF_IGNORE_UNAVAILABLE_STATE: True}
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -176,7 +176,7 @@ async def test_advanced_power_configuration_can_be_set(hass: HomeAssistant) -> N
 
 
 async def test_entity_selection_mandatory(hass: HomeAssistant) -> None:
-    result = await select_menu_item(hass, Steps.VIRTUAL_POWER)
+    result = await select_menu_item(hass, Step.VIRTUAL_POWER)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -198,7 +198,7 @@ async def test_global_configuration_is_applied_to_field_default(
     }
     await run_powercalc_setup(hass, {}, global_config)
 
-    result = await select_menu_item(hass, Steps.VIRTUAL_POWER)
+    result = await select_menu_item(hass, Step.VIRTUAL_POWER)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys[schema_keys.index(CONF_CREATE_UTILITY_METERS)].description == {
@@ -217,7 +217,7 @@ async def test_global_configuration_is_applied_to_field_default(
         {CONF_POWER: 50},
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.POWER_ADVANCED
+    assert result["step_id"] == Step.POWER_ADVANCED
     schema_keys: list[vol.Optional] = list(result["data_schema"].schema.keys())
     assert schema_keys[schema_keys.index(CONF_ENERGY_INTEGRATION_METHOD)].default() == ENERGY_INTEGRATION_METHOD_RIGHT
     assert schema_keys[schema_keys.index(CONF_IGNORE_UNAVAILABLE_STATE)].description == {"suggested_value": True}

--- a/tests/config_flow/test_virtual_power_library.py
+++ b/tests/config_flow/test_virtual_power_library.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.selector import SelectSelector
 
 from custom_components.powercalc.config_flow import (
     CONF_CONFIRM_AUTODISCOVERED_MODEL,
-    Steps,
+    Step,
 )
 from custom_components.powercalc.const import (
     CONF_MANUFACTURER,
@@ -40,9 +40,9 @@ async def test_manually_setup_from_library(
         unique_id=DEFAULT_UNIQUE_ID,
     )
 
-    result = await select_menu_item(hass, Steps.MENU_LIBRARY)
+    result = await select_menu_item(hass, Step.MENU_LIBRARY)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.VIRTUAL_POWER
+    assert result["step_id"] == Step.VIRTUAL_POWER
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -50,7 +50,7 @@ async def test_manually_setup_from_library(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.LIBRARY
+    assert result["step_id"] == Step.LIBRARY
 
     result = await set_virtual_power_configuration(
         hass,
@@ -73,9 +73,9 @@ async def test_manual_setup_from_library_skips_to_manufacturer_step(
         unique_id=DEFAULT_UNIQUE_ID,
     )
 
-    result = await select_menu_item(hass, Steps.MENU_LIBRARY)
+    result = await select_menu_item(hass, Step.MENU_LIBRARY)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.VIRTUAL_POWER
+    assert result["step_id"] == Step.VIRTUAL_POWER
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -83,7 +83,7 @@ async def test_manual_setup_from_library_skips_to_manufacturer_step(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
 
 
 async def test_manufacturer_listing_is_filtered_by_entity_domain(
@@ -95,7 +95,7 @@ async def test_manufacturer_listing_is_filtered_by_entity_domain(
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
     data_schema: vol.Schema = result["data_schema"]
     manufacturer_select: SelectSelector = data_schema.schema["manufacturer"]
     manufacturer_options = manufacturer_select.config["options"]
@@ -116,7 +116,7 @@ async def test_manufacturer_listing_is_filtered_by_entity_domain2(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
     data_schema: vol.Schema = result["data_schema"]
     manufacturer_select: SelectSelector = data_schema.schema["manufacturer"]
     manufacturer_options = manufacturer_select.config["options"]
@@ -157,7 +157,7 @@ async def test_change_manufacturer_model_from_options_flow(hass: HomeAssistant) 
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.LIBRARY_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.LIBRARY_OPTIONS)
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -165,7 +165,7 @@ async def test_change_manufacturer_model_from_options_flow(hass: HomeAssistant) 
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -173,7 +173,7 @@ async def test_change_manufacturer_model_from_options_flow(hass: HomeAssistant) 
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MODEL
+    assert result["step_id"] == Step.MODEL
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],

--- a/tests/config_flow/test_virtual_power_linear.py
+++ b/tests/config_flow/test_virtual_power_linear.py
@@ -2,7 +2,7 @@ from homeassistant import data_entry_flow
 from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_LINEAR,
     CONF_MAX_POWER,
@@ -61,7 +61,7 @@ async def test_linear_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.LINEAR)
+    result = await initialize_options_flow(hass, entry, Step.LINEAR)
 
     user_input = {CONF_MAX_POWER: 50}
     result = await hass.config_entries.options.async_configure(
@@ -84,7 +84,7 @@ async def test_linear_options_flow_error(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.LINEAR)
+    result = await initialize_options_flow(hass, entry, Step.LINEAR)
 
     user_input = {CONF_MIN_POWER: 55, CONF_MAX_POWER: 50}
     result = await hass.config_entries.options.async_configure(

--- a/tests/config_flow/test_virtual_power_lut.py
+++ b/tests/config_flow/test_virtual_power_lut.py
@@ -5,7 +5,7 @@ from homeassistant.const import CONF_ENTITY_ID, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import SelectSelector
 
-from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Steps
+from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Step
 from custom_components.powercalc.const import (
     CONF_CREATE_ENERGY_SENSOR,
     CONF_MANUFACTURER,
@@ -37,7 +37,7 @@ async def test_lut_manual_flow(hass: HomeAssistant) -> None:
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
     data_schema: vol.Schema = result["data_schema"]
     manufacturer_select: SelectSelector = data_schema.schema["manufacturer"]
     manufacturer_options = manufacturer_select.config["options"]
@@ -50,7 +50,7 @@ async def test_lut_manual_flow(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MODEL
+    assert result["step_id"] == Step.MODEL
     data_schema: vol.Schema = result["data_schema"]
     model_select: SelectSelector = data_schema.schema["model"]
     model_options = model_select.config["options"]
@@ -95,7 +95,7 @@ async def test_lut_autodiscover_flow(
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.LIBRARY
+    assert result["step_id"] == Step.LIBRARY
     assert result["description_placeholders"] == {
         "manufacturer": "ikea",
         "model": "LED1545G12",
@@ -128,7 +128,7 @@ async def test_lut_not_autodiscovered_model_unsupported(
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
 
 
 async def test_lut_not_autodiscovered(hass: HomeAssistant) -> None:
@@ -138,7 +138,7 @@ async def test_lut_not_autodiscovered(hass: HomeAssistant) -> None:
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
 
 
 async def test_lut_autodiscover_flow_not_confirmed(
@@ -158,7 +158,7 @@ async def test_lut_autodiscover_flow_not_confirmed(
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.LIBRARY
+    assert result["step_id"] == Step.LIBRARY
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -166,7 +166,7 @@ async def test_lut_autodiscover_flow_not_confirmed(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MANUFACTURER
+    assert result["step_id"] == Step.MANUFACTURER
 
 
 async def test_lut_flow_with_sub_profiles(
@@ -187,7 +187,7 @@ async def test_lut_flow_with_sub_profiles(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.SUB_PROFILE
+    assert result["step_id"] == Step.SUB_PROFILE
     data_schema: vol.Schema = result["data_schema"]
     model_select: SelectSelector = data_schema.schema["sub_profile"]
     select_options = model_select.config["options"]
@@ -221,7 +221,7 @@ async def test_lut_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.BASIC_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.BASIC_OPTIONS)
 
     user_input = {CONF_CREATE_ENERGY_SENSOR: False}
 

--- a/tests/config_flow/test_virtual_power_multi_switch.py
+++ b/tests/config_flow/test_virtual_power_multi_switch.py
@@ -10,7 +10,7 @@ from pytest_homeassistant_custom_component.common import mock_device_registry, m
 
 from custom_components.powercalc import DiscoveryManager
 from custom_components.powercalc.common import create_source_entity
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_MANUFACTURER,
     CONF_MODE,
@@ -75,7 +75,7 @@ async def test_discovery_flow(
     result = await initialize_discovery_flow(hass, source_entity, confirm_autodiscovered_model=True)
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == Steps.MULTI_SWITCH
+    assert result["step_id"] == Step.MULTI_SWITCH
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -159,7 +159,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.MULTI_SWITCH)
+    result = await initialize_options_flow(hass, entry, Step.MULTI_SWITCH)
 
     user_input = {CONF_POWER_OFF: 20, CONF_POWER: 5, CONF_ENTITIES: ["switch.a", "switch.c"]}
     result = await hass.config_entries.options.async_configure(

--- a/tests/config_flow/test_virtual_power_playbook.py
+++ b/tests/config_flow/test_virtual_power_playbook.py
@@ -2,7 +2,7 @@ from homeassistant import data_entry_flow
 from homeassistant.const import ATTR_ENTITY_ID, CONF_ENTITY_ID, STATE_IDLE, STATE_PLAYING
 from homeassistant.core import HomeAssistant
 
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_AUTOSTART,
     CONF_MODE,
@@ -82,7 +82,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.PLAYBOOK)
+    result = await initialize_options_flow(hass, entry, Step.PLAYBOOK)
 
     user_input = {
         CONF_PLAYBOOKS: {

--- a/tests/config_flow/test_virtual_power_wled.py
+++ b/tests/config_flow/test_virtual_power_wled.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 import custom_components.test.sensor as test_sensor_platform
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_MANUFACTURER,
     CONF_MODE,
@@ -66,7 +66,7 @@ async def test_wled_options_flow(hass: HomeAssistant) -> None:
         },
     )
 
-    result = await initialize_options_flow(hass, entry, Steps.WLED)
+    result = await initialize_options_flow(hass, entry, Step.WLED)
 
     user_input = {CONF_VOLTAGE: 12}
     result = await hass.config_entries.options.async_configure(

--- a/tests/power_profile/device_types/test_smart_dimmer.py
+++ b/tests/power_profile/device_types/test_smart_dimmer.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.powercalc import CONF_IGNORE_UNAVAILABLE_STATE, async_setup_entry
-from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Steps
+from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Step
 from custom_components.powercalc.const import (
     CONF_CUSTOM_MODEL_DIRECTORY,
     CONF_LINEAR,
@@ -114,14 +114,14 @@ async def test_smart_dimmer_power_input_gui_config_flow(
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     flow = flows[0]
 
-    assert flow["step_id"] == Steps.LIBRARY
+    assert flow["step_id"] == Step.LIBRARY
     result = await hass.config_entries.flow.async_configure(
         flow["flow_id"],
         {CONF_CONFIRM_AUTODISCOVERED_MODEL: True},
     )
 
     # After confirming the manufacturer/model we must be directed to the linear config step
-    assert result["step_id"] == Steps.LINEAR
+    assert result["step_id"] == Step.LINEAR
     result = await hass.config_entries.flow.async_configure(
         flow["flow_id"],
         {CONF_MIN_POWER: 2, CONF_MAX_POWER: 50},
@@ -149,7 +149,7 @@ async def test_smart_dimmer_power_input_gui_config_flow(
     assert hass.states.get(power_sensor_id).state == "0.30"
 
     # Change the power value via the options
-    result = await initialize_options_flow(hass, config_entry, Steps.LINEAR)
+    result = await initialize_options_flow(hass, config_entry, Step.LINEAR)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_MIN_POWER: 4, CONF_MAX_POWER: 40},

--- a/tests/power_profile/device_types/test_smart_switch.py
+++ b/tests/power_profile/device_types/test_smart_switch.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.powercalc import async_setup_entry
-from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Steps
+from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Step
 from custom_components.powercalc.const import (
     CONF_CUSTOM_MODEL_DIRECTORY,
     CONF_FIXED,
@@ -138,14 +138,14 @@ async def test_smart_switch_power_input_gui_config_flow(
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     flow = flows[0]
 
-    assert flow["step_id"] == Steps.LIBRARY
+    assert flow["step_id"] == Step.LIBRARY
     result = await hass.config_entries.flow.async_configure(
         flow["flow_id"],
         {CONF_CONFIRM_AUTODISCOVERED_MODEL: True},
     )
 
     # After confirming the manufacturer/model we must be directed to the fixed config step
-    assert result["step_id"] == Steps.FIXED
+    assert result["step_id"] == Step.FIXED
     result = await hass.config_entries.flow.async_configure(
         flow["flow_id"],
         {CONF_POWER: 50},
@@ -172,7 +172,7 @@ async def test_smart_switch_power_input_gui_config_flow(
     assert hass.states.get(power_sensor_id).state == "0.23"
 
     # Change the power value via the options
-    result = await initialize_options_flow(hass, config_entry, Steps.FIXED)
+    result = await initialize_options_flow(hass, config_entry, Step.FIXED)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_POWER: 100},

--- a/tests/strategy/test_wled.py
+++ b/tests/strategy/test_wled.py
@@ -17,7 +17,7 @@ from pytest_homeassistant_custom_component.common import (
 
 import custom_components.test.sensor as test_sensor_platform
 from custom_components.powercalc.common import create_source_entity
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_POWER_FACTOR,
     CONF_VOLTAGE,
@@ -198,7 +198,7 @@ async def test_wled_autodiscovery_flow(hass: HomeAssistant, caplog: pytest.LogCa
     flow = flows[0]
     context = flow["context"]
     assert context["source"] == SOURCE_INTEGRATION_DISCOVERY
-    assert flow["step_id"] == Steps.WLED
+    assert flow["step_id"] == Step.WLED
 
     result = await hass.config_entries.flow.async_configure(
         flow["flow_id"],

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -42,7 +42,7 @@ from pytest_homeassistant_custom_component.common import (
     mock_registry,
 )
 
-from custom_components.powercalc.config_flow import Steps
+from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     ATTR_CALCULATION_MODE,
     ATTR_ENTITIES,
@@ -623,7 +623,7 @@ async def test_change_options_of_renamed_sensor(
 
     assert hass.states.get("sensor.test_energy_daily").name == "Renamed daily utility meter"
 
-    result = await initialize_options_flow(hass, entry, Steps.FIXED)
+    result = await initialize_options_flow(hass, entry, Step.FIXED)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_POWER: 100},
@@ -833,14 +833,14 @@ async def test_change_config_entry_entity_id(hass: HomeAssistant) -> None:
     assert power_state.state == "50.00"
 
     # Change the entity_id using the options flow
-    result = await initialize_options_flow(hass, entry, Steps.BASIC_OPTIONS)
+    result = await initialize_options_flow(hass, entry, Step.BASIC_OPTIONS)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_ENTITY_ID: new_light_id},
     )
     await hass.async_block_till_done()
 
-    result = await initialize_options_flow(hass, entry, Steps.FIXED)
+    result = await initialize_options_flow(hass, entry, Step.FIXED)
     await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_POWER: 100},


### PR DESCRIPTION
- Abstract some duplicate logic away into generic steps
- Rename `Steps` enum to `Step`
- Rename group steps to a more logical naming convention
- Fixes menu translations

Still this file is huge, will see if we can split up in future PR.