### PR TITLE
Document analytics feature introduction version

### DIFF
--- a/docs/source/misc/analytics.md
+++ b/docs/source/misc/analytics.md
@@ -4,6 +4,10 @@ Powercalc can optionally send a small amount of anonymous, aggregated usage data
 
 This feature is **opt-in**, can be disabled at any time.
 
+!!! note
+
+    This feature was introduced in v1.20.0-beta.1. Versions before this do not send analytics.
+
 ---
 
 ## Why we collect analytics


### PR DESCRIPTION
I was on the wiki looking for information about how to use an energy monitor device with PowerCalc (measuring what it is measuring, with consistent UI around the energy/usage etc - rather than the measurement device itself which is the default) when I came across [Analytics](https://docs.powercalc.nl/misc/analytics/).

> UPDATE: For posterity, how to configure that is [here](https://docs.powercalc.nl/sensor-types/real-power-sensor/). It is supported in the UI.

I went to go enable it (_really, I should've delayed and should read the code before doing such things :-D but I thought "hey, this is useful and I think this guy would use the data for 😇 not 😈"_) and noticed no setting.

Then I got anxious that maybe the wiki for configuration was outdated, and the ability to opt-out had been removed, sending data all of the time!  This is **not the case**, and that's why I send this change request, in case anyone else is an anxious morning person like myself 😅

