### PR TITLE
correctly flag wyze plug as a smart plug without built-in energy moni…

### DIFF
--- a/profile_library/wyze/WLPP1CFH/model.json
+++ b/profile_library/wyze/WLPP1CFH/model.json
@@ -7,11 +7,6 @@
   "measure_device": "Shelly EM Mini Gen4",
   "measure_method": "manual",
   "name": "Plug",
-  "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 1.4,
   "standby_power_on": 1.6
 }


### PR DESCRIPTION
…toring

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
Wyze plug

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
Device already exists - but
WLPP1CFH
WyzeLabs

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [X] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->

Just fixing the profile I submitted yesterday - didn't realize when I copied the profile file manually from my TP-link P110M I was accidentally setting up the Wyze plug as a plug that had energy monitoring. This device does not, it is rather old and simple.