### PR TITLE
Support Kasa power meters on Python 3.14

### DIFF
--- a/utils/measure/measure/powermeter/kasa.py
+++ b/utils/measure/measure/powermeter/kasa.py
@@ -14,8 +14,7 @@ class KasaPowerMeter(PowerMeter):
 
     def get_power(self, include_voltage: bool = False) -> PowerMeasurementResult:
         """Get a new power reading from the Kasa device. Optionally include voltage."""
-        loop = asyncio.get_event_loop()
-        power, voltage = loop.run_until_complete(self.async_read_power_meter())
+        power, voltage = asyncio.run(self.async_read_power_meter())
 
         if include_voltage:
             return PowerMeasurementResult(power=power, voltage=voltage, updated=time.time())

--- a/utils/measure/tests/powermeter/test_kasa.py
+++ b/utils/measure/tests/powermeter/test_kasa.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from kasa import Module
 from measure.powermeter.kasa import KasaPowerMeter
+from measure.powermeter.powermeter import PowerMeasurementResult
 
 
 def test_reads_power_and_voltage_from_energy_module() -> None:
@@ -17,3 +18,21 @@ def test_reads_power_and_voltage_from_energy_module() -> None:
 
     assert asyncio.run(meter.async_read_power_meter()) == (12.5, 230.4)
     plug.update.assert_awaited_once_with()
+
+
+def test_get_power_creates_its_own_event_loop() -> None:
+    plug = MagicMock()
+    plug.update = AsyncMock()
+    plug.modules = {
+        Module.Energy: MagicMock(current_consumption=12.5, voltage=230.4),
+    }
+
+    with (
+        patch("measure.powermeter.kasa.IotPlug", return_value=plug),
+        patch("measure.powermeter.kasa.asyncio.get_event_loop", side_effect=RuntimeError("no current event loop")),
+        patch("measure.powermeter.kasa.time.time", return_value=123.0),
+    ):
+        meter = KasaPowerMeter("192.0.2.1")
+        result = meter.get_power(include_voltage=True)
+
+    assert result == PowerMeasurementResult(power=12.5, voltage=230.4, updated=123.0)


### PR DESCRIPTION
## Summary

- run the asynchronous Kasa read operation in an explicitly managed event loop
- add regression coverage for synchronous Kasa reads without a current event loop

## Why

Python 3.14 no longer creates an event loop implicitly for `asyncio.get_event_loop()`. The synchronous Kasa power-meter adapter therefore failed before it could contact the plug.

## Impact

Kasa power meters work from the synchronous measurement pipeline on Python 3.14 while keeping the existing async device interaction unchanged.

## Validation

- 25 power-meter tests passed
- Ruff passed for the changed files
- targeted mypy check passed
