### PR TITLE
Add alias for Hue Devere Medium model

### DIFF
--- a/profile_library/signify/915005996601/model.json
+++ b/profile_library/signify/915005996601/model.json
@@ -8,6 +8,7 @@
     "VERSION": "master"
   },
   "name": "Hue Enrave Medium",
+  "device_type": "light",
   "standby_power": 0.1,
   "calculation_strategy": "lut",
   "aliases": [


### PR DESCRIPTION
This fixes Issue #3609

Adds an alias to the Enrave Medium Model to also reflect the Devere Medium Model.