### PR TITLE
Add APC Back-UPS ES 650G1 NUT UPS power profile

### DIFF
--- a/profile_library/apc/BE650G1/model.json
+++ b/profile_library/apc/BE650G1/model.json
@@ -1,0 +1,57 @@
+{
+  "name": "APC Back-UPS ES 650G1",
+  "aliases": [
+    "Back-UPS ES 650G1"
+  ],
+  "description": "Power profile for the APC Back-UPS ES 650G1 (650 VA / 390 W). Estimates real-time output power from NUT load percentage.",
+  "device_type": "ups",
+  "calculation_strategy": "fixed",
+  "compatible_integrations": [
+    "nut"
+  ],
+  "created_at": "2026-04-28T00:00:00Z",
+  "measure_method": "manual",
+  "measure_device": "N/A",
+  "config_flow_discovery_remarks": "The Back-UPS ES 650G1 reports load in 10% increments and does not provide ups.realpower. Defaults of 650 VA and 0.6 power factor approximate watts for typical computer/electronics loads; use 1.0 for resistive loads.",
+  "fields": {
+    "load_entity": {
+      "label": "Load percentage entity",
+      "description": "The NUT sensor showing UPS load percentage (0-100%)",
+      "selector": {
+        "entity": {
+          "domain": "sensor"
+        }
+      }
+    },
+    "nominal_va": {
+      "label": "Nominal Power (VA)",
+      "description": "The VA rating of your UPS. Default: 650",
+      "selector": {
+        "number": {
+          "min": 100,
+          "max": 10000
+        }
+      }
+    },
+    "power_factor": {
+      "label": "Power Factor",
+      "description": "Ratio of real power to apparent power. Use 0.6 for computers/electronics, 1.0 for resistive loads like heaters. Default: 0.6",
+      "selector": {
+        "number": {
+          "min": 0.1,
+          "max": 1.0,
+          "step": 0.1
+        }
+      }
+    }
+  },
+  "fixed_config": {
+    "power": "{{ states('[[load_entity]]') | float(0) / 100 * [[nominal_va]] | float(0) * [[power_factor]] | float(0.6) }}"
+  },
+  "author_info": {
+    "name": "Brian Egge",
+    "github": "brianegge",
+    "email": "brianegge@gmail.com"
+  },
+  "author": "Brian Egge"
+}

--- a/profile_library/apc/manufacturer.json
+++ b/profile_library/apc/manufacturer.json
@@ -1,0 +1,7 @@
+{
+  "name": "APC",
+  "aliases": [
+    "American Power Conversion",
+    "Schneider Electric"
+  ]
+}


### PR DESCRIPTION
## Device information

APC Back-UPS ES 650G1 (model `BE650G1`) — 650 VA / 390 W consumer UPS, USB-monitored via the [NUT integration](https://www.home-assistant.io/integrations/nut/) using the `usbhid-ups` driver.

- Manufacturer page: https://www.apc.com/us/en/product/BE650G1/
- The unit reports `device.model: "Back-UPS ES 650G1"` and `ups.load` (whole-percent integers, in 10% steps), but does **not** expose `ups.realpower` or `ups.realpower.nominal`.
- This profile reuses the existing UPS device type and `fixed` calculation strategy added in #4067 / #4085 (Tripp Lite). It estimates output watts from `load% × nominal_va × power_factor / 100`, with sensible defaults baked in (`nominal_va: 650`, `power_factor: 0.6` for typical computer loads).

## Home Assistant Device information

```
Manufacturer: APC
Model: Back-UPS ES 650G1
Integration: Network UPS Tools (NUT)
Sensors used: sensor.<ups>_load (ups.load)
```

## Checklist

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info

This is a UPS (`device_type: ups`), not a light — the light-specific checklist items don't apply. The profile uses `calculation_strategy: fixed` with a Jinja template (same shape as `profile_library/tripp_lite/Tripplite/model.json`), so no LUT/CSV measurements are needed.

The model directory uses APC's SKU `BE650G1`, with `aliases: ["Back-UPS ES 650G1"]` so the NUT-reported `device.model` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)