### PR TITLE
Restrict Home Assistant app adapters

### DIFF
--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -539,6 +539,7 @@ def _preflight(context: AppContext, payload: MeasurementRequest) -> PreflightRes
             load_entities=load_entities,
             diagnose_power_meter=context.power_meter_diagnostics.evaluate,
             supports_voltage=lambda spec: context.build_power_meter(spec).has_voltage_support(),
+            developer_mode=context.developer_mode,
         ).validate(payload)
     except ActiveSessionError as error:
         raise HTTPException(status_code=409, detail=str(error)) from error

--- a/utils/measure/measure/ha_app/preflight.py
+++ b/utils/measure/measure/ha_app/preflight.py
@@ -5,16 +5,20 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from measure.const import DUMMY_LOAD_MEASUREMENT_COUNT, DUMMY_LOAD_MEASUREMENTS_DURATION
-from measure.controller.charging.spec import HassChargingControllerSpec, charging_entity_domain
-from measure.controller.fan.spec import HassFanControllerSpec
+from measure.controller.charging.spec import (
+    DummyChargingControllerSpec,
+    HassChargingControllerSpec,
+    charging_entity_domain,
+)
+from measure.controller.fan.spec import DummyFanControllerSpec, HassFanControllerSpec
 from measure.controller.light.const import MAX_MIRED, MIN_MIRED, LutMode
 from measure.controller.light.controller import LightInfo
 from measure.controller.light.dummy import DummyLightController
-from measure.controller.light.spec import DummyLightControllerSpec, HassLightControllerSpec
-from measure.controller.media.spec import HassMediaControllerSpec
+from measure.controller.light.spec import DummyLightControllerSpec, HassLightControllerSpec, HueLightControllerSpec
+from measure.controller.media.spec import DummyMediaControllerSpec, HassMediaControllerSpec
 from measure.home_assistant_entities import DeviceClass, EntityDomain
 from measure.powermeter.diagnostics import DiagnosticStatus, PowerMeterDiagnostic
-from measure.powermeter.spec import HassPowerMeterSpec, PowerMeterSpec
+from measure.powermeter.spec import DummyPowerMeterSpec, HassPowerMeterSpec, PowerMeterSpec, ShellyPowerMeterSpec
 from measure.request import (
     ChargingMeasurementRequest,
     DummyLoadCalibrationRequest,
@@ -65,16 +69,19 @@ class MeasurementPreflight:
         load_entities: EntityLoader,
         diagnose_power_meter: Callable[[PowerMeterSpec], PowerMeterDiagnostic] | None = None,
         supports_voltage: Callable[[PowerMeterSpec], bool] | None = None,
+        developer_mode: bool = False,
     ) -> None:
         self._has_active_session = has_active_session
         self._verify_storage = verify_storage
         self._load_entities = load_entities
         self._diagnose_power_meter = diagnose_power_meter
         self._supports_voltage = supports_voltage
+        self._developer_mode = developer_mode
 
     def validate(self, request: MeasurementRequest) -> PreflightResult:
         """Return warnings and estimates, or raise a typed preflight error."""
 
+        self._validate_adapters(request)
         if self._has_active_session():
             raise ActiveSessionError("A measurement session is already active")
         try:
@@ -113,6 +120,39 @@ class MeasurementPreflight:
             supported_modes=result.supported_modes,
             power_meter_diagnostic=diagnostic,
         )
