### PR TITLE
Add HP Color LaserJet Pro MFP 3301 power profile

### DIFF
--- a/profile_library/hp/MFP 3301/model.json
+++ b/profile_library/hp/MFP 3301/model.json
@@ -1,0 +1,22 @@
+{
+  "aliases": [
+    "HP Color LaserJet Pro MFP 3301"
+  ],
+  "author_info": {
+    "name": "Brian Egge",
+    "email": "brianegge@gmail.com",
+    "github": "brianegge"
+  },
+  "calculation_strategy": "fixed",
+  "created_at": "2026-03-14T00:00:00Z",
+  "device_type": "printer",
+  "fixed_config": {
+    "states_power": {
+      "idle": 2.2
+    }
+  },
+  "measure_description": "Standby power measured at 2.2W via Shelly 4PM. Printing a single page draws 550-670W peak for ~12s (fusing), but HA's IPP integration polls only every 60s so the 'printing' state is never captured. A playbook strategy triggered by a page counter would better model print energy (~0.002 kWh/page), but no page counter entity is currently available. Power readings during a single-page color print:\n\n  Time    Power(W)  State\n  00:00   2.2       idle (baseline)\n  00:24   9.1       warm-up\n  00:30   550.2     fusing\n  00:36   669.5     fusing (peak)\n  00:42   41.6      cool-down\n  00:48   9.6       cool-down\n  01:18   9.0       cool-down\n  01:48   4.5       settling\n  01:54   2.6       returning to idle",
+  "measure_device": "Shelly 4PM",
+  "measure_method": "manual",
+  "name": "Color LaserJet Pro MFP 3301"
+}

--- a/profile_library/hp/manufacturer.json
+++ b/profile_library/hp/manufacturer.json
@@ -1,0 +1,6 @@
+{
+  "name": "HP",
+  "aliases": [
+    "Hewlett-Packard"
+  ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

HP Color LaserJet Pro MFP 3301 - color laser multifunction printer.
Serial: VND1B47698

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

- Entity: `sensor.hp_color_laserjet_pro_mfp_3301`
- Integration: IPP
- States: idle, printing, stopped
- Info: HP Color LaserJet Pro MFP 3301 [1E0C70]

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [x] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->

Fixed strategy with idle power of 2.2W measured via Shelly 4PM.

Only `idle` state power is included because HA's IPP integration polls every 60s,
which is too slow to capture the brief `printing` state (~12s of 550-670W fusing).
A playbook strategy triggered by a page counter would better model print energy
(~0.002 kWh/page), but no page counter entity is currently available via IPP.

Power readings during a single-page color print:

| Time  | Power (W) | Phase              |
|-------|----------:|:-------------------|
| 00:00 |       2.2 | idle (baseline)    |
| 00:24 |       9.1 | warm-up            |
| 00:30 |     550.2 | fusing             |
| 00:36 |     669.5 | fusing (peak)      |
| 00:42 |      41.6 | cool-down          |
| 00:48 |       9.6 | cool-down          |
| 01:18 |       9.0 | cool-down          |
| 01:48 |       4.5 | settling           |
| 01:54 |       2.6 | returning to idle  |

🤖 Generated with [Claude Code](https://claude.com/claude-code)