### PR TITLE
Adding an alias for the LED2201G8 bulb as seen with firmware 3.0.23

### DIFF
--- a/profile_library/ikea/LED2201G8/model.json
+++ b/profile_library/ikea/LED2201G8/model.json
@@ -10,6 +10,9 @@
   },
   "name": "TRÅDFRI LED bulb E27 1055 lumen, smart wireless dimmable/white spectrum globe",
   "standby_power": 0.19,
+  "aliases": [
+    "TRADFRI bulb E27 WS globe 1055lm"
+  ],
   "created_at": "2023-12-28T17:44:26",
   "author": "Jari Eskelinen <jari.eskelinen@iki.fi>"
 }


### PR DESCRIPTION
Adding an alias for the LED2201G8 bulb as seen with firmware 3.0.23 (Up to date firmware)

**Getting the following error in home-assistant:**
Problem loading model: Model IKEA of Sweden TRADFRI bulb E27 WS globe 1055lm not found

**Also captured full text from device-info in the IKEA HomeSmart App.**
```
Firmware: 3.0.23 Up-to-date
Model: TRADFRI bulb E27 WS globe 1055lm
Product ID: LED2201G8
Serial number: 8C6FB9FFFEEA7EF2
Manufacturer: IKEA of Sweden
```