### PR TITLE
Measured Sonoff ZBMINIR2 Smart Switch

### DIFF
--- a/profile_library/sonoff/ZBMINIR2/model.json
+++ b/profile_library/sonoff/ZBMINIR2/model.json
@@ -12,9 +12,6 @@
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
   "only_self_usage": false,
-  "aliases": [
-    "ZBMINI Extreme Zigbee Smart Switch (Neutral Wire Required)"
-  ],
   "created_at": "2025-11-13T14:22:10",
   "author": "LtKowalski <232428921+LtKowalski@users.noreply.github.com>"
 }


### PR DESCRIPTION
Hi,

Thanks bramstroker for your awesome work!

The least I can do to help is to add some measurements. The first device I chose is my number one go-to smart switch: The Sonoff ZBMINIR2. It was hard to measure because it does not consume much energy when in standby mode.
I got myself a PeakTech 4350 which can measure small Amps.
Fortunately I got a lot of spare ZBMINIR2's so I installed 10 of them in a test setting for measurement. I measured the mA of the 10 devices with the PeakTech 4350 and the Voltage was measured by an IKEA INSPELNIG plug. Divided the result by 10 and got the Watt of a single device.
I did several runs for both states (standby and standby on) to ensure there were no measurement errors.