### PR TITLE
Add profile for FRITZ!Box 7590

### DIFF
--- a/profile_library/avm/FRITZ!Box 7590/model.json
+++ b/profile_library/avm/FRITZ!Box 7590/model.json
@@ -1,0 +1,17 @@
+{
+  "measure_description": "Manually measured",
+  "measure_method": "manual",
+  "measure_device": "BlitzWolf BW-SHP15",
+  "name": "FRITZ!Box 7590",
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "network",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 10.9
+  },
+  "created_at": "2025-03-21T22:22:16",
+  "author": "thueske"
+}


### PR DESCRIPTION
When create a PR for new measurements to the library, please go the the `Preview` tab and select the `power-profile` template:
If you are issuing a new PR for other purpose you can remove all this text.

* [Power profile](?expand=1&template=power_profile.md)
