### PR TITLE
Fix Model Shelly I4 Gen3 not creating entities

### DIFF
--- a/profile_library/shelly/Shelly I4 Gen3/model.json
+++ b/profile_library/shelly/Shelly I4 Gen3/model.json
@@ -17,6 +17,7 @@
   "discovery_by": "device",
   "device_type": "generic_iot",
   "only_self_usage": true,
+  "calculation_strategy": "fixed",
   "config_flow_discovery_remarks": "This device contains four button/switch detectors but does not switch itself any electrical devices.",
   "config_flow_sub_profile_remarks": "You need to select a profile depending on your settings.\nThe ECO setting only changes the power consumption in the listed configurations. Activating any other settings not listed in the profile name will change the power draw.\n\"WLAN + BT + ECO\": All three turned on, repeater turned off.\n\"WLAN + ECO\": Both turned on, repeater turned off.\n\"Other combinations\": For all other combinations. Maximum device power draw.",
   "author": "CV",


### PR DESCRIPTION
I guess, after some changes to powercalc configuring this device succeeds but no entities are created. The following error is shown in the debug log when such a device was already configured prior to changes:

```
2025-02-27 13:51:46.630 DEBUG (MainThread) [custom_components.powercalc.power_profile.power_profile] Loading sub profile: +wlan_+bt_+eco
2025-02-27 13:51:46.630 DEBUG (MainThread) [custom_components.powercalc.sensors.power] Creating power sensor (entity_id=sensor.dummy entity_category=None, sensor_name=Home-EG-Zimmer5-Multitaster4-Tuer Device Power strategy=lut manufacturer=shelly model=Shelly I4 Gen3 unique_id=pc_0726540008d04b1d60e3dd7cb7a45128)
2025-02-27 13:51:46.630 ERROR (MainThread) [custom_components.powercalc.sensors.power] sensor.dummy: Skipping sensor setup: Only light entities can use the LUT mode
```
