### PR TITLE
Added manufacturer alias. Added model IDs to device aliases.

### DIFF
--- a/profile_library/shelly/Shelly 3EM/model.json
+++ b/profile_library/shelly/Shelly 3EM/model.json
@@ -8,11 +8,14 @@
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
   },
-  "device_type": "smart_switch",
+  "device_type": "energy_meter",
   "calculation_strategy": "fixed",
   "fixed_config": {
     "power": 1.22
   },
+  "aliases": [
+    "SHEM-3"
+  ],
   "created_at": "2024-12-01T18:27:00",
   "author": "RubenKelevra <cyrond@gmail.com>"
 }

--- a/profile_library/shelly/Shelly 3EM/model.json
+++ b/profile_library/shelly/Shelly 3EM/model.json
@@ -8,7 +8,7 @@
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
   },
-  "device_type": "energy_meter",
+  "device_type": "power_meter",
   "calculation_strategy": "fixed",
   "fixed_config": {
     "power": 1.22

--- a/profile_library/shelly/manufacturer.json
+++ b/profile_library/shelly/manufacturer.json
@@ -1,4 +1,6 @@
 {
   "name": "shelly",
-  "aliases": ["Allterco Robotics"]
+  "aliases": [
+    "Allterco Robotics"
+  ]
 }

--- a/profile_library/shelly/manufacturer.json
+++ b/profile_library/shelly/manufacturer.json
@@ -1,4 +1,4 @@
 {
   "name": "shelly",
-  "aliases": []
+  "aliases": ["Allterco Robotics"]
 }

--- a/profile_library/shelly/shelly plug s/model.json
+++ b/profile_library/shelly/shelly plug s/model.json
@@ -13,6 +13,9 @@
   "fixed_config": {
     "power": 0.89
   },
+  "aliases": [
+    "SHPLG-S"
+  ],
   "created_at": "2024-12-01T18:15:00",
   "author": "RubenKelevra <cyrond@gmail.com>"
 }

--- a/profile_library/shelly/shelly plus plug s/model.json
+++ b/profile_library/shelly/shelly plus plug s/model.json
@@ -1,5 +1,5 @@
 {
-  "measure_description": "Manually measured. (LED off). Transcribed from https://www.youtube.com/watch?v=cLtao6yG7ds",
+  "measure_description": "Manually measured. (LED off). Transcribed from https://www.youtube.com/watch?v=cLtao6yG7ds. V2 added to V1 since the manufacturer doesn't mention other changes than mechanical",
   "measure_method": "manual",
   "measure_device": "GW Instek GPM-8310",
   "name": "Shelly Plus Plug S",
@@ -13,6 +13,11 @@
   "fixed_config": {
     "power": 1.01
   },
+  "aliases": [
+    "Shelly Plus Plug S V2",
+    "SNPL-00112EU",
+    "SNPL-10112EU"
+  ],
   "created_at": "2024-12-01T18:36:00",
   "author": "RubenKelevra <cyrond@gmail.com>"
 }


### PR DESCRIPTION
* Extended existing profiles with aliases to match shelly device ids. 
* added Allterco to the manufacturer alias, since Shelly is not a manufacturer.
* changed `smart_switch` to `energy_meter` for Shelly 3EM as discussed over here: https://github.com/bramstroker/homeassistant-powercalc/discussions/2862#discussioncomment-11684724