### PR TITLE
Add Shelly Europe Ltd. as Shelly alias

### DIFF
--- a/profile_library/shelly/manufacturer.json
+++ b/profile_library/shelly/manufacturer.json
@@ -1,4 +1,4 @@
 {
-  "name": "shelly",
-  "aliases": []
+  "name": "Shelly",
+  "aliases": ["Shelly Europe Ltd."]
 }


### PR DESCRIPTION
This PR adds Shelly Europe Ltd. as an alias to Shelly's manufacturer.
This name is confirmed (on Shelly Community FB). It has been pointed out that it is currently printed on the back of Shelly's packaging. 

I'm adding it in advance to the official HA Shelly integration. I'm going to inform them about the official name.