### PR TITLE
Add Beoplay M5

### DIFF
--- a/profile_library/bang olufsen/Beoplay M5/model.json
+++ b/profile_library/bang olufsen/Beoplay M5/model.json
@@ -1,40 +1,40 @@
 {
-    "author": "sbrandsborg",
-    "aliases": [
-        "Beoplay M5"
-    ],
-    "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
-    "calculation_strategy": "linear",
-    "created_at": "2026-01-29T12:42:28Z",
-    "device_type": "smart_speaker",
-    "linear_config": {
-        "calibrate": [
-            "0 -> 3.2",
-            "10 -> 5.9",
-            "20 -> 7.0",
-            "30 -> 7.0",
-            "40 -> 6.9",
-            "50 -> 6.6",
-            "60 -> 7.58",
-            "70 -> 9.43",
-            "80 -> 14.88",
-            "90 -> 19.2",
-            "100 -> 20.3"
-        ]
-    },
-    "description": "Beoplay M5 - Powerful Wireless Speaker",
-    "measure_description": "Measured with utils/measure script (full 100% volume) using standard settings (1 sample, 5s sleep).",
-    "measure_device": "Shelly Plug S Gen3",
-    "measure_method": "script",
-    "measure_settings": {
-        "SAMPLE_COUNT": 1,
-        "SLEEP_TIME": 5,
-        "VERSION": "master"
-    },
-    "name": "Beoplay M5",
-    "standby_power": 3.2,
-    "author_info": {
-        "name": "Steffen Brandsborg",
-        "github": "sbrandsborg"
-    }
+  "author": "sbrandsborg",
+  "aliases": [
+    "Beoplay M5"
+  ],
+  "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+  "calculation_strategy": "linear",
+  "created_at": "2026-01-29T12:42:28Z",
+  "device_type": "smart_speaker",
+  "linear_config": {
+    "calibrate": [
+      "0 -> 3.2",
+      "10 -> 5.9",
+      "20 -> 7.0",
+      "30 -> 7.0",
+      "40 -> 6.9",
+      "50 -> 6.6",
+      "60 -> 7.58",
+      "70 -> 9.43",
+      "80 -> 14.88",
+      "90 -> 19.2",
+      "100 -> 20.3"
+    ]
+  },
+  "description": "Beoplay M5 - Powerful Wireless Speaker",
+  "measure_description": "Measured with utils/measure script (full 100% volume) using standard settings (1 sample, 5s sleep).",
+  "measure_device": "Shelly Plug S Gen3",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 1,
+    "SLEEP_TIME": 5,
+    "VERSION": "master"
+  },
+  "name": "Beoplay M5",
+  "standby_power": 3.2,
+  "author_info": {
+    "name": "Steffen Brandsborg",
+    "github": "sbrandsborg"
+  }
 }


### PR DESCRIPTION
Added model configuration for Beoplay M5 smart speaker.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
https://www.bang-olufsen.com/en/int/speakers/beoplay-m5
## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
2714 CA16
by Bang & Olufsen
## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
