### PR TITLE
feat(measure): add hs + color_temp + effect option to light runner

### DIFF
--- a/utils/measure/measure/powermeter/kasa.py
+++ b/utils/measure/measure/powermeter/kasa.py
@@ -24,6 +24,7 @@ class KasaPowerMeter(PowerMeter):
 
     async def async_read_power_meter(self) -> tuple[float, float | None]:
         from kasa import Module
+
         await self._smartplug.update()
         energy = self._smartplug.modules[Module.Energy]
         return float(energy.current_consumption), float(energy.voltage)

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -696,6 +696,7 @@ class LightRunner(MeasurementRunner):
         ]
         if self.light_controller.has_effect_support():
             modes.append((LutMode.EFFECT, {LutMode.EFFECT}))
+            modes.append(("hs + color_temp + effect", {LutMode.HS, LutMode.COLOR_TEMP, LutMode.EFFECT}))
 
         questions = [
             inquirer.List(

--- a/utils/measure/tests/runner/test_light.py
+++ b/utils/measure/tests/runner/test_light.py
@@ -88,4 +88,3 @@ def test_get_questions(mock_config_factory) -> None:  # noqa: ANN001
     choices = mode_question.choices
 
     assert ("hs + color_temp + effect", {LutMode.HS, LutMode.COLOR_TEMP, LutMode.EFFECT}) in choices
-

--- a/utils/measure/tests/runner/test_light.py
+++ b/utils/measure/tests/runner/test_light.py
@@ -75,3 +75,17 @@ def test_resume_effect(mock_config_factory, tmp_path: str) -> None:  # noqa: ANN
     assert isinstance(resume_variation, EffectVariation)
     assert resume_variation.effect == "nightlight"
     assert resume_variation.bri == 200
+
+
+def test_get_questions(mock_config_factory) -> None:  # noqa: ANN001
+    """Test get_questions contains the new triple mode choice when effects are supported."""
+    mock_config = mock_config_factory()
+    measure_util_mock = MagicMock(MeasureUtil)
+    runner = LightRunner(measure_util_mock, mock_config)
+
+    questions = runner.get_questions()
+    mode_question = next(q for q in questions if q.name == QUESTION_MODE)
+    choices = mode_question.choices
+
+    assert ("hs + color_temp + effect", {LutMode.HS, LutMode.COLOR_TEMP, LutMode.EFFECT}) in choices
+


### PR DESCRIPTION
Description
Added a combined hs + color_temp + effect option to the light measurement CLI.

Right now, if you're measuring a bulb that supports colour, colour temp, and effects, you have to run effects in separate passes. This adds a unified option to run all three in a single session (if the light controller has effect support enabled).

Changes
Added the new combined choice to LightRunner.get_questions() in runner/light.py.
Added a unit test in tests/runner/test_light.py to verify the option shows up correctly.