### PR TITLE
Stop controlled devices after measurements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,16 @@ Configured via `pyproject.toml`:
 - Use `@pytest.mark.parametrize` for test variants
 - We strive to 100% test coverage in the project. Make sure to run full test suite before submitting a PR.
 
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) for every commit message, for example:
+
+- `fix(measure): stop controlled devices during cleanup`
+- `feat(measure): add a new measurement workflow`
+- `refactor(measure): centralize artifact path construction`
+
+Do not use Lore-style commit trailers or decision-record commit formats unless explicitly requested.
+
 ## Pull Requests
 
 - Target upstream: `bramstroker/homeassistant-powercalc`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,5 +102,6 @@ Do not use Lore-style commit trailers or decision-record commit formats unless e
 ## Pull Requests
 
 - Target upstream: `bramstroker/homeassistant-powercalc`
+- Use concise, human-readable PR titles without Conventional Commit prefixes or scopes so Release Drafter produces clean release notes
 - New profiles use the `power_profile` PR template
 - One device per PR

--- a/utils/measure/measure/runner/fan.py
+++ b/utils/measure/measure/runner/fan.py
@@ -73,3 +73,11 @@ class FanRunner(MeasurementRunner[FanMeasurementRequest]):
         _LOGGER.info("Waiting %d seconds to measure power", SLEEP_TIME_PERCENTAGE_CHANGE)
         self.interaction.wait(SLEEP_TIME_PERCENTAGE_CHANGE)
         return self.measure_util.take_average_measurement(MEASURE_DURATION_PER_STEP)
+
+    def cleanup(self) -> None:
+        """Turn off the fan after success, failure, or cancellation."""
+
+        try:
+            self.fan_controller.turn_off()
+        except Exception:  # noqa: BLE001 - cleanup must not mask the measurement outcome
+            _LOGGER.warning("Could not turn off fan during cleanup", exc_info=True)

--- a/utils/measure/measure/runner/recorder.py
+++ b/utils/measure/measure/runner/recorder.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 import time
 
-from measure.execution import ImmediateInteraction, MeasurementCancelledError, RunInteraction
+from measure.execution import ImmediateInteraction, RunInteraction
 from measure.request import RecorderMeasurementRequest, validate_export_filename
 from measure.runner.const import DEFAULT_EXPORT_FILENAME
 from measure.runner.runner import MeasurementRunner, RunnerResult
@@ -43,8 +43,8 @@ class RecorderRunner(MeasurementRunner[RecorderMeasurementRequest]):
         start_time = time.time()
         voltages: list[float] = []
         recorded = 0
-        # Stopping a recorder (KeyboardInterrupt on the CLI, cancellation in the app) is the
-        # normal way to finish it, so we treat it as a successful completion, not a cancel.
+        # Ctrl-C is the CLI's normal recorder stop action. App cancellation remains a
+        # cancellation so its session state reflects the command the user issued.
         try:
             with csv_filepath.open("w", newline="") as csv_file:
                 writer = csv.writer(csv_file)
@@ -59,7 +59,7 @@ class RecorderRunner(MeasurementRunner[RecorderMeasurementRequest]):
                     # Open-ended recording: report the running sample count (total 0 = indeterminate).
                     self.interaction.progress(recorded, 0, phase="Recording")
                     self.interaction.wait(INTERVAL)
