### PR TITLE
Device HmIP-FROLL corrected measurments + strategy

### DIFF
--- a/profile_library/eq-3/HmIP-FROLL/closing/model.json
+++ b/profile_library/eq-3/HmIP-FROLL/closing/model.json
@@ -1,0 +1,3 @@
+{
+    "standby_power_on": 0.68
+}

--- a/profile_library/eq-3/HmIP-FROLL/model.json
+++ b/profile_library/eq-3/HmIP-FROLL/model.json
@@ -1,9 +1,12 @@
 {
-  "measure_description": "Manually measured",
-  "measure_method": "manual",
-  "measure_device": "From manufacturer specifications",
+  "measure_description": "Manually measured with dummy load attached at 7.7W (average over 300s) multiple times, than calculated average of that.",
+  "measure_device": "Shelly PM Mini Gen3 (S3PM-001PCEU16)",
+  "measure_method": "script",
+  "measure_settings": {
+    "VERSION": "v1.17.1:docker"
+   },
   "name": "HmIP-FROLL",
-  "standby_power": 0.2,
+  "standby_power": 0.12,
   "standby_power_on": 0.2,
   "sensor_config": {
     "power_sensor_naming": "{} Device Power",
@@ -17,7 +20,20 @@
       "closing": 0
     }
   },
-  "created_at": "2024-09-06T18:37:40",
+  "sub_profile_select": {
+    "matchers": [
+      {
+        "type": "entity_state",
+        "entity_id": "cover.{{source_object_id}}",
+        "map": {
+          "closing": "closing",
+          "opening": "opening"
+        }
+      }
+    ],
+    "default": "no_movement"
+  },
+  "created_at": "2025-02-04T18:37:40",
   "author": "CV",
   "description": "HomematicIP flush mounted shutter actuator. This model is only configured to calculate the power usage of the smart actuator itself because the shutter motor connected is individual and can have different power draw even windows-by-window."
 }

--- a/profile_library/eq-3/HmIP-FROLL/no_movement/model.json
+++ b/profile_library/eq-3/HmIP-FROLL/no_movement/model.json
@@ -1,0 +1,3 @@
+{
+    "standby_power_on": 0
+}

--- a/profile_library/eq-3/HmIP-FROLL/opening/model.json
+++ b/profile_library/eq-3/HmIP-FROLL/opening/model.json
@@ -1,0 +1,3 @@
+{
+    "standby_power_on": 0.4
+}


### PR DESCRIPTION
I measured this previously added eq-3 device using the docker-measuring option with a Shelly PM Mini Gen3. This measurement is an average of multiple average-measurements taken over a period of 300s each.

If necessary I changes the calculation_strategy and added only_self_usage.
