### PR TITLE
Add aliases for EVE Energy

### DIFF
--- a/profile_library/eve/20EBU4101/model.json
+++ b/profile_library/eve/20EBU4101/model.json
@@ -1,5 +1,9 @@
 {
   "aliases": [
+    "20ECF6001",
+    "20EBO8301",
+    "20ECL1301",
+    "20EBT8601",
     "20EBU4101"
   ],
   "author": "dxmnkd316 <46753733+dxmnkd316@users.noreply.github.com>",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
I got the other model numbers from the manufacturer's [website](https://www.evehome.com/en/identify-your-eve-accessory?product=eve-energy).

- 20ECF6001 -> Australia version
- 20EBO8301 -> Europe version
- 20ECL1301 -> Switzerland version
- 20EBT8601 -> U.K. version
- 20EBU4101 -> U.S. & Canada version

The U.S. version was already in the library. I measured the European version and got almost identical values. The other model numbers come from the website and are always the models with Thread.


## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
Eve Energy 20EBO8301 (80)
von Eve Systems
Firmware: 3.5.0
Hardware: 1.1
Seriennummer: RV08L1A11661


## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [ ] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->