-        except KeyboardInterrupt, MeasurementCancelledError:
+        except KeyboardInterrupt:
             _LOGGER.info("Stopped recording")
 
         summary = {

--- a/utils/measure/measure/runner/speaker.py
+++ b/utils/measure/measure/runner/speaker.py
@@ -126,3 +126,11 @@ class SpeakerRunner(MeasurementRunner[SpeakerMeasurementRequest]):
         except ZeroReadingError:
             _LOGGER.error("Measured 0 watt as standby power.")
             return MeasurementResult(power=0, voltages=[])
+
+    def cleanup(self) -> None:
+        """Stop playback after success, failure, or cancellation."""
+
+        try:
+            self.media_controller.turn_off()
+        except Exception:  # noqa: BLE001 - cleanup must not mask the measurement outcome
+            _LOGGER.warning("Could not turn off speaker during cleanup", exc_info=True)

--- a/utils/measure/tests/runner/test_fan.py
+++ b/utils/measure/tests/runner/test_fan.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, call
 
+from measure.controller.fan.controller import FanController
 from measure.controller.fan.dummy import DummyFanController
 from measure.controller.fan.spec import DummyFanControllerSpec
 from measure.execution import RunInteraction
@@ -78,3 +79,20 @@ def test_run_reports_fan_percentage_operating_points(export_path: str) -> None:
     points = [call.args[0] for call in interaction.operating_point.call_args_list]
     assert points[0] == {"type": "fan", "percentage": 5, "on": True}
     assert points[-1] == {"type": "fan", "percentage": 100, "on": True}
+
+
+def test_cleanup_turns_off_fan() -> None:
+    fan_controller = MagicMock(FanController)
+    runner = FanRunner(MagicMock(MeasureUtil), fan_controller)
+
+    runner.cleanup()
+
+    fan_controller.turn_off.assert_called_once_with()
+
+
+def test_cleanup_does_not_surface_fan_shutdown_failure() -> None:
+    fan_controller = MagicMock(FanController)
+    fan_controller.turn_off.side_effect = RuntimeError("offline")
+    runner = FanRunner(MagicMock(MeasureUtil), fan_controller)
+
+    runner.cleanup()

--- a/utils/measure/tests/runner/test_manual_measurements.py
+++ b/utils/measure/tests/runner/test_manual_measurements.py
@@ -7,6 +7,7 @@ from measure.request import AverageMeasurementRequest, RecorderMeasurementReques
 from measure.runner.average import AverageRunner
 from measure.runner.recorder import RecorderRunner
 from measure.util.measure_util import MeasurementResult, MeasureUtil
+import pytest
 
 
 def test_average_reports_start_phase_after_confirmation() -> None:
@@ -28,7 +29,21 @@ def test_recorder_reports_start_phase_after_confirmation(tmp_path: Path) -> None
     interaction.wait.side_effect = MeasurementCancelledError
     runner = RecorderRunner(measure_util, interaction)
 
-    runner.run(RecorderMeasurementRequest(power_meter=DummyPowerMeterSpec()), str(tmp_path))
+    with pytest.raises(MeasurementCancelledError):
+        runner.run(RecorderMeasurementRequest(power_meter=DummyPowerMeterSpec()), str(tmp_path))
 
     interaction.confirm.assert_called_once_with("Ready to start recording. Stop the measurement when you are finished.")
     interaction.phase.assert_called_once_with("Starting recording")
+
+
+def test_recorder_treats_cli_interrupt_as_successful_stop(tmp_path: Path) -> None:
+    measure_util = MagicMock(spec=MeasureUtil)
+    measure_util.take_measurement.return_value = MeasurementResult(power=4.2, voltages=[])
+    interaction = MagicMock(spec=RunInteraction)
+    interaction.wait.side_effect = KeyboardInterrupt
+    runner = RecorderRunner(measure_util, interaction)
+
+    result = runner.run(RecorderMeasurementRequest(power_meter=DummyPowerMeterSpec()), str(tmp_path))
+
+    assert result.summary is not None
+    assert result.summary["Samples recorded"] == "1"

--- a/utils/measure/tests/runner/test_speaker.py
+++ b/utils/measure/tests/runner/test_speaker.py
@@ -77,3 +77,20 @@ def test_run_reports_volume_and_muted_operating_points() -> None:
         {"type": "speaker", "volume": 20, "muted": False},
     ]
     assert {"type": "speaker", "volume": 0, "muted": True} in points
+
+
+def test_cleanup_turns_off_speaker() -> None:
+    media_controller = MagicMock(MediaController)
+    runner = SpeakerRunner(MagicMock(MeasureUtil), MeasurementParameters(), media_controller)
+
+    runner.cleanup()
+
+    media_controller.turn_off.assert_called_once_with()
+
+
+def test_cleanup_does_not_surface_speaker_shutdown_failure() -> None:
+    media_controller = MagicMock(MediaController)
+    media_controller.turn_off.side_effect = RuntimeError("offline")
+    runner = SpeakerRunner(MagicMock(MeasureUtil), MeasurementParameters(), media_controller)
+
+    runner.cleanup()


### PR DESCRIPTION
## Summary

- stop speaker playback during runner cleanup
- turn fans off during runner cleanup
- preserve CLI `Ctrl+C` recorder completion while treating app cancellation as cancelled
- document the repository's Conventional Commits convention

## Why

Speaker and fan measurements could leave a controlled device running when a measurement completed, failed, or was cancelled. Recorder cancellation also conflated an app cancellation request with the CLI's explicit stop interaction.

## Impact

Controlled devices now return to a safe off state across measurement exit paths. Cleanup failures are logged without hiding the original measurement result.

## Validation

- 22 focused measure runner and recorder tests passed
- focused Ruff checks passed
