### PR TITLE
Add TP-Link Tapo P115 profile

### DIFF
--- a/profile_library/tp-link/P115/model.json
+++ b/profile_library/tp-link/P115/model.json
@@ -1,0 +1,17 @@
+{
+  "measure_description": "Manually measured.",
+  "measure_method": "manual",
+  "measure_device": "TP-Link Tapo P115",
+  "name": "TP Link Tapo P115 Mini Smart Wi-Fi Socket with Energy Monitoring",
+  "standby_power": 0.6,
+  "standby_power_on": 1.0,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "only_self_usage": true,
+  "created_at": "2025-11-14T10:49:34",
+  "author": "belledesire"
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
Tapo P115 Mini Smart Wi-Fi Socket, Energy Monitoring

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
P115
by TP-Link
Firmware: 1.3.4 Build 250403 Rel.150504
Hardware: 1.0 

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
Same device in specs as P110, copied from P110 profile, verified by measuring again myself