### PR TITLE
Implement per device discovery

### DIFF
--- a/custom_components/powercalc/discovery.py
+++ b/custom_components/powercalc/discovery.py
@@ -337,8 +337,9 @@ class DiscoveryManager:
         )
         return model_info
 
-    async def get_model_information_from_device(self, device_entry: dr.DeviceEntry) -> ModelInfo | None:
-        """See if we have enough information in device registry to automatically setup the power sensor."""
+    @staticmethod
+    async def get_model_information_from_device(device_entry: dr.DeviceEntry) -> ModelInfo | None:
+        """See if we have enough information in device registry to automatically set up the power sensor."""
         if device_entry.manufacturer is None or device_entry.model is None:
             return None
 

--- a/custom_components/powercalc/discovery.py
+++ b/custom_components/powercalc/discovery.py
@@ -92,11 +92,13 @@ class DiscoveryManager:
     async def start_discovery(self) -> None:
         """Start the discovery procedure."""
 
+        # Build a list of config entries which are already setup, to prevent duplicate discovery flows
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if entry.unique_id:
                 self.initialized_flows.add(entry.unique_id)
-                if str(entry.data.get(CONF_ENTITY_ID)) != DUMMY_ENTITY_ID:
-                    self.initialized_flows.add(str(entry.data.get(CONF_ENTITY_ID)))
+                entity_id = str(entry.data.get(CONF_ENTITY_ID))
+                if entity_id != DUMMY_ENTITY_ID:
+                    self.initialized_flows.add(entity_id)
 
         _LOGGER.debug("Start auto discovery")
 

--- a/custom_components/powercalc/power_profile/power_profile.py
+++ b/custom_components/powercalc/power_profile/power_profile.py
@@ -46,6 +46,11 @@ class DeviceType(StrEnum):
     VACUUM_ROBOT = "vacuum_robot"
 
 
+class DiscoveryType(StrEnum):
+    DEVICE = "device"
+    ENTITY = "entity"
+
+
 class SubProfileMatcherType(StrEnum):
     ATTRIBUTE = "attribute"
     ENTITY_ID = "entity_id"
@@ -226,6 +231,10 @@ class PowerProfile:
         except ValueError:
             _LOGGER.warning("Unknown device type: %s", device_type)
             return None
+
+    @property
+    def discovery_type(self) -> DiscoveryType:
+        return DiscoveryType(self._json_data.get("discovery_type", DiscoveryType.ENTITY))
 
     @property
     def config_flow_discovery_remarks(self) -> str | None:

--- a/custom_components/powercalc/power_profile/power_profile.py
+++ b/custom_components/powercalc/power_profile/power_profile.py
@@ -46,7 +46,7 @@ class DeviceType(StrEnum):
     VACUUM_ROBOT = "vacuum_robot"
 
 
-class DiscoveryType(StrEnum):
+class DiscoveryBy(StrEnum):
     DEVICE = "device"
     ENTITY = "entity"
 
@@ -233,8 +233,8 @@ class PowerProfile:
             return None
 
     @property
-    def discovery_type(self) -> DiscoveryType:
-        return DiscoveryType(self._json_data.get("discovery_type", DiscoveryType.ENTITY))
+    def discovery_by(self) -> DiscoveryBy:
+        return DiscoveryBy(self._json_data.get("discovery_by", DiscoveryBy.ENTITY))
 
     @property
     def config_flow_discovery_remarks(self) -> str | None:

--- a/custom_components/powercalc/power_profile/power_profile.py
+++ b/custom_components/powercalc/power_profile/power_profile.py
@@ -36,6 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 class DeviceType(StrEnum):
     CAMERA = "camera"
     COVER = "cover"
+    GENERIC_IOT = "generic_iot"
     LIGHT = "light"
     POWER_METER = "power_meter"
     PRINTER = "printer"
