### PR TITLE
adding support for tapo P110m

### DIFF
--- a/profile_library/tp-link/P110M/model.json
+++ b/profile_library/tp-link/P110M/model.json
@@ -1,0 +1,20 @@
+{
+  "aliases": [
+    "261"
+  ],
+  "author": "Bob Shaker <bobshaker1@gmail.com>",
+  "calculation_strategy": "fixed",
+  "created_at": "2026-01-21T16:14:00",
+  "device_type": "smart_switch",
+  "measure_description": "Manually measured.",
+  "measure_device": "Shelly EM Mini Gen4",
+  "measure_method": "manual",
+  "name": "Tapo Mini Smart Wi-Fi Plug with Energy Monitoring, Matter Certified",
+  "only_self_usage": true,
+  "sensor_config": {
+    "energy_sensor_naming": "{} Device Energy",
+    "power_sensor_naming": "{} Device Power"
+  },
+  "standby_power": 0.3,
+  "standby_power_on": 1.2
+}

--- a/profile_library/tp-link/manufacturer.json
+++ b/profile_library/tp-link/manufacturer.json
@@ -1,6 +1,7 @@
 {
   "name": "TP-Link",
   "aliases": [
-    "Tapo"
+    "Tapo",
+    "Kasa"
   ]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.

-->
  https://www.tp-link.com/us/home-networking/smart-plug/tapo-p110m/

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

From the matter integration:

Smart Wi-Fi Plug (261)
by Tapo
Firmware: 1.3.0
Hardware: 1.0
Serial number: xxx
Node ID: xxx
Network type: Wi-Fi
Device type: End device
Network name: xxx
MAC address: xxx
IP address(es): xxx


From the tp-link integration:
P110M
by TP-Link
Firmware: 1.3.2 Build 250526 Rel.171305
Hardware: 1.0 

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [na] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [na] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
