### PR TITLE
Add FRITZ!Repeater 2700

### DIFF
--- a/profile_library/avm/FRITZ!Repeater 2700/model.json
+++ b/profile_library/avm/FRITZ!Repeater 2700/model.json
@@ -1,0 +1,21 @@
+{
+  "author": "hpuac",
+  "calculation_strategy": "fixed",
+  "created_at": "2026-02-14T19:53:35Z",
+  "device_type": "network",
+  "fixed_config": {
+    "power": 4.79
+  },
+  "measure_description": "Measured with Powercalc measure tool in Average mode (600 seconds)",
+  "measure_device": "Shelly Plug S",
+  "measure_method": "script",
+  "name": "FRITZ!Repeater 2700",
+  "sensor_config": {
+    "energy_sensor_naming": "{} Device Energy",
+    "power_sensor_naming": "{} Device Power"
+  },
+  "author_info": {
+    "name": "hpuac",
+    "github": "hpuac"
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
[FRITZ!Repeater 2700](https://fritz.com/products/fritz-repeater-2700-20003135)

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
```
FRITZ!Repeater 2700
von FRITZ!
```
<img width="303" height="151" alt="Screenshot 2026-02-14 at 21 43 41" src="https://github.com/user-attachments/assets/180a0a3a-5a18-4efc-a7e0-a0e0529e1b89" />

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
- Device was connected via 2.5-gigabit LAN
- Multiple WiFi devices were connected
- 2.4 and 5 GHz Wi-Fi were enabled
- Measured via Shelly Plug S Gen 1

Script output:
```
docker run --pull=always --rm --name=measure --env-file=.env -v $(pwd)/export:/app/export -v $(pwd)/.persistent:/app/.persistent -it bramgerritsen/powercalc-measure:latest
latest: Pulling from bramgerritsen/powercalc-measure
Digest: sha256:3410a30a929e434f2e74c7307e6eb48554740b0fe75215e8d887299a44b63068
Status: Image is up to date for bramgerritsen/powercalc-measure:latest
Powercalc measure: v1.20.5:docker

2026-02-14 19:41:53,800 [INFO] Selected powermeter: shelly
2026-02-14 19:41:53,800 [INFO] Selected light controller: hue
[?] What kind of measurement session do you want to run?: 
   Light bulb(s)
   Smart speaker
   Recorder
 > Average
   Charging device
   Fan

[?] For how long do you want to measure? In seconds: 600
2026-02-14 19:43:36,271 [INFO] Exporting to /app/export/generic
Press enter to start
2026-02-14 19:43:37,849 [INFO] Measuring average power over 600 seconds
2026-02-14 19:43:37,907 [INFO] Measured power: 4.65 W
2026-02-14 19:43:40,975 [INFO] Measured power: 4.84 W
2026-02-14 19:43:44,043 [INFO] Measured power: 4.75 W
2026-02-14 19:43:47,110 [INFO] Measured power: 4.68 W
2026-02-14 19:43:50,200 [INFO] Measured power: 4.81 W
2026-02-14 19:43:53,271 [INFO] Measured power: 4.86 W
2026-02-14 19:43:56,338 [INFO] Measured power: 4.80 W
2026-02-14 19:43:59,410 [INFO] Measured power: 4.90 W
2026-02-14 19:44:02,481 [INFO] Measured power: 4.81 W
2026-02-14 19:44:05,556 [INFO] Measured power: 4.68 W
2026-02-14 19:44:08,615 [INFO] Measured power: 4.95 W
2026-02-14 19:44:11,670 [INFO] Measured power: 4.67 W
2026-02-14 19:44:14,735 [INFO] Measured power: 4.74 W
2026-02-14 19:44:17,802 [INFO] Measured power: 4.80 W
2026-02-14 19:44:20,868 [INFO] Measured power: 4.67 W
2026-02-14 19:44:23,930 [INFO] Measured power: 4.72 W
2026-02-14 19:44:26,990 [INFO] Measured power: 4.85 W
2026-02-14 19:44:30,059 [INFO] Measured power: 4.70 W
2026-02-14 19:44:33,137 [INFO] Measured power: 4.68 W
2026-02-14 19:44:36,203 [INFO] Measured power: 4.71 W
2026-02-14 19:44:39,269 [INFO] Measured power: 4.73 W
2026-02-14 19:44:42,342 [INFO] Measured power: 4.95 W
2026-02-14 19:44:45,450 [INFO] Measured power: 4.81 W
2026-02-14 19:44:48,519 [INFO] Measured power: 5.02 W
2026-02-14 19:44:51,588 [INFO] Measured power: 4.78 W
2026-02-14 19:44:54,645 [INFO] Measured power: 4.74 W
2026-02-14 19:44:57,701 [INFO] Measured power: 4.84 W
2026-02-14 19:45:00,760 [INFO] Measured power: 4.77 W
2026-02-14 19:45:03,824 [INFO] Measured power: 4.76 W
2026-02-14 19:45:06,889 [INFO] Measured power: 4.79 W
2026-02-14 19:45:09,953 [INFO] Measured power: 4.98 W
2026-02-14 19:45:13,042 [INFO] Measured power: 4.84 W
2026-02-14 19:45:16,123 [INFO] Measured power: 4.98 W
2026-02-14 19:45:20,184 [INFO] Measured power: 4.70 W
2026-02-14 19:45:23,251 [INFO] Measured power: 4.76 W
2026-02-14 19:45:26,302 [INFO] Measured power: 4.68 W
2026-02-14 19:45:29,367 [INFO] Measured power: 4.77 W
2026-02-14 19:45:32,427 [INFO] Measured power: 4.67 W
2026-02-14 19:45:35,502 [INFO] Measured power: 4.64 W
2026-02-14 19:45:38,562 [INFO] Measured power: 4.72 W
2026-02-14 19:45:41,630 [INFO] Measured power: 4.89 W
2026-02-14 19:45:44,694 [INFO] Measured power: 4.65 W
2026-02-14 19:45:47,755 [INFO] Measured power: 4.72 W
2026-02-14 19:45:50,814 [INFO] Measured power: 4.80 W
2026-02-14 19:45:53,890 [INFO] Measured power: 4.66 W
2026-02-14 19:45:56,956 [INFO] Measured power: 4.66 W
2026-02-14 19:46:00,024 [INFO] Measured power: 4.83 W
2026-02-14 19:46:03,091 [INFO] Measured power: 4.75 W
2026-02-14 19:46:06,167 [INFO] Measured power: 4.84 W
2026-02-14 19:46:09,236 [INFO] Measured power: 4.75 W
2026-02-14 19:46:12,305 [INFO] Measured power: 4.74 W
2026-02-14 19:46:15,371 [INFO] Measured power: 4.84 W
2026-02-14 19:46:18,447 [INFO] Measured power: 4.96 W
2026-02-14 19:46:21,516 [INFO] Measured power: 4.77 W
2026-02-14 19:46:24,582 [INFO] Measured power: 4.89 W
2026-02-14 19:46:27,648 [INFO] Measured power: 4.67 W
2026-02-14 19:46:30,721 [INFO] Measured power: 4.70 W
2026-02-14 19:46:33,779 [INFO] Measured power: 4.72 W
2026-02-14 19:46:36,847 [INFO] Measured power: 4.68 W
2026-02-14 19:46:39,910 [INFO] Measured power: 4.68 W
2026-02-14 19:46:42,973 [INFO] Measured power: 4.80 W
2026-02-14 19:46:46,050 [INFO] Measured power: 4.61 W
2026-02-14 19:46:49,125 [INFO] Measured power: 4.69 W
2026-02-14 19:46:52,191 [INFO] Measured power: 4.65 W
2026-02-14 19:46:55,267 [INFO] Measured power: 4.55 W
2026-02-14 19:46:58,336 [INFO] Measured power: 4.58 W
2026-02-14 19:47:01,396 [INFO] Measured power: 4.85 W
2026-02-14 19:47:04,463 [INFO] Measured power: 4.77 W
2026-02-14 19:47:07,548 [INFO] Measured power: 4.86 W
2026-02-14 19:47:10,615 [INFO] Measured power: 4.82 W
2026-02-14 19:47:13,673 [INFO] Measured power: 4.57 W
2026-02-14 19:47:16,745 [INFO] Measured power: 4.59 W
2026-02-14 19:47:19,804 [INFO] Measured power: 4.71 W
2026-02-14 19:47:22,871 [INFO] Measured power: 4.92 W
2026-02-14 19:47:25,936 [INFO] Measured power: 4.68 W
2026-02-14 19:47:28,997 [INFO] Measured power: 4.87 W
2026-02-14 19:47:32,063 [INFO] Measured power: 4.75 W
2026-02-14 19:47:35,129 [INFO] Measured power: 4.81 W
2026-02-14 19:47:38,191 [INFO] Measured power: 4.80 W
2026-02-14 19:47:41,249 [INFO] Measured power: 4.87 W
2026-02-14 19:47:44,312 [INFO] Measured power: 4.74 W
2026-02-14 19:47:47,371 [INFO] Measured power: 4.76 W
2026-02-14 19:47:50,449 [INFO] Measured power: 4.66 W
2026-02-14 19:47:53,524 [INFO] Measured power: 4.87 W
2026-02-14 19:47:56,597 [INFO] Measured power: 4.68 W
2026-02-14 19:47:59,662 [INFO] Measured power: 4.85 W
2026-02-14 19:48:02,726 [INFO] Measured power: 4.73 W
2026-02-14 19:48:05,794 [INFO] Measured power: 4.85 W
2026-02-14 19:48:08,848 [INFO] Measured power: 4.81 W
2026-02-14 19:48:11,912 [INFO] Measured power: 4.94 W
2026-02-14 19:48:14,971 [INFO] Measured power: 4.72 W
2026-02-14 19:48:18,036 [INFO] Measured power: 4.57 W
2026-02-14 19:48:21,092 [INFO] Measured power: 4.76 W
2026-02-14 19:48:24,149 [INFO] Measured power: 4.64 W
2026-02-14 19:48:27,210 [INFO] Measured power: 4.83 W
2026-02-14 19:48:30,275 [INFO] Measured power: 4.67 W
2026-02-14 19:48:33,342 [INFO] Measured power: 4.75 W
2026-02-14 19:48:36,407 [INFO] Measured power: 4.75 W
2026-02-14 19:48:39,477 [INFO] Measured power: 4.81 W
2026-02-14 19:48:42,539 [INFO] Measured power: 4.94 W
2026-02-14 19:48:45,598 [INFO] Measured power: 4.94 W
2026-02-14 19:48:48,663 [INFO] Measured power: 4.91 W
2026-02-14 19:48:51,722 [INFO] Measured power: 4.82 W
2026-02-14 19:48:54,783 [INFO] Measured power: 4.89 W
2026-02-14 19:48:57,848 [INFO] Measured power: 4.79 W
2026-02-14 19:49:00,910 [INFO] Measured power: 4.55 W
2026-02-14 19:49:03,973 [INFO] Measured power: 4.77 W
2026-02-14 19:49:07,028 [INFO] Measured power: 4.74 W
2026-02-14 19:49:10,086 [INFO] Measured power: 4.63 W
2026-02-14 19:49:13,142 [INFO] Measured power: 4.84 W
2026-02-14 19:49:16,207 [INFO] Measured power: 4.63 W
2026-02-14 19:49:19,277 [INFO] Measured power: 4.60 W
2026-02-14 19:49:22,360 [INFO] Measured power: 4.91 W
2026-02-14 19:49:25,425 [INFO] Measured power: 4.44 W
2026-02-14 19:49:28,485 [INFO] Measured power: 4.87 W
2026-02-14 19:49:31,547 [INFO] Measured power: 4.85 W
2026-02-14 19:49:34,607 [INFO] Measured power: 4.51 W
2026-02-14 19:49:37,677 [INFO] Measured power: 5.01 W
2026-02-14 19:49:40,739 [INFO] Measured power: 4.96 W
2026-02-14 19:49:43,807 [INFO] Measured power: 4.96 W
2026-02-14 19:49:46,876 [INFO] Measured power: 4.94 W
2026-02-14 19:49:49,936 [INFO] Measured power: 4.85 W
2026-02-14 19:49:53,006 [INFO] Measured power: 4.65 W
2026-02-14 19:49:56,075 [INFO] Measured power: 4.46 W
2026-02-14 19:49:59,141 [INFO] Measured power: 4.66 W
2026-02-14 19:50:02,202 [INFO] Measured power: 4.77 W
2026-02-14 19:50:05,262 [INFO] Measured power: 4.77 W
2026-02-14 19:50:08,327 [INFO] Measured power: 4.86 W
2026-02-14 19:50:11,387 [INFO] Measured power: 5.17 W
2026-02-14 19:50:14,446 [INFO] Measured power: 4.83 W
2026-02-14 19:50:17,501 [INFO] Measured power: 4.63 W
2026-02-14 19:50:20,573 [INFO] Measured power: 5.31 W
2026-02-14 19:50:23,640 [INFO] Measured power: 4.98 W
2026-02-14 19:50:26,721 [INFO] Measured power: 5.01 W
2026-02-14 19:50:29,789 [INFO] Measured power: 4.76 W
2026-02-14 19:50:32,854 [INFO] Measured power: 4.92 W
2026-02-14 19:50:35,913 [INFO] Measured power: 4.85 W
2026-02-14 19:50:38,980 [INFO] Measured power: 4.85 W
2026-02-14 19:50:42,041 [INFO] Measured power: 4.80 W
2026-02-14 19:50:45,108 [INFO] Measured power: 5.18 W
2026-02-14 19:50:48,174 [INFO] Measured power: 5.01 W
2026-02-14 19:50:51,241 [INFO] Measured power: 4.74 W
2026-02-14 19:50:54,295 [INFO] Measured power: 4.96 W
2026-02-14 19:50:57,353 [INFO] Measured power: 5.04 W
2026-02-14 19:51:00,416 [INFO] Measured power: 4.73 W
2026-02-14 19:51:03,481 [INFO] Measured power: 4.77 W
2026-02-14 19:51:06,543 [INFO] Measured power: 4.73 W
2026-02-14 19:51:09,626 [INFO] Measured power: 4.76 W
2026-02-14 19:51:12,684 [INFO] Measured power: 4.58 W
2026-02-14 19:51:15,751 [INFO] Measured power: 4.70 W
2026-02-14 19:51:18,810 [INFO] Measured power: 4.88 W
2026-02-14 19:51:21,875 [INFO] Measured power: 4.85 W
2026-02-14 19:51:24,946 [INFO] Measured power: 4.68 W
2026-02-14 19:51:28,008 [INFO] Measured power: 4.42 W
2026-02-14 19:51:31,070 [INFO] Measured power: 4.84 W
2026-02-14 19:51:34,228 [INFO] Measured power: 4.95 W
2026-02-14 19:51:37,310 [INFO] Measured power: 4.59 W
2026-02-14 19:51:40,376 [INFO] Measured power: 5.06 W
2026-02-14 19:51:43,450 [INFO] Measured power: 4.68 W
2026-02-14 19:51:46,514 [INFO] Measured power: 4.71 W
2026-02-14 19:51:49,575 [INFO] Measured power: 4.81 W
2026-02-14 19:51:52,642 [INFO] Measured power: 5.01 W
2026-02-14 19:51:55,712 [INFO] Measured power: 4.63 W
2026-02-14 19:51:58,797 [INFO] Measured power: 4.96 W
2026-02-14 19:52:01,865 [INFO] Measured power: 4.63 W
2026-02-14 19:52:04,937 [INFO] Measured power: 4.75 W
2026-02-14 19:52:08,004 [INFO] Measured power: 4.84 W
2026-02-14 19:52:11,068 [INFO] Measured power: 4.74 W
2026-02-14 19:52:14,131 [INFO] Measured power: 4.78 W
2026-02-14 19:52:17,196 [INFO] Measured power: 4.70 W
2026-02-14 19:52:20,290 [INFO] Measured power: 4.79 W
2026-02-14 19:52:23,356 [INFO] Measured power: 4.80 W
2026-02-14 19:52:27,417 [INFO] Measured power: 4.73 W
2026-02-14 19:52:30,483 [INFO] Measured power: 4.84 W
2026-02-14 19:52:33,551 [INFO] Measured power: 4.68 W
2026-02-14 19:52:36,612 [INFO] Measured power: 4.58 W
2026-02-14 19:52:39,686 [INFO] Measured power: 4.62 W
2026-02-14 19:52:42,749 [INFO] Measured power: 4.79 W
2026-02-14 19:52:45,805 [INFO] Measured power: 4.70 W
2026-02-14 19:52:48,866 [INFO] Measured power: 4.87 W
2026-02-14 19:52:51,930 [INFO] Measured power: 4.75 W
2026-02-14 19:52:54,992 [INFO] Measured power: 4.77 W
2026-02-14 19:52:58,062 [INFO] Measured power: 4.87 W
2026-02-14 19:53:01,127 [INFO] Measured power: 4.61 W
2026-02-14 19:53:04,440 [INFO] Measured power: 4.82 W
2026-02-14 19:53:07,502 [INFO] Measured power: 4.72 W
2026-02-14 19:53:10,570 [INFO] Measured power: 4.70 W
2026-02-14 19:53:13,633 [INFO] Measured power: 4.99 W
2026-02-14 19:53:16,694 [INFO] Measured power: 6.00 W
2026-02-14 19:53:19,750 [INFO] Measured power: 4.83 W
2026-02-14 19:53:22,817 [INFO] Measured power: 4.89 W
2026-02-14 19:53:25,877 [INFO] Measured power: 4.87 W
2026-02-14 19:53:28,938 [INFO] Measured power: 4.99 W
2026-02-14 19:53:32,000 [INFO] Measured power: 4.82 W
2026-02-14 19:53:35,061 [INFO] Measured power: 4.89 W
2026-02-14 19:53:35,064 [INFO] Average of 195 measurements: 4.79 W
```