### PR TITLE
Add Hue infuse alias for white model

### DIFF
--- a/profile_library/signify/915005997301/model.json
+++ b/profile_library/signify/915005997301/model.json
@@ -10,10 +10,10 @@
     "VERSION": "v1.14.10:docker"
   },
   "name": "Hue Infuse Medium Ceiling Lamp",
-  "device_type": "light",  
+  "device_type": "light",
   "standby_power": 0.16,
   "aliases": [
     "915005997201"
-  ],  
+  ],
   "author": "vladi-k <53343355+vladi-k@users.noreply.github.com>"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
Hue Infuse ceiling light M (white version)

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
Hue Infuse ceiling (915005997201)
by Signify Netherlands B.V.
Connected via Hue Bridge Pro
Firmware: 1.122.8 

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
This is the alias for the white version of this lamp 915005997201