+
+    def _validate_adapters(self, request: MeasurementRequest) -> None:
+        power_meter = request.power_meter
+        if isinstance(power_meter, DummyPowerMeterSpec):
+            if not self._developer_mode:
+                raise PreflightError("Dummy power meters require developer mode in the Home Assistant app")
+        elif not isinstance(power_meter, HassPowerMeterSpec | ShellyPowerMeterSpec):
+            label = power_meter.type.value.replace("_", " ").title()
+            raise PreflightError(f"{label} power meters are not supported by the Home Assistant app")
+
+        controller = None
+        if isinstance(
+            request,
+            LightMeasurementRequest | SpeakerMeasurementRequest | ChargingMeasurementRequest | FanMeasurementRequest,
+        ):
+            controller = request.controller
+        if controller is None:
+            return
+        if isinstance(
+            controller,
+            DummyLightControllerSpec | DummyMediaControllerSpec | DummyChargingControllerSpec | DummyFanControllerSpec,
+        ):
+            if not self._developer_mode:
+                raise PreflightError("Dummy controllers require developer mode in the Home Assistant app")
+            return
+        if isinstance(
+            controller,
+            HassLightControllerSpec | HassMediaControllerSpec | HassChargingControllerSpec | HassFanControllerSpec,
+        ):
+            return
+        if isinstance(controller, HueLightControllerSpec):
+            raise PreflightError("Hue light controllers are not supported by the Home Assistant app")
+        raise PreflightError(f"{type(controller).__name__} is not supported by the Home Assistant app")
 
     def _validate_power_meter(self, request: MeasurementRequest) -> None:
         if isinstance(request.power_meter, HassPowerMeterSpec):

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -428,6 +428,45 @@ def test_preflight_rejects_unavailable_entity(tmp_path: Path) -> None:
     assert response.json()["code"] == "preflight_failed"
 
 
+def test_preflight_rejects_cli_only_power_meter_adapter(tmp_path: Path) -> None:
+    response = client(tmp_path).post(
+        "/api/preflight",
+        json={
+            "measure_type": "average",
+            "power_meter": {"type": "kasa", "device_ip": "192.0.2.1"},
+            "duration": 60,
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["message"] == "Kasa power meters are not supported by the Home Assistant app"
+
+
+def test_preflight_rejects_cli_only_controller_adapter(tmp_path: Path) -> None:
+    request = payload()
+    request["controller"] = {"type": "hue", "bridge_ip": "192.0.2.2", "light": "1"}
+
+    response = client(tmp_path).post("/api/preflight", json=request)
+
+    assert response.status_code == 422
+    assert response.json()["message"] == "Hue light controllers are not supported by the Home Assistant app"
+
+
+def test_preflight_allows_dummy_adapters_only_in_developer_mode(tmp_path: Path) -> None:
+    request = {
+        "measure_type": "average",
+        "power_meter": {"type": "dummy"},
+        "duration": 1,
+    }
+
+    rejected = client(tmp_path).post("/api/preflight", json=request)
+    accepted = client(tmp_path, developer_mode=True).post("/api/preflight", json=request)
+
+    assert rejected.status_code == 422
+    assert rejected.json()["message"] == "Dummy power meters require developer mode in the Home Assistant app"
+    assert accepted.status_code == 200
+
+
 @pytest.mark.parametrize("entity_id", ["sensor.unknown_power", "sensor.text_power"])
 def test_preflight_rejects_non_numeric_power_state(tmp_path: Path, entity_id: str) -> None:
     response = client(tmp_path).post(

--- a/utils/measure/tests/test_preflight.py
+++ b/utils/measure/tests/test_preflight.py
@@ -36,6 +36,7 @@ def preflight(
     active: bool = False,
     writable: bool = True,
     voltage_supported: bool = True,
+    developer_mode: bool = True,
 ) -> MeasurementPreflight:
     def verify() -> None:
         if not writable:
@@ -46,6 +47,7 @@ def preflight(
         verify_storage=verify,
         load_entities=lambda domain, device_class: entities.get((domain, device_class), []),
         supports_voltage=lambda _: voltage_supported,
+        developer_mode=developer_mode,
     )
 
 


### PR DESCRIPTION
## Summary

- enforce the Home Assistant app's supported power-meter and controller adapters during preflight
- keep synthetic adapters available only in developer mode
- reject CLI-only adapters with actionable validation messages before construction or network access

## Why

The shared request schema intentionally contains every CLI and app adapter. A crafted app API request could therefore select adapters that are unavailable or inappropriate inside the Home Assistant app, including Kasa and native Hue adapters.

## Impact

The app accepts Home Assistant and Shelly power meters, Home Assistant controllers, and developer-only dummy adapters. Unsupported adapter requests now fail consistently with HTTP 422 instead of reaching missing dependencies or unintended network paths.

## Validation

- 49 API and preflight tests passed
- Ruff passed for the changed files
- targeted mypy check passed
