### PR TITLE
Add IKEA E2221 (INSPELNING smart plug 110V JP/US version)

### DIFF
--- a/profile_library/ikea/E2221/model.json
+++ b/profile_library/ikea/E2221/model.json
@@ -1,0 +1,24 @@
+{
+  "aliases": [
+    "INSPELNING Smart plug"
+  ],
+  "author": "Patrick Lehner <lehnerpat@users.noreply.github.com>",
+  "calculation_strategy": "fixed",
+  "created_at": "2026-04-08T10:46:42Z",
+  "device_type": "smart_switch",
+  "measure_description": "Manually measured (Japan model@110V)",
+  "measure_device": "Ketotek KTEM02BL Electricity Monitor",
+  "measure_method": "manual",
+  "name": "INSPELNING smart plug",
+  "only_self_usage": true,
+  "sensor_config": {
+    "energy_sensor_naming": "{} Device Energy",
+    "power_sensor_naming": "{} Device Power"
+  },
+  "standby_power": 0.2,
+  "standby_power_on": 0.7,
+  "author_info": {
+    "name": "Patrick Lehner",
+    "github": "lehnerpat"
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

IKEA INSPELNING (Plug, smart/energy monitor), this is the two-prong 110V version sold in Japan.

It's no longer available on IKEA Japan's website (it's superseded by the Matter-over-Thread device of the new smart home line-up), but here's the product page via the wayback machine:

https://web.archive.org/web/20260219140337/https://www.ikea.com/jp/en/p/inspelning-plug-smart-energy-monitor-40569844/

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

INSPELNING Smart plug
by IKEA of Sweden
Connected via Generic Zigbee Coordinator (EZSP)
Firmware: 0x02040045

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
