### PR TITLE
Add Bang & Olufsen Beosound Edge

### DIFF
--- a/profile_library/bang olufsen/Beosound Edge/model.json
+++ b/profile_library/bang olufsen/Beosound Edge/model.json
@@ -1,41 +1,41 @@
 {
-    "author": "sbrandsborg",
-    "aliases": [
-        "6661 S53",
-        "Beosound Edge"
-    ],
-    "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
-    "calculation_strategy": "linear",
-    "created_at": "2026-01-29T07:14:10Z",
-    "device_type": "smart_speaker",
-    "linear_config": {
-        "calibrate": [
-            "0 -> 2.4",
-            "10 -> 23.7",
-            "20 -> 23.8",
-            "30 -> 23.8",
-            "40 -> 23.8",
-            "50 -> 24.25",
-            "60 -> 26.62",
-            "70 -> 26.5",
-            "80 -> 26.4",
-            "90 -> 34.98",
-            "100 -> 36.6"
-        ]
-    },
-    "description": "Beosound Edge - Multiroom speaker",
-    "measure_description": "Measured with utils/measure script using manual streaming (Pink Noise) due to API limitations with automated playback.",
-    "measure_device": "Shelly Plug S Gen3",
-    "measure_method": "script",
-    "measure_settings": {
-        "SAMPLE_COUNT": 1,
-        "SLEEP_TIME": 5,
-        "VERSION": "master"
-    },
-    "name": "Beosound Edge",
-    "standby_power": 2.4,
-    "author_info": {
-        "name": "Steffen Brandsborg",
-        "github": "sbrandsborg"
-    }
+  "author": "sbrandsborg",
+  "aliases": [
+    "6661 S53",
+    "Beosound Edge"
+  ],
+  "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+  "calculation_strategy": "linear",
+  "created_at": "2026-01-29T07:14:10Z",
+  "device_type": "smart_speaker",
+  "linear_config": {
+    "calibrate": [
+      "0 -> 2.4",
+      "10 -> 23.7",
+      "20 -> 23.8",
+      "30 -> 23.8",
+      "40 -> 23.8",
+      "50 -> 24.25",
+      "60 -> 26.62",
+      "70 -> 26.5",
+      "80 -> 26.4",
+      "90 -> 34.98",
+      "100 -> 36.6"
+    ]
+  },
+  "description": "Beosound Edge - Multiroom speaker",
+  "measure_description": "Measured with utils/measure script using manual streaming (Pink Noise) due to API limitations with automated playback.",
+  "measure_device": "Shelly Plug S Gen3",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 1,
+    "SLEEP_TIME": 5,
+    "VERSION": "master"
+  },
+  "name": "Beosound Edge",
+  "standby_power": 2.4,
+  "author_info": {
+    "name": "Steffen Brandsborg",
+    "github": "sbrandsborg"
+  }
 }


### PR DESCRIPTION
Added model.json for Beosound Edge with specifications and measurement details.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
https://www.bang-olufsen.com/en/int/speakers/beosound-edge
## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
6661 S53
by Bang & Olufsen
## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
