### PR TITLE
Add FRITZ!Box 6670 Cable

### DIFF
--- a/profile_library/avm/FRITZ!Box 6670 Cable/model.json
+++ b/profile_library/avm/FRITZ!Box 6670 Cable/model.json
@@ -1,0 +1,17 @@
+{
+  "author": "hpuac",
+  "calculation_strategy": "fixed",
+  "created_at": "2026-02-14T20:27:59Z",
+  "device_type": "network",
+  "fixed_config": {
+    "power": 12.14
+  },
+  "measure_description": "Measured with Powercalc measure tool in Average mode (600 seconds)",
+  "measure_device": "Shelly Plug S",
+  "measure_method": "script",
+  "name": "FRITZ!Box 6670 Cable",
+  "author_info": {
+    "name": "hpuac",
+    "github": "hpuac"
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
[FRITZ!Box 6670 Cable](https://fritz.com/products/fritz-box-6670-cable-20003047)

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
```
FRITZ!Box 6670 Cable
von FRITZ! 
```
<img width="304" height="148" alt="Screenshot 2026-02-14 at 22 04 44" src="https://github.com/user-attachments/assets/caae0ef2-2961-4edd-93ab-f8449f08b823" />

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Note, please read
I was not sure if I should raise this PR or not. Because https://github.com/bramstroker/homeassistant-powercalc/pull/3214 was initially challenged but then later https://github.com/bramstroker/homeassistant-powercalc/pull/3745 was merged. 
As I measured the device anyways, I thought let's try it, worst case we close it again. But I guess then also https://github.com/bramstroker/homeassistant-powercalc/pull/3745 should be removed again to be consistent.

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
- Device was connected via Cable, 1126,4 Mbit/s down, 52,5 Mbit/s up
- Network switch was connected via 2.5-gigabit LAN
- Multiple WiFi devices were connected
- 2.4 and 5 GHz Wi-Fi were enabled
- Smart Home/NAS functionality is not used
- Measured via Shelly Plug S Gen 1

Script output:
```
docker run --pull=always --rm --name=measure --env-file=.env -v $(pwd)/export:/app/export -v $(pwd)/.persistent:/app/.persistent -it bramgerritsen/powercalc-measure:latest
latest: Pulling from bramgerritsen/powercalc-measure
Digest: sha256:3410a30a929e434f2e74c7307e6eb48554740b0fe75215e8d887299a44b63068
Status: Image is up to date for bramgerritsen/powercalc-measure:latest
Powercalc measure: v1.20.5:docker

2026-02-14 20:17:06,092 [INFO] Selected powermeter: shelly
2026-02-14 20:17:06,092 [INFO] Selected light controller: hue
[?] What kind of measurement session do you want to run?: 
   Light bulb(s)
   Smart speaker
   Recorder
 > Average
   Charging device
   Fan

[?] For how long do you want to measure? In seconds: 600
2026-02-14 20:17:11,777 [INFO] Exporting to /app/export/generic
Press enter to start
2026-02-14 20:18:02,863 [INFO] Measuring average power over 600 seconds
2026-02-14 20:18:02,926 [INFO] Measured power: 12.00 W
2026-02-14 20:18:05,990 [INFO] Measured power: 12.06 W
2026-02-14 20:18:09,056 [INFO] Measured power: 11.92 W
2026-02-14 20:18:12,141 [INFO] Measured power: 12.13 W
2026-02-14 20:18:15,207 [INFO] Measured power: 12.38 W
2026-02-14 20:18:19,223 [INFO] Measured power: 12.45 W
2026-02-14 20:18:22,287 [INFO] Measured power: 12.32 W
2026-02-14 20:18:25,628 [INFO] Measured power: 12.10 W
2026-02-14 20:18:28,929 [INFO] Measured power: 12.29 W
2026-02-14 20:18:31,998 [INFO] Measured power: 12.22 W
2026-02-14 20:18:35,063 [INFO] Measured power: 12.06 W
2026-02-14 20:18:38,141 [INFO] Measured power: 12.01 W
2026-02-14 20:18:41,461 [INFO] Measured power: 12.09 W
2026-02-14 20:18:45,524 [INFO] Measured power: 12.40 W
2026-02-14 20:18:48,592 [INFO] Measured power: 12.03 W
2026-02-14 20:18:51,658 [INFO] Measured power: 12.00 W
2026-02-14 20:18:54,728 [INFO] Measured power: 12.15 W
2026-02-14 20:18:57,800 [INFO] Measured power: 12.05 W
2026-02-14 20:19:00,871 [INFO] Measured power: 12.20 W
2026-02-14 20:19:03,939 [INFO] Measured power: 12.05 W
2026-02-14 20:19:07,003 [INFO] Measured power: 11.98 W
2026-02-14 20:19:10,065 [INFO] Measured power: 12.17 W
2026-02-14 20:19:13,365 [INFO] Measured power: 11.96 W
2026-02-14 20:19:16,431 [INFO] Measured power: 12.23 W
2026-02-14 20:19:19,511 [INFO] Measured power: 12.06 W
2026-02-14 20:19:22,591 [INFO] Measured power: 11.92 W
2026-02-14 20:19:25,652 [INFO] Measured power: 12.25 W
2026-02-14 20:19:28,729 [INFO] Measured power: 11.96 W
2026-02-14 20:19:32,050 [INFO] Measured power: 12.06 W
2026-02-14 20:19:35,117 [INFO] Measured power: 12.08 W
2026-02-14 20:19:38,184 [INFO] Measured power: 12.27 W
2026-02-14 20:19:41,260 [INFO] Measured power: 12.08 W
2026-02-14 20:19:44,335 [INFO] Measured power: 12.03 W
2026-02-14 20:19:47,635 [INFO] Measured power: 12.10 W
2026-02-14 20:19:50,703 [INFO] Measured power: 12.15 W
2026-02-14 20:19:53,771 [INFO] Measured power: 12.17 W
2026-02-14 20:19:56,845 [INFO] Measured power: 12.23 W
2026-02-14 20:19:59,911 [INFO] Measured power: 12.29 W
2026-02-14 20:20:02,982 [INFO] Measured power: 12.25 W
2026-02-14 20:20:06,054 [INFO] Measured power: 12.19 W
2026-02-14 20:20:09,123 [INFO] Measured power: 12.30 W
2026-02-14 20:20:12,195 [INFO] Measured power: 12.13 W
2026-02-14 20:20:15,262 [INFO] Measured power: 12.22 W
2026-02-14 20:20:18,328 [INFO] Measured power: 12.29 W
2026-02-14 20:20:21,387 [INFO] Measured power: 12.01 W
2026-02-14 20:20:24,452 [INFO] Measured power: 12.18 W
2026-02-14 20:20:27,513 [INFO] Measured power: 12.34 W
2026-02-14 20:20:30,590 [INFO] Measured power: 12.07 W
2026-02-14 20:20:33,661 [INFO] Measured power: 12.14 W
2026-02-14 20:20:36,731 [INFO] Measured power: 11.92 W
2026-02-14 20:20:39,796 [INFO] Measured power: 11.89 W
2026-02-14 20:20:42,870 [INFO] Measured power: 12.02 W
2026-02-14 20:20:45,936 [INFO] Measured power: 11.88 W
2026-02-14 20:20:49,549 [INFO] Measured power: 12.14 W
2026-02-14 20:20:52,622 [INFO] Measured power: 12.01 W
2026-02-14 20:20:55,934 [INFO] Measured power: 12.08 W
2026-02-14 20:20:59,000 [INFO] Measured power: 11.94 W
2026-02-14 20:21:02,058 [INFO] Measured power: 12.06 W
2026-02-14 20:21:05,114 [INFO] Measured power: 12.22 W
2026-02-14 20:21:08,190 [INFO] Measured power: 12.02 W
2026-02-14 20:21:11,272 [INFO] Measured power: 12.09 W
2026-02-14 20:21:14,340 [INFO] Measured power: 12.00 W
2026-02-14 20:21:18,408 [INFO] Measured power: 11.95 W
2026-02-14 20:21:21,474 [INFO] Measured power: 12.10 W
2026-02-14 20:21:24,545 [INFO] Measured power: 11.91 W
2026-02-14 20:21:27,613 [INFO] Measured power: 12.11 W
2026-02-14 20:21:30,960 [INFO] Measured power: 12.04 W
2026-02-14 20:21:34,030 [INFO] Measured power: 12.28 W
2026-02-14 20:21:37,098 [INFO] Measured power: 12.54 W
2026-02-14 20:21:40,170 [INFO] Measured power: 12.31 W
2026-02-14 20:21:43,243 [INFO] Measured power: 12.19 W
2026-02-14 20:21:46,315 [INFO] Measured power: 12.61 W
2026-02-14 20:21:49,384 [INFO] Measured power: 12.49 W
2026-02-14 20:21:52,452 [INFO] Measured power: 12.12 W
2026-02-14 20:21:55,543 [INFO] Measured power: 12.15 W
2026-02-14 20:21:58,615 [INFO] Measured power: 12.06 W
2026-02-14 20:22:01,699 [INFO] Measured power: 12.12 W
2026-02-14 20:22:04,783 [INFO] Measured power: 12.48 W
2026-02-14 20:22:07,856 [INFO] Measured power: 12.43 W
2026-02-14 20:22:10,921 [INFO] Measured power: 12.39 W
2026-02-14 20:22:13,990 [INFO] Measured power: 12.51 W
2026-02-14 20:22:17,057 [INFO] Measured power: 12.49 W
2026-02-14 20:22:20,122 [INFO] Measured power: 12.29 W
2026-02-14 20:22:23,195 [INFO] Measured power: 12.26 W
2026-02-14 20:22:26,272 [INFO] Measured power: 12.16 W
2026-02-14 20:22:29,337 [INFO] Measured power: 12.26 W
2026-02-14 20:22:32,407 [INFO] Measured power: 12.20 W
2026-02-14 20:22:35,482 [INFO] Measured power: 12.19 W
2026-02-14 20:22:38,555 [INFO] Measured power: 12.25 W
2026-02-14 20:22:41,874 [INFO] Measured power: 12.36 W
2026-02-14 20:22:44,943 [INFO] Measured power: 12.29 W
2026-02-14 20:22:48,010 [INFO] Measured power: 12.30 W
2026-02-14 20:22:51,078 [INFO] Measured power: 12.10 W
2026-02-14 20:22:54,145 [INFO] Measured power: 12.28 W
2026-02-14 20:22:57,213 [INFO] Measured power: 12.25 W
2026-02-14 20:23:00,303 [INFO] Measured power: 12.24 W
2026-02-14 20:23:03,371 [INFO] Measured power: 12.17 W
2026-02-14 20:23:06,899 [INFO] Measured power: 12.21 W
2026-02-14 20:23:09,974 [INFO] Measured power: 12.31 W
2026-02-14 20:23:13,035 [INFO] Measured power: 12.15 W
2026-02-14 20:23:16,111 [INFO] Measured power: 12.12 W
2026-02-14 20:23:19,173 [INFO] Measured power: 12.31 W
2026-02-14 20:23:22,242 [INFO] Measured power: 12.44 W
2026-02-14 20:23:26,324 [INFO] Measured power: 12.48 W
2026-02-14 20:23:29,389 [INFO] Measured power: 11.98 W
2026-02-14 20:23:32,463 [INFO] Measured power: 12.16 W
2026-02-14 20:23:35,542 [INFO] Measured power: 11.90 W
2026-02-14 20:23:38,609 [INFO] Measured power: 12.04 W
2026-02-14 20:23:41,681 [INFO] Measured power: 12.32 W
2026-02-14 20:23:44,746 [INFO] Measured power: 11.98 W
2026-02-14 20:23:47,815 [INFO] Measured power: 12.25 W
2026-02-14 20:23:50,887 [INFO] Measured power: 12.12 W
2026-02-14 20:23:53,968 [INFO] Measured power: 12.17 W
2026-02-14 20:23:57,043 [INFO] Measured power: 12.05 W
2026-02-14 20:24:00,112 [INFO] Measured power: 12.09 W
2026-02-14 20:24:03,180 [INFO] Measured power: 12.13 W
2026-02-14 20:24:06,250 [INFO] Measured power: 11.96 W
2026-02-14 20:24:09,318 [INFO] Measured power: 12.09 W
2026-02-14 20:24:12,383 [INFO] Measured power: 12.00 W
2026-02-14 20:24:15,457 [INFO] Measured power: 12.03 W
2026-02-14 20:24:18,524 [INFO] Measured power: 11.90 W
2026-02-14 20:24:21,589 [INFO] Measured power: 12.08 W
2026-02-14 20:24:24,662 [INFO] Measured power: 11.95 W
2026-02-14 20:24:27,735 [INFO] Measured power: 12.11 W
2026-02-14 20:24:30,813 [INFO] Measured power: 12.05 W
2026-02-14 20:24:33,888 [INFO] Measured power: 12.07 W
2026-02-14 20:24:36,963 [INFO] Measured power: 11.82 W
2026-02-14 20:24:40,033 [INFO] Measured power: 12.10 W
2026-02-14 20:24:43,101 [INFO] Measured power: 12.04 W
2026-02-14 20:24:46,175 [INFO] Measured power: 12.03 W
2026-02-14 20:24:49,247 [INFO] Measured power: 12.21 W
2026-02-14 20:24:52,319 [INFO] Measured power: 12.06 W
2026-02-14 20:24:55,387 [INFO] Measured power: 11.95 W
2026-02-14 20:24:58,464 [INFO] Measured power: 12.08 W
2026-02-14 20:25:01,531 [INFO] Measured power: 12.12 W
2026-02-14 20:25:04,605 [INFO] Measured power: 11.92 W
2026-02-14 20:25:07,675 [INFO] Measured power: 11.93 W
2026-02-14 20:25:10,748 [INFO] Measured power: 12.18 W
2026-02-14 20:25:13,820 [INFO] Measured power: 12.07 W
2026-02-14 20:25:16,889 [INFO] Measured power: 12.07 W
2026-02-14 20:25:19,962 [INFO] Measured power: 12.13 W
2026-02-14 20:25:23,043 [INFO] Measured power: 12.24 W
2026-02-14 20:25:26,113 [INFO] Measured power: 12.08 W
2026-02-14 20:25:29,182 [INFO] Measured power: 12.09 W
2026-02-14 20:25:32,260 [INFO] Measured power: 12.29 W
2026-02-14 20:25:35,332 [INFO] Measured power: 12.02 W
2026-02-14 20:25:38,403 [INFO] Measured power: 12.04 W
2026-02-14 20:25:41,480 [INFO] Measured power: 12.05 W
2026-02-14 20:25:44,549 [INFO] Measured power: 12.14 W
2026-02-14 20:25:47,622 [INFO] Measured power: 12.09 W
2026-02-14 20:25:50,970 [INFO] Measured power: 11.96 W
2026-02-14 20:25:54,037 [INFO] Measured power: 12.39 W
2026-02-14 20:25:57,107 [INFO] Measured power: 12.19 W
2026-02-14 20:26:00,175 [INFO] Measured power: 11.98 W
2026-02-14 20:26:03,473 [INFO] Measured power: 12.11 W
2026-02-14 20:26:06,542 [INFO] Measured power: 12.10 W
2026-02-14 20:26:09,606 [INFO] Measured power: 12.23 W
2026-02-14 20:26:12,682 [INFO] Measured power: 11.87 W
2026-02-14 20:26:15,753 [INFO] Measured power: 11.96 W
2026-02-14 20:26:18,831 [INFO] Measured power: 12.05 W
2026-02-14 20:26:21,909 [INFO] Measured power: 12.06 W
2026-02-14 20:26:24,982 [INFO] Measured power: 12.14 W
2026-02-14 20:26:28,060 [INFO] Measured power: 12.25 W
2026-02-14 20:26:31,133 [INFO] Measured power: 12.13 W
2026-02-14 20:26:34,205 [INFO] Measured power: 11.78 W
2026-02-14 20:26:37,281 [INFO] Measured power: 12.00 W
2026-02-14 20:26:40,348 [INFO] Measured power: 12.05 W
2026-02-14 20:26:43,421 [INFO] Measured power: 12.09 W
2026-02-14 20:26:46,725 [INFO] Measured power: 12.01 W
2026-02-14 20:26:50,032 [INFO] Measured power: 12.12 W
2026-02-14 20:26:53,119 [INFO] Measured power: 12.01 W
2026-02-14 20:26:56,192 [INFO] Measured power: 12.09 W
2026-02-14 20:26:59,257 [INFO] Measured power: 12.11 W
2026-02-14 20:27:02,332 [INFO] Measured power: 12.13 W
2026-02-14 20:27:05,402 [INFO] Measured power: 11.97 W
2026-02-14 20:27:08,480 [INFO] Measured power: 12.06 W
2026-02-14 20:27:11,552 [INFO] Measured power: 12.00 W
2026-02-14 20:27:14,858 [INFO] Measured power: 11.79 W
2026-02-14 20:27:18,927 [INFO] Measured power: 11.98 W
2026-02-14 20:27:22,000 [INFO] Measured power: 12.40 W
2026-02-14 20:27:25,075 [INFO] Measured power: 11.99 W
2026-02-14 20:27:29,150 [INFO] Measured power: 12.13 W
2026-02-14 20:27:32,219 [INFO] Measured power: 12.46 W
2026-02-14 20:27:35,288 [INFO] Measured power: 12.26 W
2026-02-14 20:27:38,362 [INFO] Measured power: 12.23 W
2026-02-14 20:27:41,430 [INFO] Measured power: 12.32 W
2026-02-14 20:27:44,508 [INFO] Measured power: 12.28 W
2026-02-14 20:27:47,578 [INFO] Measured power: 12.39 W
2026-02-14 20:27:50,652 [INFO] Measured power: 12.49 W
2026-02-14 20:27:53,723 [INFO] Measured power: 12.33 W
2026-02-14 20:27:56,796 [INFO] Measured power: 12.13 W
2026-02-14 20:27:59,866 [INFO] Measured power: 12.36 W
2026-02-14 20:27:59,869 [INFO] Average of 192 measurements: 12.14 W
```