### PR TITLE
Adding an alias for Lenovo Smart Clock

### DIFF
--- a/profile_library/lenovo/Smart Clock with Google Assistant/model.json
+++ b/profile_library/lenovo/Smart Clock with Google Assistant/model.json
@@ -22,7 +22,8 @@
     ]
   },
   "aliases": [
-    "Lenovo Smart Clock"
+    "Lenovo Smart Clock",
+    "LenovoCD-24502F"
   ],
   "created_at": "2022-10-05T10:14:54",
   "author": "Daniel O'Connor <daniel.oconnor@gmail.com>"


### PR DESCRIPTION
Adding an alias for the Lenovo Smart Clock as seen in my Home Assistant:
<img width="353" height="239" alt="image" src="https://github.com/user-attachments/assets/e468058a-f2f9-4d85-90fe-af0c808ac8be" />