### PR TITLE
Device HM-ES-PMSw1-DR corrected measurments + strategy

### DIFF
--- a/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
+++ b/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
@@ -1,10 +1,13 @@
 {
-  "measure_description": "Manually measured",
-  "measure_method": "manual",
-  "measure_device": "From manufacturer specifications",
+  "measure_description": "Manually measured with dummy load attached at 7.7W (average over 300s) multiple times, than calculated average of that.",
+  "measure_device": "Shelly PM Mini Gen3 (S3PM-001PCEU16)",
+  "measure_method": "script",
+  "measure_settings": {
+    "VERSION": "v1.17.1:docker"
+   },
   "name": "HM-ES-PMSw1-DR",
-  "standby_power": 0.3,
-  "standby_power_on": 0.3,
+  "standby_power": 0.37,
+  "standby_power_on": 0.73,
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",
     "energy_sensor_naming": "{} Device Energy"
@@ -14,5 +17,5 @@
   "only_self_usage": true,
   "created_at": "2024-09-06T18:37:40",
   "author": "CV",
-  "description": "Homematic DIN rail mount smart switch with power measurement integrated for outlets. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage is measured by the smart device."
+  "description": "HomematicIP DIN rail mount smart switch with power measurement integrated for outlets. This model is configured only for standby power usage of the smart device itself. The connected device(s) power usage is measured by the smart device."
 }


### PR DESCRIPTION
I measured this previously added eq-3 device using the docker-measuring option with a Shelly PM Mini Gen3. This measurement is an average of multiple average-measurements taken over a period of 300s each.

If necessary I changes the `calculation_strategy` and added `only_self_usage`.