### PR TITLE
Device HmIP-FSM corrected measurments + strategy

### DIFF
--- a/profile_library/eq-3/HmIP-FSM/model.json
+++ b/profile_library/eq-3/HmIP-FSM/model.json
@@ -1,10 +1,13 @@
 {
-  "measure_description": "Manually measured",
-  "measure_method": "manual",
-  "measure_device": "From manufacturer specifications",
+  "measure_description": "Manually measured with dummy load attached at 7.7W (average over 300s) multiple times, than calculated average of that.",
+  "measure_device": "Shelly PM Mini Gen3 (S3PM-001PCEU16)",
+  "measure_method": "script",
+  "measure_settings": {
+    "VERSION": "v1.17.1:docker"
+   },
   "name": "HmIP-FSM",
   "standby_power": 0.2,
-  "standby_power_on": 0.2,
+  "standby_power_on": 0.74,
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
@@ -12,7 +15,7 @@
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
   "only_self_usage": true,
-  "created_at": "2024-09-06T18:37:40",
+  "created_at": "2025-002-04T18:37:40",
   "author": "CV",
   "description": "HomematicIP flush mounted smart switch with power measurement integrated. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage is measured by the smart device."
 }

--- a/profile_library/eq-3/HmIP-FSM/model.json
+++ b/profile_library/eq-3/HmIP-FSM/model.json
@@ -4,7 +4,7 @@
   "measure_method": "script",
   "measure_settings": {
     "VERSION": "v1.17.1:docker"
-   },
+  },
   "name": "HmIP-FSM",
   "standby_power": 0.2,
   "standby_power_on": 0.74,

--- a/profile_library/eq-3/HmIP-FSM/model.json
+++ b/profile_library/eq-3/HmIP-FSM/model.json
@@ -15,7 +15,7 @@
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
   "only_self_usage": true,
-  "created_at": "2025-002-04T18:37:40",
+  "created_at": "2024-09-06T18:37:40",
   "author": "CV",
   "description": "HomematicIP flush mounted smart switch with power measurement integrated. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage is measured by the smart device."
 }


### PR DESCRIPTION
I measured this previously added eq-3 device using the docker-measuring option with a Shelly PM Mini Gen3. This measurement is an average of multiple average-measurements taken over a period of 300s each.

If necessary I changes the `calculation_strategy` and added `only_self_usage`.