### PR TITLE
Validate charging battery sources before measurement

### DIFF
--- a/utils/measure/measure/controller/charging/spec.py
+++ b/utils/measure/measure/controller/charging/spec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from measure.controller.charging.const import BatteryLevelSourceType, ChargingControllerType, ChargingDeviceType
 
@@ -29,7 +29,13 @@ class HassChargingControllerSpec(_ChargingControllerSpec):
     entity_id: str = Field(pattern=r"^(vacuum|lawn_mower)\.[a-z0-9_]+$")
     battery_level_source_type: BatteryLevelSourceType = BatteryLevelSourceType.ATTRIBUTE
     battery_level_attribute: str | None = None
-    battery_level_entity_id: str | None = None
+    battery_level_entity_id: str | None = Field(default=None, pattern=r"^sensor\.[a-z0-9_]+$")
+
+    @model_validator(mode="after")
+    def validate_battery_level_source(self) -> HassChargingControllerSpec:
+        if self.battery_level_source_type == BatteryLevelSourceType.ENTITY and self.battery_level_entity_id is None:
+            raise ValueError("battery_level_entity_id is required when the battery level source is an entity")
+        return self
 
 
 ChargingControllerSpec = Annotated[

--- a/utils/measure/measure/ha_app/preflight.py
+++ b/utils/measure/measure/ha_app/preflight.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+import math
 from typing import Protocol
 
 from measure.const import DUMMY_LOAD_MEASUREMENT_COUNT, DUMMY_LOAD_MEASUREMENTS_DURATION
+from measure.controller.charging.const import ATTR_BATTERY_LEVEL, BatteryLevelSourceType
 from measure.controller.charging.spec import (
     DummyChargingControllerSpec,
     HassChargingControllerSpec,
@@ -40,6 +42,8 @@ class ActiveSessionError(PreflightError):
 
 class EntityRecord(Protocol):
     entity_id: str
+    state: str
+    attribute_names: list[str]
     supported_modes: list[LutMode] | None
     effect_list: list[str] | None
     min_mired: int | None
@@ -188,7 +192,35 @@ class MeasurementPreflight:
             if isinstance(request.controller, HassChargingControllerSpec):
                 if not request.controller.entity_id.startswith(f"{domain}."):
                     raise PreflightError("Charging device type does not match the selected entity")
-                self._require_entity(request.controller.entity_id, domain, "Selected charging device is unavailable")
+                charging_entity = self._require_entity(
+                    request.controller.entity_id,
+                    domain,
+                    "Selected charging device is unavailable",
+                )
+                self._validate_charging_battery_source(request.controller, charging_entity)
+
+    def _validate_charging_battery_source(
+        self,
+        controller: HassChargingControllerSpec,
+        charging_entity: EntityRecord,
+    ) -> None:
+        if controller.battery_level_source_type == BatteryLevelSourceType.ATTRIBUTE:
+            attribute = controller.battery_level_attribute or ATTR_BATTERY_LEVEL
+            if attribute not in charging_entity.attribute_names:
+                raise PreflightError(f"Battery level attribute {attribute} is not available on the charging device")
+            return
+
+        battery_entity = self._require_entity(
+            controller.battery_level_entity_id,
+            EntityDomain.SENSOR,
+            "Selected battery level sensor is unavailable",
+        )
+        try:
+            level = float(battery_entity.state)
+        except ValueError, TypeError:
+            level = math.nan
+        if not math.isfinite(level) or not 0 <= level <= 100:
+            raise PreflightError("Battery level sensor must report a numeric percentage between 0 and 100")
 
     def _validate_light(self, request: LightMeasurementRequest) -> PreflightResult:
         if isinstance(request.controller, DummyLightControllerSpec):
@@ -233,7 +265,9 @@ class MeasurementPreflight:
             supported_modes=tuple(sorted(request.modes, key=str)),
         )
 
-    def _require_entity(self, entity_id: str | None, domain: EntityDomain, message: str) -> None:
-        available = {entity.entity_id for entity in self._load_entities(domain, None)}
-        if entity_id not in available:
+    def _require_entity(self, entity_id: str | None, domain: EntityDomain, message: str) -> EntityRecord:
+        available = {entity.entity_id: entity for entity in self._load_entities(domain, None)}
+        entity = available.get(entity_id or "")
+        if entity is None:
             raise PreflightError(message)
+        return entity

--- a/utils/measure/tests/test_preflight.py
+++ b/utils/measure/tests/test_preflight.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
+from measure.controller.charging.const import BatteryLevelSourceType
 from measure.controller.charging.spec import HassChargingControllerSpec
 from measure.controller.fan.spec import HassFanControllerSpec
 from measure.controller.light.const import LutMode
@@ -28,6 +29,8 @@ class Entity(EntityRecord):
     effect_list: list[str] | None = None
     min_mired: int | None = None
     max_mired: int | None = None
+    state: str = "available"
+    attribute_names: list[str] = field(default_factory=list)
 
 
 def preflight(
@@ -58,8 +61,9 @@ def base_entities() -> dict[tuple[str | None, str | None], list[Entity]]:
         ("light", None): [Entity("light.test", [LutMode.BRIGHTNESS])],
         ("media_player", None): [Entity("media_player.test")],
         ("fan", None): [Entity("fan.test")],
-        ("vacuum", None): [Entity("vacuum.test")],
-        ("lawn_mower", None): [Entity("lawn_mower.test")],
+        ("vacuum", None): [Entity("vacuum.test", attribute_names=["battery_level"])],
+        ("lawn_mower", None): [Entity("lawn_mower.test", attribute_names=["battery_level"])],
+        ("sensor", None): [Entity("sensor.battery", state="75")],
     }
 
 
@@ -185,6 +189,47 @@ def test_preflight_rejects_charging_type_entity_domain_mismatch() -> None:
 
     with pytest.raises(PreflightError, match="does not match"):
         checker.validate(request)
+
+
+def test_preflight_rejects_missing_charging_battery_attribute() -> None:
+    request = ChargingMeasurementRequest(
+        power_meter=HassPowerMeterSpec(entity_id="sensor.power"),
+        controller=HassChargingControllerSpec(entity_id="vacuum.test", battery_level_attribute="charge_percent"),
+        charging_device_type="vacuum_robot",
+    )
+
+    with pytest.raises(PreflightError, match=r"charge_percent.*not available"):
+        preflight(base_entities()).validate(request)
+
+
+@pytest.mark.parametrize(
+    ("battery_entity", "entities", "message"),
+    [
+        ("sensor.missing", base_entities(), "battery level sensor is unavailable"),
+        (
+            "sensor.battery",
+            base_entities() | {("sensor", None): [Entity("sensor.battery", state="unknown")]},
+            "numeric percentage",
+        ),
+    ],
+)
+def test_preflight_rejects_invalid_charging_battery_sensor(
+    battery_entity: str,
+    entities: dict[tuple[str | None, str | None], list[Entity]],
+    message: str,
+) -> None:
+    request = ChargingMeasurementRequest(
+        power_meter=HassPowerMeterSpec(entity_id="sensor.power"),
+        controller=HassChargingControllerSpec(
+            entity_id="vacuum.test",
+            battery_level_source_type=BatteryLevelSourceType.ENTITY,
+            battery_level_entity_id=battery_entity,
+        ),
+        charging_device_type="vacuum_robot",
+    )
+
+    with pytest.raises(PreflightError, match=message):
+        preflight(entities).validate(request)
 
 
 def test_light_preflight_accepts_dummy_controller_without_entity_checks() -> None:

--- a/utils/measure/tests/test_request.py
+++ b/utils/measure/tests/test_request.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from measure.cli.request_adapter import request_from_answers
 from measure.const import PARAMETER_LIMITS, QUESTION_ENTITY_ID, QUESTION_MEASURE_DEVICE, MeasureType
+from measure.controller.charging.const import BatteryLevelSourceType
+from measure.controller.charging.spec import HassChargingControllerSpec
 from measure.controller.light.const import LightControllerType, LutMode
 from measure.powermeter.const import PowerMeterType
 from measure.powermeter.spec import DummyPowerMeterSpec
@@ -132,6 +134,14 @@ def test_request_rejects_dummy_load_with_synthetic_power_meter() -> None:
     dummy_load = DummyLoadCalibrationRequest(description="test load")
     with pytest.raises(ValidationError, match="synthetic"):
         AverageMeasurementRequest(power_meter=power_meter, dummy_load=dummy_load)
+
+
+def test_charging_controller_requires_battery_sensor_for_entity_source() -> None:
+    with pytest.raises(ValidationError, match="battery_level_entity_id"):
+        HassChargingControllerSpec(
+            entity_id="vacuum.test",
+            battery_level_source_type=BatteryLevelSourceType.ENTITY,
+        )
 
 
 def test_cli_request_contains_only_resolved_measurement_input(mock_config_factory: MockConfigFactory) -> None:


### PR DESCRIPTION
## Summary

- require a battery sensor when charging uses an entity-based battery source
- verify configured battery attributes exist on the charging device
- verify separate battery sensors are available and report a finite percentage between 0 and 100

## Why

Charging preflight previously checked only the controlled vacuum or lawn mower entity. Missing attributes and invalid battery sensors were discovered only after the measurement started.

## Impact

Invalid charging configurations now fail before execution with actionable messages. Both the default `battery_level` attribute and CLI-configured sensor sources remain supported.

## Validation

- 101 relevant API, preflight, request, and charging-controller tests passed
- Ruff passed for the changed files and commit hooks passed
- targeted mypy check passed
