### PR TITLE
Add alias from official esphome config file

### DIFF
--- a/profile_library/athom/rgbww-light/model.json
+++ b/profile_library/athom/rgbww-light/model.json
@@ -1,4 +1,7 @@
 {
+  "aliases": [
+    "athom.rgbww-light"
+  ],
   "author": "DellanX <31318348+DellanX@users.noreply.github.com>",
   "calculation_strategy": "lut",
   "created_at": "2022-09-15T20:58:17Z",


### PR DESCRIPTION
see https://devices.esphome.io/devices/athom-e27-7w-bulb/