### PR TITLE
Add alias 1742830P7 to Signify LCS001 profile

### DIFF
--- a/profile_library/signify/LCS001/model.json
+++ b/profile_library/signify/LCS001/model.json
@@ -1,9 +1,5 @@
 {
-  "aliases": [
-    "1741430P7",
-    "1741530P7",
-    "1741830P7"
-  ],
+  "aliases": ["1741430P7", "1741530P7", "1741830P7", "1742830P7"],
   "author": "mariwing <mariwing@gmail.com>",
   "calculation_strategy": "lut",
   "created_at": "2021-10-08T13:31:47Z",

--- a/profile_library/signify/LCS001/model.json
+++ b/profile_library/signify/LCS001/model.json
@@ -1,5 +1,10 @@
 {
-  "aliases": ["1741430P7", "1741530P7", "1741830P7", "1742830P7"],
+  "aliases": [
+    "1741430P7",
+    "1741530P7",
+    "1741830P7",
+    "1742830P7"
+  ],
   "author": "mariwing <mariwing@gmail.com>",
   "calculation_strategy": "lut",
   "created_at": "2021-10-08T13:31:47Z",


### PR DESCRIPTION
## Summary
- Adds model alias `1742830P7` to the existing Signify LCS001 light profile so it is correctly detected by powercalc

## Test plan
- [x] Verify the alias `1742830P7` is recognized and maps to the LCS001 LUT profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)