### PR TITLE
add FRITZ!Box 6690 Cable

### DIFF
--- a/profile_library/avm/FRITZ!Box 6690 Cable/model.json
+++ b/profile_library/avm/FRITZ!Box 6690 Cable/model.json
@@ -1,0 +1,20 @@
+{
+  "calculation_strategy": "fixed",
+  "created_at": "2026-04-17T10:48:22Z",
+  "device_type": "network",
+  "discovery_by": "device",
+  "fixed_config": {
+    "power": 15.75
+  },
+  "measure_description": "Measured with Powercalc measure tool in Average mode (600 seconds)",
+  "measure_device": "Shelly PM Mini Gen3",
+  "measure_method": "script",
+  "measure_settings": {
+    "VERSION": "v1.20.12:docker"
+  },
+  "name": "FRITZ!Box 6690 Cable",
+  "author_info": {
+    "name": "Tim",
+    "github": "EinRainerZufall"
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
Add the FRITZ!Box 6690 Cable

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
FRITZ!Box 6690 Cable
von FRITZ!
Firmware: 8.21

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [x] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
