### PR TITLE
[translations] [SK] Update sk.json - fix error - missing placeholder

### DIFF
--- a/custom_components/powercalc/translations/sk.json
+++ b/custom_components/powercalc/translations/sk.json
@@ -323,9 +323,9 @@
       },
       "sub_profile": {
         "data": {
-          "sub_profile": "Pod profil"
+          "sub_profile": "Podprofil"
         },
-        "description": "Tento model má viacero podprofilov. Vyberte ten, ktorý vyhovuje vášmu zariadeniu",
+        "description": "Tento model má viacero podprofilov. Vyberte ten, ktorý vyhovuje vášmu zariadeniu:\n\n\"{entity_id}\"",
         "title": "Konfigurácia podprofilu"
       },
       "smart_switch": {


### PR DESCRIPTION
Logger: homeassistant.helpers.translation
Source: helpers/translation.py:285
First occurred: 20:10:15 (1 occurrences)
Last logged: 20:10:15

Validation of translation placeholders for localized (sk) string component.powercalc.config.step.sub_profile.description failed: (set() != {'entity_id'})
