### PR TITLE
Feature: Support for dummy loads with Kasa devices

### DIFF
--- a/utils/measure/measure/powermeter/kasa.py
+++ b/utils/measure/measure/powermeter/kasa.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from kasa import SmartPlug
 
-from measure.powermeter.errors import UnsupportedFeatureError
 from measure.powermeter.powermeter import PowerMeasurementResult, PowerMeter
 
 
@@ -15,22 +14,21 @@ class KasaPowerMeter(PowerMeter):
         self._smartplug = SmartPlug(device_ip)
 
     def get_power(self, include_voltage: bool = False) -> PowerMeasurementResult:
-        """Get a new power reading from the Kasa device. Optionally include voltage (FIXME: not yet implemented)."""
-        if include_voltage:
-            # FIXME: Not yet implemented # noqa: FIX001
-            raise UnsupportedFeatureError("Voltage measurement is not yet implemented for Kasa devices.")
-
+        """Get a new power reading from the Kasa device. Optionally include voltage."""
         loop = asyncio.get_event_loop()
-        power = loop.run_until_complete(self.async_read_power_meter())
+        power, voltage = loop.run_until_complete(self.async_read_power_meter())
 
+        if include_voltage:
+            return PowerMeasurementResult(power=power, voltage=voltage, updated=time.time())
         return PowerMeasurementResult(power=power, updated=time.time())
 
-    async def async_read_power_meter(self) -> None:
+    async def async_read_power_meter(self) -> tuple[float, float | None]:
         await self._smartplug.update()
-        return self._smartplug.emeter_realtime["power"]
+        emeter = self._smartplug.modules["emeter"]
+        return float(emeter.realtime.power), float(emeter.realtime.voltage)
 
     def has_voltage_support(self) -> bool:
-        return False
+        return True
 
     def process_answers(self, answers: dict[str, Any]) -> None:
         pass

--- a/utils/measure/measure/powermeter/kasa.py
+++ b/utils/measure/measure/powermeter/kasa.py
@@ -23,9 +23,10 @@ class KasaPowerMeter(PowerMeter):
         return PowerMeasurementResult(power=power, updated=time.time())
 
     async def async_read_power_meter(self) -> tuple[float, float | None]:
+        from kasa import Module
         await self._smartplug.update()
-        emeter = self._smartplug.modules["emeter"]
-        return float(emeter.realtime.power), float(emeter.realtime.voltage)
+        energy = self._smartplug.modules[Module.Energy]
+        return float(energy.current_consumption), float(energy.voltage)
 
     def has_voltage_support(self) -> bool:
         return True


### PR DESCRIPTION
I was trying to run the measure utility with a dummy load using my Kasa plug, but it errored out because voltage measurement wasn't implemented yet for Kasa devices. 

This PR fixes that so we can use Kasa plugs for dummy load setups. 

Changes:
   * Updated async_read_power_meter to use the python-kasa API (Module.Energy) so it pulls both power and voltage.
   * Updated get_power() to return the voltage in the PowerMeasurementResult.
   * Flipped has_voltage_support to True.

I've tested this locally with an incandescent dummy load, however I do not have another brand of powermeter to compare expected behaviour.