### PR TITLE
Normalize generated profile metadata

### DIFF
--- a/utils/measure/measure/request.py
+++ b/utils/measure/measure/request.py
@@ -122,6 +122,11 @@ class BaseMeasurementRequest(BaseModel):
             raise ValueError("model_id contains unsafe characters")
         return value
 
+    @field_validator("product_name", "measure_device", mode="before")
+    @classmethod
+    def normalize_profile_metadata(cls, value: str) -> str:
+        return value.strip()
+
     @field_validator("parameters")
     @classmethod
     def validate_parameters(cls, value: MeasurementParameters) -> MeasurementParameters:
@@ -136,7 +141,7 @@ class BaseMeasurementRequest(BaseModel):
 
     @property
     def model_name(self) -> str:
-        return self.product_name.strip()
+        return self.product_name
 
     @property
     def generate_model_json(self) -> bool:

--- a/utils/measure/tests/test_request.py
+++ b/utils/measure/tests/test_request.py
@@ -47,6 +47,21 @@ def test_request_round_trip_preserves_typed_input() -> None:
     assert isinstance(restored.dummy_load, DummyLoadReuseRequest)
 
 
+def test_request_normalizes_profile_metadata() -> None:
+    request = LightMeasurementRequest.model_validate(
+        valid_request() | {"product_name": "  Test light  ", "measure_device": "  Test meter  "},
+    )
+
+    assert request.product_name == "Test light"
+    assert request.measure_device == "Test meter"
+
+
+@pytest.mark.parametrize("field", ["product_name", "measure_device"])
+def test_request_rejects_blank_required_profile_metadata(field: str) -> None:
+    with pytest.raises(ValidationError, match=field):
+        LightMeasurementRequest.model_validate(valid_request() | {field: "   "})
+
+
 def test_request_accepts_dummy_load_calibration() -> None:
     request = LightMeasurementRequest.model_validate(
         valid_request() | {"dummy_load": {"mode": "calibrate", "description": "60 W incandescent bulb"}},


### PR DESCRIPTION
## Summary

- trim product names and measurement-device descriptions in the shared request contract
- reject whitespace-only required profile metadata
- remove redundant trimming at model-write time

## Why

The frontend trims these fields, but API and CLI callers could still pass padded or whitespace-only values. Pydantic's minimum-length validation ran before any normalization, allowing blank-looking metadata into generated profiles.

## Impact

Every transport now produces the same clean profile metadata, and invalid required values fail during request validation instead of reaching `model.json`.

## Validation

- 54 request and execution tests passed
- Ruff passed for the changed files
- targeted mypy check passed
