### PR TITLE
Added black version alias in model.json

### DIFF
--- a/profile_library/signify/915005986901/model.json
+++ b/profile_library/signify/915005986901/model.json
@@ -9,7 +9,11 @@
     "VERSION": "v1.11.6:docker"
   },
   "name": "Hue Signe Gradient Table Lamp",
+  "device_type": "light",
   "standby_power": 0.6,
+  "aliases": [
+    "915005987001"
+  ],
   "author": "pwnagepeter <hauke@pwnagepeter.net>",
   "created_at": "2024-07-21T11:13:03"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
Hue Signe Gradient Table Lamp - Black

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
Device info
Signe gradient table (915005987001)
by Signify Netherlands B.V.
Connected via Hue Bridge Pro
Firmware: 1.122.8

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
Misnamed the branch and commit, sorry for that but this actually adds the black color version to the existing white one