### PR TITLE
Update standby power value for Play:1 model

### DIFF
--- a/profile_library/sonos/play 1/model.json
+++ b/profile_library/sonos/play 1/model.json
@@ -26,5 +26,5 @@
   "measure_device": "ZOOZ Z-WAVE PLUS S2 POWER STRIP ZEN20 VER. 3.0",
   "measure_method": "script",
   "name": "Play:1",
-  "standby_power": 3.8
+  "standby_power": 3.31
 }


### PR DESCRIPTION
As of official SONOS documentation below, standby power is 3.8 watts for 230V.

https://support.sonos.com/en-us/article/sonos-power-consumption-while-idle