### PR TITLE
Change only_self_usage from true to false

### DIFF
--- a/profile_library/innr/OSP 210/model.json
+++ b/profile_library/innr/OSP 210/model.json
@@ -8,10 +8,6 @@
   "measure_method": "manual",
   "name": "Zigbee Outdoor Smart Plug",
   "only_self_usage": false,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.3,
   "standby_power_on": 0.8,
   "author_info": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information

Innr OSP 210 Zigbee Outdoor smart plug (self usage fixed)

## Home Assistant Device information

OSP 210
by innr
Connected via SMLight Zigbee Coordinator (EZSP)
Firmware: 0x11003674

## Checklist

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
Adjustment of self usage (bugfix)