### PR TITLE
Device HM-LC-Sw1-DR corrected measurments + strategy

### DIFF
--- a/profile_library/eq-3/HM-LC-Sw1-DR/model.json
+++ b/profile_library/eq-3/HM-LC-Sw1-DR/model.json
@@ -1,18 +1,20 @@
 {
-  "measure_description": "Manually measured",
-  "measure_method": "manual",
-  "measure_device": "From manufacturer specifications",
+  "measure_description": "Manually measured with dummy load attached at 7.7W (average over 300s) multiple times, than calculated average of that.",
+  "measure_device": "Shelly PM Mini Gen3 (S3PM-001PCEU16)",
+  "measure_method": "script",
+  "measure_settings": {
+    "VERSION": "v1.17.1:docker"
+   },
   "name": "HM-LC-Sw1-DR",
-  "standby_power": 0.35,
-  "standby_power_on": 0.35,
+  "standby_power": 0.32,
+  "standby_power_on": 0.52,
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
   },
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
-  "only_self_usage": true,
-  "created_at": "2024-09-06T18:37:40",
+  "created_at": "2025-02-04T18:37:40",
   "author": "CV",
-  "description": "Homematic DIN rail mount smart switch. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage must be configured by the user since it is possible to connect anything to it."
+  "description": "HomematicIP DIN rail mount smart switch. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage must be configured by the user since it is possible to connect anything to it."
 }

--- a/profile_library/eq-3/HM-LC-Sw1-DR/model.json
+++ b/profile_library/eq-3/HM-LC-Sw1-DR/model.json
@@ -4,7 +4,7 @@
   "measure_method": "script",
   "measure_settings": {
     "VERSION": "v1.17.1:docker"
-   },
+  },
   "name": "HM-LC-Sw1-DR",
   "standby_power": 0.32,
   "standby_power_on": 0.52,


### PR DESCRIPTION
I measured this previously added eq-3 device using the docker-measuring option with a Shelly PM Mini Gen3. This measurement is an average of multiple average-measurements taken over a period of 300s each.

If necessary I changes the `calculation_strategy` and added `only_self_usage`.