### PR TITLE
Fix APC BE650G1 profile to discover per-device with sane defaults

### DIFF
--- a/profile_library/apc/BE650G1/model.json
+++ b/profile_library/apc/BE650G1/model.json
@@ -6,26 +6,19 @@
   "description": "Power profile for the APC Back-UPS ES 650G1 (650 VA / 390 W). Estimates real-time output power from NUT load percentage.",
   "device_type": "ups",
   "calculation_strategy": "fixed",
+  "discovery_by": "device",
   "compatible_integrations": [
     "nut"
   ],
   "created_at": "2026-04-28T00:00:00Z",
   "measure_method": "manual",
   "measure_device": "N/A",
-  "config_flow_discovery_remarks": "The Back-UPS ES 650G1 reports load in 10% increments and does not provide ups.realpower. Defaults of 650 VA and 0.6 power factor approximate watts for typical computer/electronics loads; use 1.0 for resistive loads.",
+  "config_flow_discovery_remarks": "The Back-UPS ES 650G1 reports load in 10% increments and does not provide ups.realpower. Defaults of 650 VA and 0.7 power factor approximate watts for typical mixed loads; use 0.6 for computers/electronics or 1.0 for resistive loads.",
   "fields": {
-    "load_entity": {
-      "label": "Load percentage entity",
-      "description": "The NUT sensor showing UPS load percentage (0-100%)",
-      "selector": {
-        "entity": {
-          "domain": "sensor"
-        }
-      }
-    },
     "nominal_va": {
       "label": "Nominal Power (VA)",
       "description": "The VA rating of your UPS. Default: 650",
+      "default": 650,
       "selector": {
         "number": {
           "min": 100,
@@ -35,7 +28,8 @@
     },
     "power_factor": {
       "label": "Power Factor",
-      "description": "Ratio of real power to apparent power. Use 0.6 for computers/electronics, 1.0 for resistive loads like heaters. Default: 0.6",
+      "description": "Ratio of real power to apparent power. Use 0.6 for computers/electronics, 0.7 for mixed loads, 1.0 for resistive loads like heaters. Default: 0.7",
+      "default": 0.7,
       "selector": {
         "number": {
           "min": 0.1,
@@ -46,7 +40,7 @@
     }
   },
   "fixed_config": {
-    "power": "{{ states('[[load_entity]]') | float(0) / 100 * [[nominal_va]] | float(0) * [[power_factor]] | float(0.6) }}"
+    "power": "{{ states('[[entity_by_translation_key:ups_load]]') | float(0) / 100 * [[nominal_va]] | float(650) * [[power_factor]] | float(0.7) }}"
   },
   "author_info": {
     "name": "Brian Egge",

--- a/profile_library/apc/BE650G1/model.json
+++ b/profile_library/apc/BE650G1/model.json
@@ -13,7 +13,7 @@
   "created_at": "2026-04-28T00:00:00Z",
   "measure_method": "manual",
   "measure_device": "N/A",
-  "config_flow_discovery_remarks": "The Back-UPS ES 650G1 reports load in 10% increments and does not provide ups.realpower. Defaults of 650 VA and 0.7 power factor approximate watts for typical mixed loads; use 0.6 for computers/electronics or 1.0 for resistive loads.",
+  "config_flow_discovery_remarks": "The Back-UPS ES 650G1 reports load in 10% increments and does not provide ups.realpower. The 650 VA and 0.7 power factor defaults approximate watts for typical mixed loads; use 0.6 for computers/electronics, 0.7 for mixed loads, or 1.0 for resistive loads like heaters.",
   "fields": {
     "nominal_va": {
       "label": "Nominal Power (VA)",

--- a/profile_library/apc/BE650G1/model.json
+++ b/profile_library/apc/BE650G1/model.json
@@ -13,7 +13,7 @@
   "created_at": "2026-04-28T00:00:00Z",
   "measure_method": "manual",
   "measure_device": "N/A",
-  "config_flow_discovery_remarks": "The Back-UPS ES 650G1 reports load in 10% increments and does not provide ups.realpower. The 650 VA and 0.7 power factor defaults approximate watts for typical mixed loads; use 0.6 for computers/electronics, 0.7 for mixed loads, or 1.0 for resistive loads like heaters.",
+  "config_flow_discovery_remarks": "The Back-UPS ES 650G1 reports load in 10% increments and does not provide ups.realpower. The 650 VA and 0.7 power factor defaults approximate watts for typical mixed loads.",
   "fields": {
     "nominal_va": {
       "label": "Nominal Power (VA)",
@@ -28,7 +28,7 @@
     },
     "power_factor": {
       "label": "Power Factor",
-      "description": "Ratio of real power to apparent power. Use 0.6 for computers/electronics, 0.7 for mixed loads, 1.0 for resistive loads like heaters. Default: 0.7",
+      "description": "Ratio of real power to apparent power. Default: 0.7 for typical mixed loads.",
       "default": 0.7,
       "selector": {
         "number": {


### PR DESCRIPTION
## Device information
APC Back-UPS ES 650G1 (650 VA / 390 W), monitored via the NUT integration. This PR fixes an existing profile (`apc/BE650G1`) rather than adding new measurements.

The profile defaulted to entity-level discovery, so every NUT sensor on the UPS (input voltage, status, battery charge, load, …) spawned its own Powercalc discovery flow — producing one Powercalc card per entity instead of one per UPS.

Changes:
- Set `"discovery_by": "device"` so a single discovery flow is created per UPS, matching the existing Tripp Lite UPS profile.
- Auto-detect the load sensor via `entity_by_translation_key:ups_load` and remove the manual `load_entity` field.
- Add field `default`s so the config form pre-fills 650 VA and 0.7 power factor instead of the slider minimums (100 / 0.1).

## Home Assistant Device information
Manufacturer: APC by Schneider Electric
Model: Back-UPS ES 650G1
Integration: Network UPS Tools (NUT)

## Checklist
- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
This is a UPS profile using the `fixed` calculation strategy, so the light-specific checklist items above do not apply. No CSV measurement files are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)