@@ -61,6 +62,7 @@ class SubProfileMatcherType(StrEnum):
 DEVICE_TYPE_DOMAIN = {
     DeviceType.CAMERA: CAMERA_DOMAIN,
     DeviceType.COVER: COVER_DOMAIN,
+    DeviceType.GENERIC_IOT: SENSOR_DOMAIN,
     DeviceType.LIGHT: LIGHT_DOMAIN,
     DeviceType.POWER_METER: SENSOR_DOMAIN,
     DeviceType.SMART_DIMMER: LIGHT_DOMAIN,

--- a/custom_components/powercalc/sensors/power.py
+++ b/custom_components/powercalc/sensors/power.py
@@ -209,7 +209,7 @@ async def _get_power_profile(
 
     power_profile = None
     try:
-        model_info = await discovery_manager.extract_model_info_from_entity(source_entity.entity_entry)
+        model_info = await discovery_manager.extract_model_info_from_device_info(source_entity.entity_entry)
         power_profile = await get_power_profile(
             hass,
             sensor_config,

--- a/docs/source/library/device-types/genericiiot.md
+++ b/docs/source/library/device-types/genericiiot.md
@@ -1,0 +1,30 @@
+# Power meter
+
+Generic IoT device.
+Powercalc profiles can be used to define the self usage of the IoT device itself.
+
+## JSON
+
+```json
+{
+  "standby_power": 0.3,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "power_meter",
+  "calculation_strategy": "fixed",
+  "discovery_by": "device",
+  "fixed_config": {
+    "power": 0.3
+  }
+}
+```
+
+!!! note
+    Required fields are omitted in this example for brevity. For the full list of required fields see the [model structure](../structure.md)
+
+!!! note
+    The `discovery_by` field is set to `device` to prevent multiple discoveries for the same device.
+
+Following the example above the power for this device will always be 0.3W.

--- a/docs/source/library/device-types/index.md
+++ b/docs/source/library/device-types/index.md
@@ -6,7 +6,7 @@ Here you can find information about how to setup specific device types for the l
 
 ## :material-blinds-horizontal: Cover
 
-Generic IoT
+## :material-access-point: Generic IoT
 
 ## :material-lightbulb: [Light](light.md)
 

--- a/docs/source/library/device-types/index.md
+++ b/docs/source/library/device-types/index.md
@@ -6,6 +6,8 @@ Here you can find information about how to setup specific device types for the l
 
 ## :material-blinds-horizontal: Cover
 
+Generic IoT
+
 ## :material-lightbulb: [Light](light.md)
 
 ## :material-meter-electric: [Power meter](power-meter.md)

--- a/docs/source/library/device-types/index.md
+++ b/docs/source/library/device-types/index.md
@@ -6,7 +6,7 @@ Here you can find information about how to setup specific device types for the l
 
 ## :material-blinds-horizontal: Cover
 
-## :material-access-point: Generic IoT
+## :material-access-point: [Generic IoT](generic-iot.md)
 
 ## :material-lightbulb: [Light](light.md)
 

--- a/docs/source/library/device-types/power-meter.md
+++ b/docs/source/library/device-types/power-meter.md
@@ -11,8 +11,9 @@ Smart power meter. Powercalc profiles can be used to define the self usage of th
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
   },
-  "device_type": "smart_switch",
+  "device_type": "power_meter",
   "calculation_strategy": "fixed",
+  "discovery_by": "device",
   "fixed_config": {
     "power": 0.3
   }

--- a/docs/source/library/library.md
+++ b/docs/source/library/library.md
@@ -5,7 +5,7 @@ You can find the list of supported devices on the dedicated [library viewer](htt
 This library will keep extending by the effort of community users.
 
 At startup Powercalc will scan your HA installation and tries to match if any of them are in the library,
-when found it will provide a discovery flow for you to setup.
+when found it will provide a discovery flow for you to setup. More info about the discovery process can be found [here](#discovery).
 You can also setup Powercalc sensors for a entity manually, see [Virtual power library](../sensor-types/virtual-power-library.md).
 
 Starting from version 1.12.0 all the power profiles are moved out of the component and are downloaded from the internet on demand.
@@ -19,7 +19,7 @@ Also you only need to download the profiles you actually use, saving bandwidth a
 
 For more information about the library structure, See [structure](structure.md).
 
-To contribute see the [measure](../contributing/measure.md) section.
+To contribute new profiles see the [measure](../contributing/measure.md) section.
 
 More information about how to setup specific device types can be found in the [device types](device-types/index.md) section.
 

--- a/docs/source/library/library.md
+++ b/docs/source/library/library.md
@@ -63,7 +63,7 @@ You will have to manage the library profiles yourself, by downloading them from 
 
 ## Discovery
 
-During startup, Powercalc will scan your Home Assistant installation for entities that match the library profiles.
+During startup, Powercalc will scan your Home Assistant installation for entities and devices that match the library profiles.
 Only entities which have a device attached will be considered for discovery.
 Device information can be viewed at the top left corner of the device page in the Home Assistant UI, or in `config/.storage/core.device_registry`.
 

--- a/docs/source/library/structure.md
+++ b/docs/source/library/structure.md
@@ -22,6 +22,12 @@ Required fields are:
 You can use `aliases` to define alternative model names, which will be used during discovery.
 This can be helpful when same model is reported differently depending on the integration. For example, the same light bulb could be reported differently by the Hue integration compared to the deCONZ integration.
 
+By default Powercalc discovers on a "per entity" basis.
+This can cause issues when a device has multiple entities, causing multiple discoveries for the same device.
+When a profile does not have to be bound to a specific entity (light, switch etc.), you can set `discovery_by` to `device`.
+This will cause Powercalc to discover on a "per device" basis, which is more reliable.
+This setting is recommended for device types which map to `sensor` domain entities, these are: `network`, `power_meter` and `generic_iot`.
+
 ## Sub profiles
 
 Some profiles might have multiple profiles. This is useful when a device has different power consumption based on the state of the device.

--- a/profile_library/model_schema.json
+++ b/profile_library/model_schema.json
@@ -24,6 +24,14 @@
       "type": "string",
       "description": "A short description of the device"
     },
+    "discovery_type": {
+      "type": "string",
+      "enum": [
+        "device",
+        "entity"
+      ],
+      "description": "Whether to discover the profile by device or entity"
+    },
     "standby_power": {
       "type": "number",
       "minimum": 0.05,

--- a/profile_library/model_schema.json
+++ b/profile_library/model_schema.json
@@ -86,6 +86,7 @@
       "enum": [
         "camera",
         "cover",
+        "generic_iot",
         "light",
         "power_meter",
         "printer",

--- a/profile_library/model_schema.json
+++ b/profile_library/model_schema.json
@@ -24,7 +24,7 @@
       "type": "string",
       "description": "A short description of the device"
     },
-    "discovery_type": {
+    "discovery_by": {
       "type": "string",
       "enum": [
         "device",

--- a/tests/config_flow/common.py
+++ b/tests/config_flow/common.py
@@ -106,7 +106,7 @@ async def initialize_discovery_flow(
             await get_power_profile(
                 hass,
                 {},
-                await discovery_manager.extract_model_info_from_entity(source_entity.entity_entry),
+                await discovery_manager.extract_model_info_from_device_info(source_entity.entity_entry),
             ),
         ]
 

--- a/tests/config_flow/test_discovery.py
+++ b/tests/config_flow/test_discovery.py
@@ -4,8 +4,9 @@ import voluptuous as vol
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
 
-from custom_components.powercalc.common import create_source_entity
+from custom_components.powercalc.common import SourceEntity, create_source_entity
 from custom_components.powercalc.config_flow import CONF_CONFIRM_AUTODISCOVERED_MODEL, Step
 from custom_components.powercalc.const import (
     CONF_CREATE_ENERGY_SENSOR,
@@ -13,11 +14,13 @@ from custom_components.powercalc.const import (
     CONF_MODEL,
     CONF_SENSOR_TYPE,
     CONF_SUB_PROFILE,
+    DUMMY_ENTITY_ID,
     SensorType,
 )
 from custom_components.powercalc.discovery import get_power_profile_by_source_entity
 from custom_components.powercalc.power_profile.factory import get_power_profile
 from custom_components.powercalc.power_profile.library import ModelInfo
+from tests.common import get_test_config_dir
 from tests.config_flow.common import (
     DEFAULT_ENTITY_ID,
     DEFAULT_UNIQUE_ID,
@@ -178,3 +181,42 @@ async def test_autodiscovered_option_flow(hass: HomeAssistant) -> None:
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert not entry.data[CONF_CREATE_ENERGY_SENSOR]
+
+
+async def test_discovery_by_device(hass: HomeAssistant) -> None:
+    hass.config.config_dir = get_test_config_dir()
+
+    device_entry = DeviceEntry(
+        name="FooBar",
+        id="youless-device",
+        manufacturer="test",
+        model="discovery-type-device",
+    )
+    source_entity = SourceEntity(
+        object_id=device_entry.name,
+        name=device_entry.name,
+        entity_id=DUMMY_ENTITY_ID,
+        domain="sensor",
+        device_entry=device_entry,
+    )
+    power_profiles = [
+        await get_power_profile(hass, {}, ModelInfo("test", "discovery-type-device")),
+    ]
+    result = await initialize_discovery_flow(hass, source_entity, power_profiles)
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_CONFIRM_AUTODISCOVERED_MODEL: True},
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_ENTITY_ID: DUMMY_ENTITY_ID,
+        CONF_SENSOR_TYPE: SensorType.VIRTUAL_POWER,
+        CONF_MANUFACTURER: "test",
+        CONF_MODEL: "discovery-type-device",
+        CONF_NAME: "FooBar",
+    }
+
+    assert hass.states.get("sensor.foobar_device_power")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -45,7 +45,7 @@ from custom_components.powercalc.discovery import get_power_profile_by_source_en
 from custom_components.powercalc.power_profile.library import ModelInfo
 from custom_components.test.light import MockLight
 
-from .common import create_mock_light_entity, run_powercalc_setup
+from .common import create_mock_light_entity, get_test_config_dir, run_powercalc_setup
 from .conftest import MockEntityWithModel
 
 DEFAULT_UNIQUE_ID = "7c009ef6829f"
@@ -130,7 +130,7 @@ async def test_autodiscovery_skipped_for_lut_with_subprofiles(
     mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
-    Lights which can be autodiscovered and have sub profiles need to de skipped
+    Lights which can be autodiscovered and have sub profiles need to be skipped
     User needs to configure this because we cannot know which sub profile to select
     No power sensor should be created and no error should appear in the logs
     """
@@ -332,7 +332,7 @@ async def test_autodiscover_continues_when_one_entity_fails(
     with patch("custom_components.powercalc.power_profile.library.ProfileLibrary.find_models", new_callable=AsyncMock) as mock_find_models:
         mock_find_models.side_effect = [Exception("Test exception"), {ModelInfo("signify", "LCT010")}]
         await run_powercalc_setup(hass, {})
-        assert "Error during auto discovery" in caplog.text
+        assert "Error during entity discovery" in caplog.text
 
 
 async def test_load_model_with_slashes(
@@ -605,7 +605,7 @@ async def test_no_power_sensors_are_created_for_ignored_config_entries(
     await run_powercalc_setup(hass, {})
 
     assert not hass.states.get("sensor.test_power")
-    assert "Already setup with discovery, skipping new discovery" in caplog.text
+    assert "Already setup with discovery, skipping" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -662,7 +662,7 @@ async def test_get_model_information(
         mock_device_registry(hass, {str(device_entry.id): device_entry})
     mock_registry(hass, {str(entity_entry.id): entity_entry})
     discovery_manager = DiscoveryManager(hass, {})
-    assert await discovery_manager.get_model_information(entity_entry) == model_info
+    assert await discovery_manager.get_model_information_from_entity(entity_entry) == model_info
 
 
 async def test_interval_based_rediscovery(
@@ -704,3 +704,26 @@ async def test_update_profile_service(
     await hass.async_block_till_done()
 
     assert len([record for record in caplog.records if "Start auto discovery" in record.message]) == 2
+
+
+async def test_discovery_by_device(
+    hass: HomeAssistant,
+    mock_flow_init: AsyncMock,
+) -> None:
+    hass.config.config_dir = get_test_config_dir()
+
+    mock_device_registry(
+        hass,
+        {
+            "youless-device": DeviceEntry(
+                id="youless-device",
+                manufacturer="test",
+                model="discovery-type-device",
+            ),
+        },
+    )
+
+    await run_powercalc_setup(hass, {})
+
+    mock_calls = mock_flow_init.mock_calls
+    assert len(mock_calls) == 1

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -11,7 +11,7 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_INTEGRATION_DISCOVERY
-from homeassistant.const import CONF_ENTITY_ID, CONF_NAME, CONF_UNIQUE_ID, STATE_ON
+from homeassistant.const import CONF_ENTITY_ID, CONF_NAME, CONF_SOURCE, CONF_UNIQUE_ID, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
@@ -39,6 +39,7 @@ from custom_components.powercalc.const import (
     CONF_VOLTAGE,
     CONF_WLED,
     DOMAIN,
+    DUMMY_ENTITY_ID,
     SensorType,
 )
 from custom_components.powercalc.discovery import get_power_profile_by_source_entity
@@ -716,7 +717,7 @@ async def test_discovery_by_device(
         hass,
         {
             "youless-device": DeviceEntry(
-                id="youless-device",
+                id="ABC123",
                 manufacturer="test",
                 model="discovery-type-device",
             ),
@@ -726,4 +727,10 @@ async def test_discovery_by_device(
     await run_powercalc_setup(hass, {})
 
     mock_calls = mock_flow_init.mock_calls
+    assert mock_calls[0][1] == (DOMAIN,)
+    assert mock_calls[0][2]["context"] == {CONF_SOURCE: SOURCE_INTEGRATION_DISCOVERY}
+    assert mock_calls[0][2]["data"][CONF_ENTITY_ID] == DUMMY_ENTITY_ID
+    assert mock_calls[0][2]["data"][CONF_MANUFACTURER] == "test"
+    assert mock_calls[0][2]["data"][CONF_MODEL] == "discovery-type-device"
+    assert mock_calls[0][2]["data"][CONF_UNIQUE_ID] == "pc_ABC123"
     assert len(mock_calls) == 1

--- a/tests/testing_config/powercalc/profiles/test/discovery-type-device/model.json
+++ b/tests/testing_config/powercalc/profiles/test/discovery-type-device/model.json
@@ -2,7 +2,7 @@
   "measure_method": "manual",
   "measure_device": "Some device",
   "name": "Some smart switch",
-  "discovery_type": "device",
+  "discovery_by": "device",
   "standby_power": 0.3,
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",

--- a/tests/testing_config/powercalc/profiles/test/discovery-type-device/model.json
+++ b/tests/testing_config/powercalc/profiles/test/discovery-type-device/model.json
@@ -1,0 +1,16 @@
+{
+  "measure_method": "manual",
+  "measure_device": "Some device",
+  "name": "Some smart switch",
+  "discovery_type": "device",
+  "standby_power": 0.3,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 0.7
+  }
+}


### PR DESCRIPTION
Check name and id of devices.

Using name now as base for the entity name, but does every device have a name? Are there edge cases?

Similarly for id, using this as base for the unique_id now, can we do better?
Also assert unique_id in test.