### PR TITLE
fix: sets option flow config_entry explicitly

### DIFF
--- a/custom_components/powercalc/config_flow.py
+++ b/custom_components/powercalc/config_flow.py
@@ -1543,7 +1543,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
         super().__init__()
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self.sensor_config = dict(config_entry.data)
         self.sensor_type: SensorType = self.sensor_config.get(CONF_SENSOR_TYPE) or SensorType.VIRTUAL_POWER
         self.source_entity_id: str = self.sensor_config.get(CONF_ENTITY_ID)  # type: ignore
@@ -1554,11 +1554,11 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
         user_input: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle options flow."""
-        if self.config_entry.unique_id == ENTRY_GLOBAL_CONFIG_UNIQUE_ID:
+        if self._config_entry.unique_id == ENTRY_GLOBAL_CONFIG_UNIQUE_ID:
             self.global_config = self.get_global_powercalc_config()
             return self.async_show_menu(step_id=Step.INIT, menu_options=self.build_global_config_menu())
 
-        self.sensor_config = dict(self.config_entry.data)
+        self.sensor_config = dict(self._config_entry.data)
         if self.source_entity_id:
             self.source_entity = await create_source_entity(
                 self.source_entity_id,
@@ -1686,7 +1686,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
     async def async_step_group_custom(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the group options flow."""
         schema = self.fill_schema_defaults(
-            self.create_schema_group_custom(self.config_entry, True),
+            self.create_schema_group_custom(self._config_entry, True),
             self.sensor_config,
         )
         return await self.async_handle_options_step(user_input, schema, Step.GROUP_CUSTOM)
@@ -1768,10 +1768,10 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
 
     def persist_config_entry(self) -> FlowResult:
         """Persist changed options on the config entry."""
-        data = (self.config_entry.unique_id == ENTRY_GLOBAL_CONFIG_UNIQUE_ID and self.global_config) or self.sensor_config
+        data = (self._config_entry.unique_id == ENTRY_GLOBAL_CONFIG_UNIQUE_ID and self.global_config) or self.sensor_config
 
         self.hass.config_entries.async_update_entry(
-            self.config_entry,
+            self._config_entry,
             data=data,
         )
         return self.async_create_entry(title="", data={})


### PR DESCRIPTION
Fixes:

```
Logger: homeassistant.helpers.frame
Quelle: helpers/frame.py:324
Erstmals aufgetreten: 16:42:26 (1 Vorkommnisse)
Zuletzt protokolliert: 16:42:26

Detected that custom integration 'powercalc' sets option flow config_entry explicitly, which is deprecated at custom_components/powercalc/config_flow.py, line 1546: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/bramstroker/homeassistant-powercalc/issues
```