### PR TITLE
add Pnet to Lidl HG08131A

### DIFF
--- a/profile_library/lidl/HG08131A/model.json
+++ b/profile_library/lidl/HG08131A/model.json
@@ -10,6 +10,6 @@
     "VERSION": "master"
   },
   "name": "Livarno Lux GU10 5W RGBCT Bulb",
-  "standby_power": 0.50,
+  "standby_power": 0.5,
   "author": "RubenKelevra <cyrond@gmail.com>"
 }

--- a/profile_library/lidl/HG08131A/model.json
+++ b/profile_library/lidl/HG08131A/model.json
@@ -1,6 +1,6 @@
 {
   "calculation_strategy": "lut",
-  "created_at": "2024-11-11T10:11:31.340774",
+  "created_at": "2024-12-15T13:56:00.0",
   "measure_description": "Measured with utils/measure script",
   "measure_device": "Shelly Plug",
   "measure_method": "script",
@@ -10,6 +10,6 @@
     "VERSION": "master"
   },
   "name": "Livarno Lux GU10 5W RGBCT Bulb",
-  "standby_power": 0.03,
+  "standby_power": 0.50,
   "author": "RubenKelevra <cyrond@gmail.com>"
 }


### PR DESCRIPTION
Replaces the wrongly measured standby consumption by the official number from the spec sheet:

![24e37aa295b4b882d1a455c3b56e0bcb](https://github.com/user-attachments/assets/3bd7bed2-ab56-4faa-92ff-3d4e60782670)


@bramstroker Quick and dirty fix, until I've remeasured the light. I wanted to do some improvements on the measure script before, and need time to set the measurement up.

BTW: Probably the best spec sheet for a LED light I've ever seen. Also: They sell those as CRI >= 95 RA lamps, but they have a measured CRI of 98.3. Pretty wild.