### PR TITLE
Reject unstable dummy load calibrations

### DIFF
--- a/utils/measure/measure/const.py
+++ b/utils/measure/measure/const.py
@@ -65,6 +65,7 @@ class Trend(StrEnum):
     INCREASING = "increasing"
     DECREASING = "decreasing"
     STEADY = "steady"
+    UNSTABLE = "unstable"
 
 
 DUMMY_LOAD_MEASUREMENT_COUNT = 20

--- a/utils/measure/measure/util/measure_util.py
+++ b/utils/measure/measure/util/measure_util.py
@@ -405,9 +405,13 @@ class MeasureUtil:
         first_trend = trend_direction(first_slope)
         second_trend = trend_direction(second_slope)
 
-        if first_trend == second_trend and first_trend != Trend.STEADY:
+        if first_trend == second_trend:
             return first_trend
-        return Trend.STEADY
+        if first_trend == Trend.STEADY:
+            return second_trend
+        if second_trend == Trend.STEADY:
+            return first_trend
+        return Trend.UNSTABLE
 
     @staticmethod
     def _linear_slope(values: list[float]) -> float:

--- a/utils/measure/tests/util/test_measure_util.py
+++ b/utils/measure/tests/util/test_measure_util.py
@@ -41,8 +41,9 @@ def test_linear_slope_does_not_require_numpy(values: list[float], expected: floa
         ([6000.0 - 10.0 * index for index in range(20)], Trend.DECREASING),
         # The relative threshold keeps its sensitivity on low-ohm loads such as incandescent bulbs
         ([40.0 + 0.05 * index for index in range(20)], Trend.INCREASING),
-        # Halves disagreeing on direction means the load has settled
-        ([6000.0 + 10.0 * index for index in range(10)] + [6100.0 - 10.0 * index for index in range(10)], Trend.STEADY),
+        # Drift in only one half still means the load has not settled
+        ([6000.0 + 10.0 * index for index in range(10)] + [6100.0] * 10, Trend.INCREASING),
+        ([6100.0] * 10 + [6100.0 - 10.0 * index for index in range(10)], Trend.DECREASING),
     ],
 )
 def test_dummy_load_trend_uses_relative_threshold(averages: list[float], expected: Trend) -> None:
@@ -51,6 +52,12 @@ def test_dummy_load_trend_uses_relative_threshold(averages: list[float], expecte
 
 def test_dummy_load_trend_requires_twenty_samples() -> None:
     assert MeasureUtil.dummy_load_trend([6226.0] * 19) is None
+
+
+def test_dummy_load_trend_rejects_opposing_drift_as_unstable() -> None:
+    averages = [6000.0 + 10.0 * index for index in range(10)] + [6100.0 - 10.0 * index for index in range(10)]
+
+    assert MeasureUtil.dummy_load_trend(averages) is Trend.UNSTABLE
 
 
 def test_no_valid_average_readings_raise_typed_error(mock_config_factory: MockConfigFactory) -> None:


### PR DESCRIPTION
## Summary

- require both halves of a dummy-load calibration window to be steady before accepting it
- preserve the direction when only one half is still drifting
- classify opposing drift directions as unstable

## Why

The previous classifier treated every combination except matching directional drift as steady. A warming load with one drifting half, or a load oscillating in opposing directions, could therefore produce and persist an unreliable resistance calibration.

## Impact

Unsettled dummy loads now repeat calibration instead of being accepted prematurely. Truly steady readings and the existing relative noise threshold remain unchanged.

## Validation

- 30 dummy-load and execution tests passed
- Ruff passed for the changed files
- targeted mypy check passed
