### PR TITLE
Add measurements for the Shelly Wave 1PM Mini Z-wave switch

### DIFF
--- a/profile_library/shelly/Shelly Wave 1PM Mini/model.json
+++ b/profile_library/shelly/Shelly Wave 1PM Mini/model.json
@@ -1,0 +1,21 @@
+{
+  "measure_description": "Manually measured with Gossen Metrawatt 29S (energy speciality DMM). The device has a quite poor power factor (~0.3) making the apparent power VA of this device with 0.35 VA and 0.65 VA quite a lot higher than the effective power.",
+  "measure_method": "manual",
+  "measure_device": "Gossen Metrawatt Metra Hit 29S",
+  "name": "Shelly Wave 1PM Mini",
+  "aliases": [
+    "QMSW-0A1P8"
+  ],
+  "discovery_by": "device",
+  "device_type": "smart_switch",
+  "only_self_usage": true,
+  "calculation_strategy": "fixed",
+  "standby_power": 0.129,
+  "standby_power_on": 0.168,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "created_at": "2025-12-29T20:57:00",
+  "author": "Arne Schwabe <arne@rfc2549.org>"
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
This is the Shelly 1PM Z-wave switch that can be put into a switch box behind a light switch.

## Home Assistant Device information
Device info
QMSW-0A1P8
by Shelly Europe Ltd.
Connected via [Controller](https://home.blinkt.de/config/devices/device/4d838cd0b0394adaa8a89f324b408afc)
Firmware: 11.5.0

## Checklist


- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
This has been measured by a speciality DMM that has no problems with low power measurements and should be be probably better than most of the plugs to measure this even though it is out of calibration. 
