### PR TITLE
Added Xiaomi Multimode Gateway (aka Gateway 3)

### DIFF
--- a/profile_library/xiaomi/lumi.gateway.mgl03/model.json
+++ b/profile_library/xiaomi/lumi.gateway.mgl03/model.json
@@ -1,0 +1,24 @@
+{
+  "created_at": "2025-05-01T21:56:26Z",
+  "measure_description": "Measured with avg caluclation during 600s with dummy load. Samsung USB power adapter used.",
+  "measure_method": "script",
+  "measure_settings": {
+    "VERSION": "v1.17.11:docker"
+  },
+  "measure_device": "Shelly PM Mini Gen3",
+  "name": "lumi.gateway.mgl03",
+  "aliases": [
+    "Gateway: ZNDMWG03LM, ZNDMWG02LM, YTC4044GL, lumi.gateway.mgl03",
+    "gateway ZNDMWG03LM"
+  ],
+  "discovery_by": "device",
+  "device_type": "network",
+  "only_self_usage": true,
+  "calculation_strategy": "fixed",
+  "standby_power": 1.51,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "author": "Largelos"
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
 Xiaomi Multimode Gateway (aka Gateway 3) 
 Connected by https://github.com/AlexxIT/XiaomiGateway3

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
Gateway: ZNDMWG03LM, ZNDMWG02LM, YTC4044GL, lumi.gateway.mgl03
by Xiaomi
Firmware: 1.5.4_0090
MAC: [54:EF:44:C8:49:67](http://172.16.1.228:8123/config/dhcp?mac_address=54%3Aef%3A44%3Ac8%3A49%3A67)

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [X] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
Measured by Shelly PM Mini Gen3 with avg caluclation during 600s with dummy load. Samsung USB power adapter used.