### PR TITLE
fix: move GU10 WW 345lm alias from LED2005R5 to LED2104R3

### DIFF
--- a/profile_library/ikea/LED2005R5/model.json
+++ b/profile_library/ikea/LED2005R5/model.json
@@ -1,7 +1,6 @@
 {
   "aliases": [
     "TRADFRI bulb GU10 WS 345lm",
-    "TRADFRI bulb GU10 WW 345lm",
     "TRADFRIbulbGU10WS345lm"
   ],
   "author": "giu889 <78928093+giu889@users.noreply.github.com>",

--- a/profile_library/ikea/LED2104R3/model.json
+++ b/profile_library/ikea/LED2104R3/model.json
@@ -1,4 +1,7 @@
 {
+  "aliases": [
+    "TRADFRI bulb GU10 WW 345lm"
+  ],
   "calculation_strategy": "lut",
   "created_at": "2025-12-22T22:20:22Z",
   "device_type": "light",


### PR DESCRIPTION
**Problem**

LED2005R5 is a white spectrum (WS) profile with only `color_temp.csv.gz` LUT data, but had `"TRADFRI bulb GU10 WW 345lm"` listed as an alias. The WW (warm white) GU10 variant only supports `brightness` color mode, so when powercalc auto-discovers and matches these bulbs to LED2005R5, it can't find a brightness LUT and the power sensor goes `unavailable`.

**Fix**

Remove the WW alias from LED2005R5 and add it to LED2104R3, which has `brightness.csv.gz` LUT data matching the WW-only bulb.

**HA device info (TRADFRI gateway)**
```
manufacturer: IKEA of Sweden
model: TRADFRI bulb GU10 WW 345lm
model_id: None
sw_version: 1.0.42
supported_color_modes: [brightness]
```

The `model_id` is `None` because the TRADFRI gateway doesn't expose it, so powercalc relies on the alias to match the `model` field.