### PR TITLE
Adding pyenv version file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ cov.xml
 custom_components/test
 
 *.egg-info/
+
+# PyEnv Version File
+.python-version


### PR DESCRIPTION
The `.python-version` file is used for configuring python via [pyenv](https://github.com/pyenv/pyenv) and should be ignored as it refers to my local python virtualenv.