### PR TITLE
Log missing brightness in LUT strategy at warning, not error

### DIFF
--- a/custom_components/powercalc/strategy/lut.py
+++ b/custom_components/powercalc/strategy/lut.py
@@ -213,7 +213,9 @@ class LutStrategy(PowerCalculationStrategyInterface):
 
         brightness = attrs.get(ATTR_BRIGHTNESS)
         if brightness is None:
-            _LOGGER.error(
+            # Brightness can be briefly absent while a light is 'on' during state
+            # restoration; warning (not error) matches the other missing-attribute branches.
+            _LOGGER.warning(
                 "%s: Could not calculate power. no brightness set",
                 entity_state.entity_id,
             )

--- a/custom_components/powercalc/strategy/lut.py
+++ b/custom_components/powercalc/strategy/lut.py
@@ -213,8 +213,6 @@ class LutStrategy(PowerCalculationStrategyInterface):
 
         brightness = attrs.get(ATTR_BRIGHTNESS)
         if brightness is None:
-            # Brightness can be briefly absent while a light is 'on' during state
-            # restoration; warning (not error) matches the other missing-attribute branches.
             _LOGGER.warning(
                 "%s: Could not calculate power. no brightness set",
                 entity_state.entity_id,

--- a/tests/strategy/test_lut.py
+++ b/tests/strategy/test_lut.py
@@ -292,12 +292,18 @@ async def test_linked_profile_loaded(hass: HomeAssistant) -> None:
     )
 
 
-async def test_no_power_when_no_brightness_available(hass: HomeAssistant) -> None:
-    """When brightness attribute is not available on state return no power"""
+async def test_no_power_when_no_brightness_available(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When brightness attribute is not available on state return no power, logged at warning"""
+    caplog.set_level(logging.WARNING)
     strategy = await _create_lut_strategy(hass, "signify", "LCT010")
 
     state = State("light.test", STATE_ON, {ATTR_COLOR_MODE: ColorMode.BRIGHTNESS})
     assert not await strategy.calculate(state)
+    assert "no brightness set" in caplog.text
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
 
 
 async def test_color_mode_unknown_is_handled_gracefully(

--- a/tests/strategy/test_lut.py
+++ b/tests/strategy/test_lut.py
@@ -303,7 +303,8 @@ async def test_no_power_when_no_brightness_available(
     state = State("light.test", STATE_ON, {ATTR_COLOR_MODE: ColorMode.BRIGHTNESS})
     assert not await strategy.calculate(state)
     assert "no brightness set" in caplog.text
-    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+    record = next(record for record in caplog.records if "no brightness set" in record.getMessage())
+    assert record.levelno == logging.WARNING
 
 
 async def test_color_mode_unknown_is_handled_gracefully(


### PR DESCRIPTION
Closes #4213.

`LutStrategy.calculate()` logs at **ERROR** when a light is `on` but `brightness` is `None`. This is a benign, self-correcting transient — it fires once per LUT-profiled light during startup/state-restoration before the brightness attribute is populated; `calculate()` returns `None`, the sensor holds, and the next state update calculates correctly.

The ERROR severity is also inconsistent with how the codebase treats the same "required input attribute is `None`" condition elsewhere, which all use WARNING:

- `linear.py` — missing percentage attribute
- `lut.py` — the adjacent "color mode unknown" early-return
- `lut.py` — "effect not supported" / "effect not found"

ERROR is otherwise reserved for genuine misconfiguration (LUT file not found, colour-temp/HS missing).

**Change:** `error` → `warning` for the missing-brightness branch. Not `debug` — a light wrongly matched to a LUT profile would sit `on`/no-brightness permanently, and that should stay visible.

`test_no_power_when_no_brightness_available` is extended to assert nothing is logged at ERROR for this case (it fails on the old code, passes on the new). Full `tests/strategy/test_lut.py` green; ruff clean.

---
🤖 AI-assisted (Claude), human-reviewed before submission.
