### PR TITLE
Shelly subprofile other naming more understandable

### DIFF
--- a/profile_library/shelly/Shelly 1 mini gen3/other/model.json
+++ b/profile_library/shelly/Shelly 1 mini gen3/other/model.json
@@ -1,5 +1,5 @@
 {
-  "name": "All combinations",
+  "name": "Other combinations",
   "standby_power": 0.53,
   "standby_power_on": 0.81
 }

--- a/profile_library/shelly/Shelly 1PM Mini Gen3/other/model.json
+++ b/profile_library/shelly/Shelly 1PM Mini Gen3/other/model.json
@@ -1,5 +1,5 @@
 {
-  "name": "All combinations",
+  "name": "Other combinations",
   "standby_power": 0.58,
   "standby_power_on": 0.86
 }

--- a/profile_library/shelly/Shelly I4 Gen3/other/model.json
+++ b/profile_library/shelly/Shelly I4 Gen3/other/model.json
@@ -1,5 +1,5 @@
 {
-  "name": "All combinations",
+  "name": "Other combinations",
   "standby_power": 0.52,
   "standby_power_on": 0.52
 }


### PR DESCRIPTION
This is correcting the naming of subprofiles to make them more understandable.
