### PR TITLE
Add HomeWizard Wi-Fi Energy Socket profile

### DIFF
--- a/profile_library/homewizard/HWE-SKT/model.json
+++ b/profile_library/homewizard/HWE-SKT/model.json
@@ -1,21 +1,21 @@
 {
-    "aliases": [
-        "HWE-SKT",
-        "HWE-SKT-21"
-    ],
-    "author": "Franck Nijhof <opensource@frenck.dev>",
-    "calculation_strategy": "fixed",
-    "created_at": "2025-03-19T20:30:06",
-    "device_type": "smart_switch",
-    "measure_description": "Manually measured.",
-    "measure_device": "Zhurui PR10-C Power Recorder",
-    "measure_method": "manual",
-    "name": "HomeWizard Wi-Fi Energy Socket",
-    "only_self_usage": true,
-    "sensor_config": {
-        "energy_sensor_naming": "{} Device Energy",
-        "power_sensor_naming": "{} Device Power"
-    },
-    "standby_power": 0.80,
-    "standby_power_on": 1.49
+  "aliases": [
+    "HWE-SKT",
+    "HWE-SKT-21"
+  ],
+  "author": "Franck Nijhof <opensource@frenck.dev>",
+  "calculation_strategy": "fixed",
+  "created_at": "2025-03-19T20:30:06",
+  "device_type": "smart_switch",
+  "measure_description": "Manually measured.",
+  "measure_device": "Zhurui PR10-C Power Recorder",
+  "measure_method": "manual",
+  "name": "HomeWizard Wi-Fi Energy Socket",
+  "only_self_usage": true,
+  "sensor_config": {
+    "energy_sensor_naming": "{} Device Energy",
+    "power_sensor_naming": "{} Device Power"
+  },
+  "standby_power": 0.8,
+  "standby_power_on": 1.49
 }

--- a/profile_library/homewizard/HWE-SKT/model.json
+++ b/profile_library/homewizard/HWE-SKT/model.json
@@ -1,0 +1,21 @@
+{
+    "aliases": [
+        "HWE-SKT",
+        "HWE-SKT-21"
+    ],
+    "author": "Franck Nijhof <opensource@frenck.dev>",
+    "calculation_strategy": "fixed",
+    "created_at": "2025-03-19T20:30:06",
+    "device_type": "smart_switch",
+    "measure_description": "Manually measured.",
+    "measure_device": "Zhurui PR10-C Power Recorder",
+    "measure_method": "manual",
+    "name": "HomeWizard Wi-Fi Energy Socket",
+    "only_self_usage": true,
+    "sensor_config": {
+        "energy_sensor_naming": "{} Device Energy",
+        "power_sensor_naming": "{} Device Power"
+    },
+    "standby_power": 0.80,
+    "standby_power_on": 1.49
+}

--- a/profile_library/homewizard/manufacturer.json
+++ b/profile_library/homewizard/manufacturer.json
@@ -1,0 +1,4 @@
+{
+  "name": "HomeWizard",
+  "aliases": []
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

The HomeWizard Wi-Fi Energy Socket

![image](https://github.com/user-attachments/assets/79fbcf76-8354-4d75-9bc9-3593771e1a2a)

HomeWizard: https://www.homewizard.com/shop/wi-fi-energy-socket/

![IMG_6139](https://github.com/user-attachments/assets/60b540af-2e51-4f7a-b95b-d13e2abfbfb5)

![IMG_6143](https://github.com/user-attachments/assets/098442b8-e2de-45ad-9448-b6cc7470e5c3)



## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

![CleanShot 2025-03-19 at 21 34 04@2x](https://github.com/user-attachments/assets/19cade97-fb99-4c30-a8d2-e87278a8aedd)

Wi-Fi Energy Socket (HWE-SKT)
by HomeWizard
Firmware: 4.07
MAC: 5C:2F:AF:1C:EB:44

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
