### PR TITLE
Add TP-Link Kasa EP10

### DIFF
--- a/profile_library/tp-link/EP10/model.json
+++ b/profile_library/tp-link/EP10/model.json
@@ -1,0 +1,13 @@
+{
+  "measure_description": "Manually measured.",
+  "measure_method": "manual",
+  "measure_device": "TP-Link Kasa KP125M",
+  "name": "TP-Link Kasa Smart WiFi Plug Mini",
+  "standby_power": 0.58,
+  "standby_power_on": 1.09,
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "only_self_usage": false,
+  "created_at": "2025-01-20T10:00:00",
+  "author": "Thiago Oliveira <infratl@gmail.com>"
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
This is a TP-Link Kasa Smart WiFi Plug Mini, model EP10
https://www.tp-link.com/us/home-networking/smart-plug/ep10/v1/

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

```
Device info
EP10
by TP-Link
Firmware: 1.0.5 Build 221021 Rel.183404
Hardware: 1.0
MAC: redacted
```

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
This was measured using the TP-Link Kasa KP125M. First I turned off the load and let it measure for about 2 hours. I then took the "mean" value from the history graph in home assistant. Then I did the same with the load on.
