### PR TITLE
Added Shelly Pro 3EM (with multiple profiles)

### DIFF
--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+bt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+bt/model.json
@@ -1,0 +1,6 @@
+{
+  "measure_description": "The device measured with Ethernet port and BlueTooth enabled. Other interfaces were disabled",
+  "standby_power": 0.979,
+  "created_at": "2024-01-03T20:07:00 CET",
+  "author": "Michal Bartak <maxym.srpl@gmail.com>"
+}

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+bt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+bt/model.json
@@ -1,5 +1,6 @@
 {
   "measure_description": "The device measured with Ethernet port and BlueTooth enabled. Other interfaces were disabled",
+  "name": "Eth + BT",
   "standby_power": 0.979,
   "created_at": "2024-01-03T20:07:00 CET",
   "author": "Michal Bartak <maxym.srpl@gmail.com>"

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_ap+wifi_clnt+bt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_ap+wifi_clnt+bt/model.json
@@ -1,5 +1,6 @@
 {
   "measure_description": "The device measured  with all interfaces enabled: Ethernet, Wifi AP, Wifi Client, BlueTooth",
+  "name": "Eth + WiFi AP + WiFi Client + BT",
   "standby_power": 1.379,
   "created_at": "2024-01-03T20:07:00 CET",
   "author": "Michal Bartak <maxym.srpl@gmail.com>"

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_ap+wifi_clnt+bt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_ap+wifi_clnt+bt/model.json
@@ -1,0 +1,6 @@
+{
+  "measure_description": "The device measured  with all interfaces enabled: Ethernet, Wifi AP, Wifi Client, BlueTooth",
+  "standby_power": 1.379,
+  "created_at": "2024-01-03T20:07:00 CET",
+  "author": "Michal Bartak <maxym.srpl@gmail.com>"
+}

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt+bt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt+bt/model.json
@@ -1,0 +1,6 @@
+{
+  "measure_description": "The device measured with Ethernet port, Wifi client and BlueTooth enabled. Other interfaces were disabled",
+  "standby_power": 1.3395,
+  "created_at": "2024-01-03T20:07:00 CET",
+  "author": "Michal Bartak <maxym.srpl@gmail.com>"
+}

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt+bt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt+bt/model.json
@@ -1,5 +1,6 @@
 {
   "measure_description": "The device measured with Ethernet port, Wifi client and BlueTooth enabled. Other interfaces were disabled",
+  "name": "Eth + WiFi Client + BT",
   "standby_power": 1.3395,
   "created_at": "2024-01-03T20:07:00 CET",
   "author": "Michal Bartak <maxym.srpl@gmail.com>"

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt/model.json
@@ -1,5 +1,6 @@
 {
   "measure_description": "The device measured with Ethernet port and Wifi client enabled. Other interfaces were disabled",
+  "name": "Eth + WiFi Client",
   "standby_power": 1.3175,
   "created_at": "2024-01-03T20:07:00 CET",
   "author": "Michal Bartak <maxym.srpl@gmail.com>"

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth+wifi_clnt/model.json
@@ -1,0 +1,6 @@
+{
+  "measure_description": "The device measured with Ethernet port and Wifi client enabled. Other interfaces were disabled",
+  "standby_power": 1.3175,
+  "created_at": "2024-01-03T20:07:00 CET",
+  "author": "Michal Bartak <maxym.srpl@gmail.com>"
+}

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth/model.json
@@ -1,5 +1,6 @@
 {
   "measure_description": "The device measured with Ethernet port enabled. Other interfaces were disabled",
+  "name": "Eth",
   "standby_power": 0.93,
   "created_at": "2024-01-03T20:07:00 CET",
   "author": "Michal Bartak <maxym.srpl@gmail.com>"

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/eth/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/eth/model.json
@@ -1,0 +1,6 @@
+{
+  "measure_description": "The device measured with Ethernet port enabled. Other interfaces were disabled",
+  "standby_power": 0.93,
+  "created_at": "2024-01-03T20:07:00 CET",
+  "author": "Michal Bartak <maxym.srpl@gmail.com>"
+}

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/model.json
@@ -1,0 +1,24 @@
+{
+  "measure_description": "The measured device fw: 1.4.4, Eco Mode disabled. The result represents the average value of measurements collected from the measurement device API for the following scenarios: dumb device/baseline consumption (~4.9W) and several device configurations. See sub-profiles.",
+  "measure_method": "manual",
+  "measure_device": "Shelly PM Mini gen3",
+  "measure_device_firmware": "20241011-114503/1.4.4-g6d2a586",
+  "measure_settings": {
+    "SAMPLE_COUNT": 200,
+    "SLEEP_TIME": 0.5
+  },
+  "name": "Shelly Pro 3EM 3CT63",
+  "aliases": [
+    "SPEM-003CEBEU63"
+  ],
+  "discovery_by": "device",
+  "device_type": "power_meter",
+  "calculation_strategy": "fixed",
+  "only_self_usage": true,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "created_at": "2024-01-03T20:07:00 CET",
+  "author": "Michal Bartak <maxym.srpl@gmail.com>"
+}

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/wifi_clnt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/wifi_clnt/model.json
@@ -1,0 +1,6 @@
+{
+  "measure_description": "The device measured with Wifi client enabled. Other interfaces were disabled",
+  "standby_power": 1.0225,
+  "created_at": "2024-01-03T20:07:00 CET",
+  "author": "Michal Bartak <maxym.srpl@gmail.com>"
+}

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/wifi_clnt/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/wifi_clnt/model.json
@@ -1,5 +1,6 @@
 {
   "measure_description": "The device measured with Wifi client enabled. Other interfaces were disabled",
+  "name": "WiFi Client",
   "standby_power": 1.0225,
   "created_at": "2024-01-03T20:07:00 CET",
   "author": "Michal Bartak <maxym.srpl@gmail.com>"


### PR DESCRIPTION
## Device information
3-phase energy metter. 
The device consists of no built-in relay. 

KB pages: https://kb.shelly.cloud/knowledge-base/shelly-pro-3em-3ct63

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
The device provides several connectivity options: Ethernet, Wifi client, Wifi AP, BlueTooth. It can be BLE gateway. It can run scripts. 
All those things may influence its power consumption. 

The current PR provides several profiles, covering consumption for various combinations of enabled comms.
No scripts were running during measurements. BLE gateway was disabled.
