### PR TITLE
Adding support for nest wifi point

### DIFF
--- a/profile_library/google/Nest Wifi Point (H2E)/model.json
+++ b/profile_library/google/Nest Wifi Point (H2E)/model.json
@@ -6,7 +6,7 @@
   "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
   "calculation_strategy": "linear",
   "created_at": "2026-01-21T21:30:47.471720",
-  "device_type": "smart_speaker",
+  "device_type": "generic_iot",
   "linear_config": {
     "calibrate": [
       "10 -> 4.0",


### PR DESCRIPTION
yes this is both a speaker and a wifi point

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
-->
Nest wifi point by google - this is their weird wifi point/ smart speaker they made.
I believe their newer models of wifi points do not have any smart speaker functionality.
There is no longer a relevant link to this product on the google store as it is old and Google is really bad at maintaining product information pages.
This is probably the best page they provide: https://support.google.com/googlenest/answer/6280668?hl=en

## Home Assistant Device information
<!--
-->
Device info
Nest Wifi point
by Google Inc. 


## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [X] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [NA] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [NA] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
-->
Kind of weird how this device works, but it is both a mesh wifi point and also it is a smart speaker.
It didn't really have anything going on for the wifi front while I was running the tests - just baseline radio traffic from the smart plug that was doing the measurements in question. Presumably this means that when wifi traffic is going crazy over the wifi point the standby values would be higher, but no real way for me to accurately measure that.

