### PR TITLE
Fix Inovelli VZM32-SN to report only device usage

### DIFF
--- a/profile_library/inovelli/VZM32-SN/model.json
+++ b/profile_library/inovelli/VZM32-SN/model.json
@@ -1,12 +1,17 @@
 {
   "author": "Martin Emde <me@martinemde.com>",
-  "calculation_strategy": "linear",
+  "calculation_strategy": "fixed",
   "created_at": "2026-06-12T21:42:00Z",
   "device_type": "smart_dimmer",
-  "measure_description": "Measured device standby power with a smart plug. 1.54 W off, 1.59 W on (no load connected); mmWave radar keeps the device drawing power continuously.",
+  "measure_description": "Measured device standby power with a smart plug. 1.54 W off, 1.59 W on; mmWave radar keeps the device drawing power continuously. The device meters its own load energy, so this profile reports only the device's own consumption.",
   "measure_device": "Shelly PM Mini Gen3",
   "measure_method": "script",
   "name": "2-in-1 mmWave Dimmer Switch (VZM32-SN)",
+  "only_self_usage": true,
+  "sensor_config": {
+    "energy_sensor_naming": "{} Device Energy",
+    "power_sensor_naming": "{} Device Power"
+  },
   "standby_power": 1.54,
   "standby_power_on": 1.59,
   "author_info": {


### PR DESCRIPTION
Followup to #4205.

The VZM32-SN profile used the `smart_dimmer` + `linear` strategy without `only_self_usage`, which makes powercalc estimate the **connected load's** power. The VZM32-SN already meters its own load energy, so the profile should only report the **device's own** consumption.

Changes (mirroring the `ecodim/ECO-DIM.07` device-only dimmer):

- `calculation_strategy`: `linear` → `fixed`
- add `only_self_usage: true`
- add `sensor_config` with `{} Device Power` / `{} Device Energy` naming

Standby values are unchanged: 1.54 W off, 1.59 W on.