### PR TITLE
Add alias 929003666501 to LCG006

### DIFF
--- a/profile_library/signify/LCG006/model.json
+++ b/profile_library/signify/LCG006/model.json
@@ -12,6 +12,9 @@
     "VERSION": "v1.16.7:docker"
   },
   "name": "Hue White and Color Ambiance GU10 400lm",
+  "aliases": [
+    "929003666501"
+  ],
   "standby_power": 0.2,
   "author_info": {
     "name": "matteobreschig",


### PR DESCRIPTION
Adds alias 929003666501 to the Signify LCG006 profile so PowerCalc auto-discovery works for this Hue GU10 model.
