### PR TITLE
Enabling codespell and fixing all outstanding spelling errors.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
         require_serial: true
         files: ^custom_components/powercalc
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+
 ci:
   autofix_commit_msg: |
     chore(lint): [pre-commit.ci] auto fixes from pre-commit.com hooks

--- a/INFO.md
+++ b/INFO.md
@@ -21,7 +21,7 @@ powercalc:
 After restarting power and energy sensors should appear for the lights found in your HA installation which are supported by powercalc.
 Please see the list of [supported models](https://library.powercalc.nl).
 When no power sensor is appearing please check the logs for any errors.
-Powercalc also provides extensive configuation to setup your own power sensors using different strategies. Please see the main [Documentation](https://github.com/bramstroker/homeassistant-powercalc/blob/master/README.md) on github for all the options and examples.
+Powercalc also provides extensive configuration to setup your own power sensors using different strategies. Please see the main [Documentation](https://github.com/bramstroker/homeassistant-powercalc/blob/master/README.md) on github for all the options and examples.
 Also see the [WiKi](https://github.com/bramstroker/homeassistant-powercalc/wiki) for even more information and the FAQ
 
 ## Debug logging

--- a/custom_components/powercalc/errors.py
+++ b/custom_components/powercalc/errors.py
@@ -6,7 +6,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 
 class PowercalcSetupError(HomeAssistantError):
-    """Raised when an error occured during powercalc sensor setup."""
+    """Raised when an error occurred during powercalc sensor setup."""
 
 
 class SensorConfigurationError(PowercalcSetupError):

--- a/custom_components/powercalc/power_profile/error.py
+++ b/custom_components/powercalc/power_profile/error.py
@@ -2,12 +2,12 @@ from homeassistant.exceptions import HomeAssistantError
 
 
 class LibraryError(HomeAssistantError):
-    """Raised when an error occured in the library logic."""
+    """Raised when an error occurred in the library logic."""
 
 
 class LibraryLoadingError(LibraryError):
-    """Raised when an error occured during library loading."""
+    """Raised when an error occurred during library loading."""
 
 
 class ProfileDownloadError(LibraryError):
-    """Raised when an error occured during profile download."""
+    """Raised when an error occurred during profile download."""

--- a/custom_components/powercalc/power_profile/loader/local.py
+++ b/custom_components/powercalc/power_profile/loader/local.py
@@ -74,7 +74,7 @@ class LocalLoader(Loader):
     async def load_model(self, manufacturer: str, model: str) -> tuple[dict, str] | None:
         """Load a model.json file from disk for a given manufacturer.lower() and model.lower()
         by querying the custom library.
-        If self._is_custom_directory == true model.json will be loaded directy from there.
+        If self._is_custom_directory == true model.json will be loaded directly from there.
 
         returns: tuple[dict, str] model.json as dictionary and model as lower case
         returns: None when manufacturer, model or model path not found
@@ -119,7 +119,7 @@ class LocalLoader(Loader):
 
     def _load_custom_library(self) -> None:
         """Loading custom models and aliases from file system.
-        Manufacturer directories without model directrories and model.json files within
+        Manufacturer directories without model directories and model.json files within
         are not loaded. Same is with model directories without model.json files.
         """
 

--- a/custom_components/powercalc/sensors/power.py
+++ b/custom_components/powercalc/sensors/power.py
@@ -520,7 +520,7 @@ class VirtualPowerSensor(SensorEntity, PowerSensor):
         trigger_entity_id: str,
         state: State | None,
     ) -> None:
-        """Update power sensor based on new dependant entity state."""
+        """Update power sensor based on new dependent entity state."""
         self._standby_sensors.pop(self.entity_id, None)
         if self._sleep_power_timer:
             self._sleep_power_timer()

--- a/docs/source/configuration/new-yaml-structure.md
+++ b/docs/source/configuration/new-yaml-structure.md
@@ -34,4 +34,4 @@ powercalc:
 !!! note
 
     You probably already have a `powercalc:` entry in your configuration for global powercalc configuration. You'll need to add `sensors` under that to prevent duplicating the `powercalc:` key.
-    When you use <https://www.home-assistant.io/docs/configuration/packages/> you can of course have powercalc sensor definitions scattered accross multiple files.
+    When you use <https://www.home-assistant.io/docs/configuration/packages/> you can of course have powercalc sensor definitions scattered across multiple files.

--- a/docs/source/library/device-types/smart-switch.md
+++ b/docs/source/library/device-types/smart-switch.md
@@ -30,7 +30,7 @@ Assuming the user provides a value of 50W the following power values will be cal
 
 !!! note
 
-    During the configuration flow the user als has the option to toggle `self_usage_included` on or off.
+    During the configuration flow the user also has the option to toggle `self_usage_included` on or off.
     When toggled on the power when ON will be 50W instead of 50.7W, in the example above.
 
 ## Smart switch with built-in powermeter

--- a/docs/source/quick-start.md
+++ b/docs/source/quick-start.md
@@ -52,7 +52,7 @@ Refer to [global configuration](configuration/global-configuration.md) for all s
 ## Energy dashboard
 
 If you want to use the virtual power sensors in the energy dashboard you'll need an energy sensor. Powercalc automatically creates one for every virtual power sensor. No need for any custom configuration.
-These energy sensors then can be selected in the energy dashboard under `Invididual devices`.
+These energy sensors then can be selected in the energy dashboard under `Individual devices`.
 
 You can disable the automatic creation of energy sensors with the option `create_energy_sensors` in your configuration (see [global configuration](configuration/global-configuration.md)).
 

--- a/docs/source/strategies/fixed.md
+++ b/docs/source/strategies/fixed.md
@@ -76,7 +76,7 @@ powercalc:
     Some states you cannot use as they are considered "off" for powercalc. In this case you'll need to use `standby_power`.
     The states which this applies to are `off`, `not_home`, `standby` and `unavailable`.
 
-You can also use state attributes. Use the `|` delimiter to seperate the attribute and value. Here is en example:
+You can also use state attributes. Use the `|` delimiter to separate the attribute and value. Here is en example:
 
 ```yaml
 powercalc:

--- a/docs/source/strategies/index.md
+++ b/docs/source/strategies/index.md
@@ -14,7 +14,7 @@ Use this when you want to set power on a linear scale. Useful for dimmable light
 
 ## :material-notebook-multiple: [LUT](lut.md)
 
-Use a Lookup table to map a given light brighness and color to a power value in Watt. Most of powercalc built-in profiles use this.
+Use a Lookup table to map a given light brightness and color to a power value in Watt. Most of powercalc built-in profiles use this.
 You'll need to use the measure utility to create these LUT files.
 
 ## :material-power-settings: [Multi Switch](multi-switch.md)

--- a/docs/source/troubleshooting/install-master.md
+++ b/docs/source/troubleshooting/install-master.md
@@ -10,4 +10,4 @@ If no new version of PowerCalc has been released yet and you need to test the la
 
 !!! note
 
-    Don't worry, next time a new version is released and you install it, HACS will update PowerCalc to the latest version, overwritting your temporary modifications.
+    Don't worry, next time a new version is released and you install it, HACS will update PowerCalc to the latest version, overwriting your temporary modifications.

--- a/profile_library/apple/HomePod Mini/model.json
+++ b/profile_library/apple/HomePod Mini/model.json
@@ -1,5 +1,5 @@
 {
-  "measure_description": "Streamed white noice for this test",
+  "measure_description": "Streamed white noise for this test",
   "measure_method": "manual",
   "measure_device": "Shelly Plug S",
   "name": "Apple HomePod Mini",

--- a/profile_library/aqara/CL-L02D/model.json
+++ b/profile_library/aqara/CL-L02D/model.json
@@ -15,5 +15,5 @@
   },
   "standby_power": 0.18,
   "author": "CV",
-  "config_flow_discovery_remarks": "This device has seperate light entities for the RGB ring and the white center light. You will be prompted to select a sub-profile. Choose the one according to the entity_id presented at that time.\nThe standby power of the device is 0.36W but devided between both light equally at this moment due to no better solutions (2025-01-27). If you only setup one light you need to correct the value yourself."
+  "config_flow_discovery_remarks": "This device has separate light entities for the RGB ring and the white center light. You will be prompted to select a sub-profile. Choose the one according to the entity_id presented at that time.\nThe standby power of the device is 0.36W but divided between both light equally at this moment due to no better solutions (2025-01-27). If you only setup one light you need to correct the value yourself."
 }

--- a/profile_library/hampton bay/HB-10521-HS/model.json
+++ b/profile_library/hampton bay/HB-10521-HS/model.json
@@ -12,5 +12,5 @@
   "name": "Smart 24ft LED Color Changing Plug-In String Lights",
   "standby_power": 1.45,
   "author": "Chris Hallgren <challgren@gmail.com>",
-  "config_flow_discovery_remarks": "***Warning** Supoort to provide measurements during an effect is running is not currently implemented."
+  "config_flow_discovery_remarks": "***Warning** Support to provide measurements during an effect is running is not currently implemented."
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,8 @@ python = ">=3.13.2,<3.14"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.codespell]
+ignore-words-list = 'hass'
+check-filenames = true
+skip = '*/translations/*.json,*/package-lock.json'

--- a/tests/power_profile/user_scenarios/test_nintendo_switch.py
+++ b/tests/power_profile/user_scenarios/test_nintendo_switch.py
@@ -28,7 +28,7 @@ async def test_nintendo_switch(hass: HomeAssistant) -> None:
         {
             CONF_ENTITY_ID: device_tracker_id,
             CONF_FIXED: {
-                CONF_POWER: "{{ iif(state_attr('media_player.baa', 'source') == 'Game', 8.0, 0) }}",
+                CONF_POWER: "{{ iif(state_attr('media_player.baa', 'source') == 'Game', 8.0, 0) }}",  # codespell:ignore iif
             },
             CONF_SLEEP_POWER: {
                 CONF_POWER: 0,

--- a/tests/sensors/test_energy.py
+++ b/tests/sensors/test_energy.py
@@ -387,7 +387,7 @@ async def test_calibrate_service(hass: HomeAssistant) -> None:
 
 async def test_real_power_sensor_kw(hass: HomeAssistant) -> None:
     """
-    Test that the riemann integral sensor is correclty created and updated for a kW power sensor
+    Test that the riemann integral sensor is correctly created and updated for a kW power sensor
     Fixes https://github.com/bramstroker/homeassistant-powercalc/issues/1676
     """
 

--- a/tests/sensors/test_power.py
+++ b/tests/sensors/test_power.py
@@ -491,7 +491,7 @@ async def test_manually_configured_sensor_overrides_profile(
     mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
-    Make sure that config settings done by user are not overriden by power profile
+    Make sure that config settings done by user are not overridden by power profile
     """
     entity_id = "light.test"
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -121,7 +121,7 @@ async def test_legacy_yaml_platform_configuration(
 
 
 async def test_utility_meter_is_created(hass: HomeAssistant) -> None:
-    """Test that utility meters are succesfully created when `create_utility_meter: true`"""
+    """Test that utility meters are successfully created when `create_utility_meter: true`"""
     await create_input_boolean(hass)
 
     await run_powercalc_setup(

--- a/utils/measure/measure/measure.py
+++ b/utils/measure/measure/measure.py
@@ -234,7 +234,7 @@ class Measure:
     def get_questions(self) -> list[Question]:
         """
         Build list of questions to ask.
-        Returns generic questions which are asked regardless of the choosen device type
+        Returns generic questions which are asked regardless of the chosen device type
         Additionally the configured runner and power_meter can also provide further questions
         """
         if self.measure_type not in [MeasureType.AVERAGE, MeasureType.RECORDER]:

--- a/utils/measure/measure/util/measure_util.py
+++ b/utils/measure/measure/util/measure_util.py
@@ -237,7 +237,7 @@ class MeasureUtil:
         print("Tip: Use a dummy load with constant power consumption. Stick to resistive loads for the best results!")
         print("Important: Connect only the dummy load to your smart plug—not the device you're measuring.")
         print()
-        print("The script will now measure the dummy load and continue once it's consumption has stablized.")
+        print("The script will now measure the dummy load and continue once it's consumption has stabilized.")
         print("Depending on the dummy load this may take 2 hours.")
         print()
         input("Ready to begin measuring the dummy load? Hit Enter ")
@@ -270,7 +270,7 @@ class MeasureUtil:
             if trend == Trend.STEADY:
                 break
 
-            print(f"Dummy load resistance has not yet stablized and is {trend}, repeating.")
+            print(f"Dummy load resistance has not yet stabilized and is {trend}, repeating.")
 
         average = round(mean(averages), 2)
 


### PR DESCRIPTION
Found a few spelling mistakes in one of the docs and did some checks with codespell. This PR enables codespell as part of pre-commit and fixes all of the identified spelling errors (all of them in strings or comments, not code).