### PR TITLE
Added Shelly plus 2PM

### DIFF
--- a/profile_library/shelly/Shelly Plus 2PM/model.json
+++ b/profile_library/shelly/Shelly Plus 2PM/model.json
@@ -11,14 +11,13 @@
   "aliases": [
     "SNSW-102P16EU"
   ],
-  "discovery_by": "entity",
+  "discovery_by": "device",
   "device_type": "smart_switch",
   "only_self_usage": true,
   "calculation_strategy": "multi_switch",
   "standby_power": 0.326,
   "multi_switch_config": {
-    "power": 0.356,
-    "power_off": 0
+    "power": 0.356
   },
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
Shelly Plus 2PM is gen2 device. 
It consists of 2 relays, each equipped with power metering.

Unlike gen1, it has multiple communication interfaces influencing measured power. 
Current measurement is executed with Wifi Client enabled only. Bluetooth and WiFi AP were disabled. I suppose it's the most used configuration (considering users remember about disabling unneeded interfaces)