### PR TITLE
Add Inovelli VZM32-SN mmWave dimmer profile

### DIFF
--- a/profile_library/inovelli/VZM32-SN/model.json
+++ b/profile_library/inovelli/VZM32-SN/model.json
@@ -1,0 +1,17 @@
+{
+  "author": "Martin Emde <me@martinemde.com>",
+  "calculation_strategy": "linear",
+  "created_at": "2026-06-12T21:42:00Z",
+  "device_type": "smart_dimmer",
+  "measure_description": "Measured device standby power with a smart plug. 1.54 W off, 1.59 W on (no load connected); mmWave radar keeps the device drawing power continuously.",
+  "measure_device": "Shelly PM Mini Gen3",
+  "measure_method": "script",
+  "name": "2-in-1 mmWave Dimmer Switch (VZM32-SN)",
+  "standby_power": 1.54,
+  "standby_power_on": 1.59,
+  "author_info": {
+    "name": "Martin Emde",
+    "email": "me@martinemde.com",
+    "github": "martinemde"
+  }
+}

--- a/profile_library/inovelli/manufacturer.json
+++ b/profile_library/inovelli/manufacturer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Inovelli",
+  "aliases": []
+}


### PR DESCRIPTION
Adds a power profile for the **Inovelli VZM32-SN** 2-in-1 mmWave Zigbee dimmer switch.

Profiled as a `smart_dimmer` using the `linear` strategy with the device's own consumption:

- **standby_power** (off): 1.54 W
- **standby_power_on** (on): 1.59 W

The mmWave radar keeps the device drawing power continuously, so on/off draw is nearly identical. Measured with a Shelly PM Mini Gen3 via the measure script (no load connected).

New manufacturer folder `inovelli/` added.