### PR TITLE
Added Matter alias for Aqara Smart Plug EU

### DIFF
--- a/profile_library/aqara/lumi.plug.maeu01/model.json
+++ b/profile_library/aqara/lumi.plug.maeu01/model.json
@@ -11,6 +11,9 @@
   },
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
+  "aliases": [
+    "Aqara Smart Plug EU"
+  ],
   "only_self_usage": true,
   "created_at": "2023-12-17T16:08:15",
   "author": "BenRoe"


### PR DESCRIPTION
Alias for plug as identified by Matter.
That's the only EU plug in the product line, so it's safe to add it.