### PR TITLE
add JBL Link Music

### DIFF
--- a/profile_library/jbl/Link Music/model.json
+++ b/profile_library/jbl/Link Music/model.json
@@ -5,17 +5,17 @@
   "device_type": "smart_speaker",
   "linear_config": {
     "calibrate": [
-      "10 -> 2.76",
-      "20 -> 2.7",
-      "30 -> 2.73",
+	  "0 -> 2.71",
+      "10 -> 2.72",
+      "20 -> 2.76",
+      "30 -> 2.76",
       "40 -> 2.76",
-      "50 -> 2.7",
+      "50 -> 2.76",
       "60 -> 2.83",
       "70 -> 3.47",
       "80 -> 5.49",
       "90 -> 7.44",
-      "100 -> 8.56",
-      "0 -> 5.61"
+      "100 -> 8.56"
     ]
   },
   "measure_description": "Measured with utils/measure script",
@@ -27,5 +27,5 @@
     "VERSION": "v1.17.6:docker"
   },
   "name": "JBL Link Music",
-  "standby_power": 2.7
+  "standby_power": 1.7
 }

--- a/profile_library/jbl/Link Music/model.json
+++ b/profile_library/jbl/Link Music/model.json
@@ -5,7 +5,7 @@
   "device_type": "smart_speaker",
   "linear_config": {
     "calibrate": [
-	  "0 -> 2.71",
+      "0 -> 2.71",
       "10 -> 2.72",
       "20 -> 2.76",
       "30 -> 2.76",

--- a/profile_library/jbl/Link Music/model.json
+++ b/profile_library/jbl/Link Music/model.json
@@ -28,5 +28,7 @@
   },
   "name": "JBL Link Music",
   "standby_power": 1.7,
-  "aliases": ["JBL Link Music"]
+  "aliases": [
+    "JBL Link Music"
+  ]
 }

--- a/profile_library/jbl/Link Music/model.json
+++ b/profile_library/jbl/Link Music/model.json
@@ -27,5 +27,6 @@
     "VERSION": "v1.17.6:docker"
   },
   "name": "JBL Link Music",
-  "standby_power": 1.7
+  "standby_power": 1.7,
+  "aliases": ["JBL Link Music"]
 }

--- a/profile_library/jbl/Link Music/model.json
+++ b/profile_library/jbl/Link Music/model.json
@@ -1,0 +1,31 @@
+{
+  "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+  "calculation_strategy": "linear",
+  "created_at": "2025-02-10T16:32:20.219347",
+  "device_type": "smart_speaker",
+  "linear_config": {
+    "calibrate": [
+      "10 -> 2.76",
+      "20 -> 2.7",
+      "30 -> 2.73",
+      "40 -> 2.76",
+      "50 -> 2.7",
+      "60 -> 2.83",
+      "70 -> 3.47",
+      "80 -> 5.49",
+      "90 -> 7.44",
+      "100 -> 8.56",
+      "0 -> 5.61"
+    ]
+  },
+  "measure_description": "Measured with utils/measure script",
+  "measure_device": "Nous A8T (esphome)",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 2,
+    "SLEEP_TIME": 3,
+    "VERSION": "v1.17.6:docker"
+  },
+  "name": "JBL Link Music",
+  "standby_power": 2.7
+}

--- a/profile_library/jbl/manufacturer.json
+++ b/profile_library/jbl/manufacturer.json
@@ -1,4 +1,4 @@
 {
-  "name": "JBL",
+  "name": "jbl",
   "aliases": []
 }

--- a/profile_library/jbl/manufacturer.json
+++ b/profile_library/jbl/manufacturer.json
@@ -1,4 +1,4 @@
 {
   "name": "jbl",
-  "aliases": []
+  "aliases": ["HARMAN International Industries"]
 }

--- a/profile_library/jbl/manufacturer.json
+++ b/profile_library/jbl/manufacturer.json
@@ -1,4 +1,6 @@
 {
   "name": "jbl",
-  "aliases": ["HARMAN International Industries"]
+  "aliases": [
+    "HARMAN International Industries"
+  ]
 }

--- a/profile_library/jbl/manufacturer.json
+++ b/profile_library/jbl/manufacturer.json
@@ -1,0 +1,4 @@
+{
+  "name": "JBL",
+  "aliases": []
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
https://de.jbl.com/LINK+MUSIC.html

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
JBL Link Music
von HARMAN International Industries

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x ] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
This only measured the speaker using the google cast integration, since the measurement script does not support airplay or 
  Bluetooth? Even so i think the difference should be small if at all
