### PR TITLE
Unify power reading validation

### DIFF
--- a/utils/measure/measure/util/measure_util.py
+++ b/utils/measure/measure/util/measure_util.py
@@ -224,11 +224,7 @@ class MeasureUtil:
         """Take one reading using the average-measurement mode selected for this run."""
         if measure_resistance:
             return self._take_resistance_reading()
-
-        if self.dummy_load_value:
-            return self._take_dummy_load_power_reading()
-
-        return self._take_power_reading()
+        return self._read_power(ignore_zero=True)
 
     def _sleep_before_next_average_reading(self, start_time: float, duration: int) -> bool:
         if not ((time.time() - start_time + self.config.sleep_time) < duration):
@@ -251,36 +247,6 @@ class MeasureUtil:
         _LOGGER.debug("Measured resistance: %.2f Ω; measured power: %.2f W, voltage: %.2f", resistance, power, voltage)
         return MeasurementResult(power=resistance, voltages=[voltage])
 
-    def _take_dummy_load_power_reading(self) -> MeasurementResult | None:
-        self.validate_dummy_load_support()
-
-        result = self.power_meter.get_power(include_voltage=True)
-        power, voltage = result.power, result.voltage
-
-        if voltage is None or voltage < 1:
-            raise ZeroReadingError("Voltage measurement returned zero")
-
-        assert self.dummy_load_value is not None
-        power -= (voltage**2) / self.dummy_load_value
-        if round(power, 2) <= 0:
-            raise DummyLoadMeasurementError(
-                "Dummy-load correction produced non-positive target power; verify the selected calibration and wiring",
-            )
-
-        _LOGGER.info("Measured power: %.2f W", power)
-        self._emit_sample(power)
-        return MeasurementResult(power=power, voltages=[voltage])
-
-    def _take_power_reading(self) -> MeasurementResult | None:
-        measurement = self.power_meter.get_power(include_voltage=self._include_voltage())
-        power = measurement.power
-        if round(power, 2) == 0:
-            _LOGGER.warning("Invalid measurement. Consumption: %.2f W; ignoring", power)
-            return None
-        _LOGGER.info("Measured power: %.2f W", power)
-        self._emit_sample(power)
-        return MeasurementResult(power=power, voltages=self._get_voltages(measurement))
-
     def take_measurement(
         self,
         start_timestamp: float | None = None,
@@ -293,14 +259,13 @@ class MeasureUtil:
         # Take multiple samples to reduce noise
         for i in range(1, self.config.sample_count + 1):
             _LOGGER.debug("Taking sample %d", i)
-            measurement, error = self._get_power_measurement()
-            if measurement:
-                result, error = self._validate_power_measurement(measurement, start_timestamp)
-                measurements.append(result.power)
-                voltages.extend(result.voltages)
-
-            if error:
+            try:
+                result = self._read_power(start_timestamp=start_timestamp)
+            except PowerMeterError as error:
                 return self._retry_measurement_or_raise(error, start_timestamp, retry_count)
+            assert result is not None
+            measurements.append(result.power)
+            voltages.extend(result.voltages)
 
             if self.config.sample_count > 1:
                 self._wait(self.config.sleep_time_sample)
@@ -313,53 +278,43 @@ class MeasureUtil:
         _LOGGER.info("Average measurement: %.3f W", average)
         return MeasurementResult(power=average, voltages=voltages)
 
-    def _get_power_measurement(self) -> tuple[PowerMeasurementResult | None, PowerMeterError | None]:
-        try:
-            include_voltage = self.dummy_load_value is not None or self._include_voltage()
-            measurement = self.power_meter.get_power(include_voltage=include_voltage)
-        except PowerMeterError as error:
-            return None, error
-
+    def _read_power(
+        self,
+        *,
+        start_timestamp: float | None = None,
+        ignore_zero: bool = False,
+    ) -> MeasurementResult | None:
+        """Read and validate one power sample for every measurement mode."""
+        include_voltage = self.dummy_load_value is not None or self._include_voltage()
+        measurement = self.power_meter.get_power(include_voltage=include_voltage)
         updated_at = dt.fromtimestamp(measurement.updated).strftime("%d-%m-%Y, %H:%M:%S")
         _LOGGER.debug("Measurement received (update_time=%s)", updated_at)
-        return measurement, None
-
-    def _validate_power_measurement(
-        self,
-        measurement: PowerMeasurementResult,
-        start_timestamp: float | None,
-    ) -> tuple[MeasurementResult, PowerMeterError | None]:
         if start_timestamp and measurement.updated < start_timestamp:
-            result = MeasurementResult(power=measurement.power, voltages=self._get_voltages(measurement))
-            return result, OutdatedMeasurementError(
+            raise OutdatedMeasurementError(
                 f"Power measurement is outdated. Aborting after {self.config.max_retries} successive retries",
             )
 
         power = measurement.power
         voltages = self._get_voltages(measurement)
-        error: PowerMeterError | None = None
-        if round(power, 2) <= 0:
-            error = ZeroReadingError("0 watt was read from the power meter")
-
         if self.dummy_load_value:
-            power, error = self._subtract_dummy_load(measurement)
+            voltage = measurement.voltage
+            if voltage is None or voltage < 1:
+                raise ZeroReadingError("0 Volt was read from the power meter")
+            power -= (voltage**2) / self.dummy_load_value
+            if round(power, 2) <= 0:
+                raise DummyLoadMeasurementError(
+                    "Dummy-load correction produced non-positive target power; "
+                    "verify the selected calibration and wiring",
+                )
+        elif round(power, 2) <= 0:
+            if ignore_zero:
+                _LOGGER.warning("Invalid measurement. Consumption: %.2f W; ignoring", power)
+                return None
+            raise ZeroReadingError("0 watt was read from the power meter")
 
-        if error is None:
-            self._emit_sample(power)
-        return MeasurementResult(power=power, voltages=voltages), error
-
-    def _subtract_dummy_load(self, measurement: PowerMeasurementResult) -> tuple[float, PowerMeterError | None]:
-        voltage = measurement.voltage
-        if voltage is None or voltage < 1:
-            return measurement.power, ZeroReadingError("0 Volt was read from the power meter")
-
-        assert self.dummy_load_value is not None
-        power = measurement.power - (voltage**2) / self.dummy_load_value
-        if round(power, 2) <= 0:
-            return power, DummyLoadMeasurementError(
-                "Dummy-load correction produced non-positive target power; verify the selected calibration and wiring",
-            )
-        return power, None
+        _LOGGER.info("Measured power: %.2f W", power)
+        self._emit_sample(power)
+        return MeasurementResult(power=power, voltages=voltages)
 
     def _retry_measurement_or_raise(
         self,

--- a/utils/measure/tests/util/test_measure_util.py
+++ b/utils/measure/tests/util/test_measure_util.py
@@ -11,6 +11,7 @@ from measure.powermeter.powermeter import PowerMeasurementResult, PowerMeter
 from measure.util.measure_util import (
     AverageMeasurementState,
     DummyLoadMeasurementError,
+    MeasurementResult,
     MeasureUtil,
     NoValidReadingsError,
 )
@@ -86,6 +87,47 @@ def test_dummy_load_emits_corrected_sample(mock_config_factory: MockConfigFactor
     assert result.power == pytest.approx(10.0)
     assert samples
     assert all(sample == pytest.approx(10.0) for sample in samples)
+
+
+@patch("time.time")
+def test_average_measurement_uses_dummy_load_correction_pipeline(
+    mock_time: MagicMock,
+    mock_config_factory: MockConfigFactory,
+) -> None:
+    power_meter = MagicMock(PowerMeter)
+    power_meter.has_voltage_support.return_value = True
+    power_meter.get_power.return_value = PowerMeasurementResult(power=20.0, voltage=10.0, updated=0.0)
+    samples: list[float] = []
+    measure_util = MeasureUtil(power_meter, mock_config_factory(), on_sample=samples.append)
+    measure_util.set_dummy_load_resistance(10.0)
+    mock_time.side_effect = lambda: 100.0 if power_meter.get_power.call_count else 0.0
+
+    result = measure_util.take_average_measurement(duration=10)
+
+    assert result == MeasurementResult(power=10.0, voltages=[10.0])
+    assert samples == [10.0]
+    power_meter.get_power.assert_called_once_with(include_voltage=True)
+
+
+def test_measurement_retries_outdated_reading_without_emitting_it(mock_config_factory: MockConfigFactory) -> None:
+    power_meter = MagicMock(PowerMeter)
+    power_meter.get_power.side_effect = [
+        PowerMeasurementResult(power=5.0, updated=10.0),
+        PowerMeasurementResult(power=7.0, updated=30.0),
+    ]
+    samples: list[float] = []
+    measure_util = MeasureUtil(
+        power_meter,
+        mock_config_factory({"max_retries": 1, "sample_count": 1}),
+        wait=lambda _: None,
+        on_sample=samples.append,
+    )
+
+    result = measure_util.take_measurement(start_timestamp=20.0)
+
+    assert result == MeasurementResult(power=7.0, voltages=[])
+    assert samples == [7.0]
+    assert power_meter.get_power.call_count == 2
 
 
 def test_dummy_load_rejects_non_positive_corrected_power(mock_config_factory: MockConfigFactory) -> None:


### PR DESCRIPTION
## Summary

- route average and sampled power measurements through one raw-reading validation pipeline
- centralize voltage collection, stale-reading rejection, dummy-load correction, zero handling, logging, and live sample events
- remove four duplicate power-reading and dummy-load helpers
- preserve the distinct retry policies of average and sampled measurements

## Why

`MeasureUtil` had two implementations for turning a power-meter response into a validated measurement. Their error messages, voltage handling, and dummy-load behavior could drift independently.

## Impact

All power measurement modes now share the same validation semantics. Resistance calibration remains separate because it intentionally converts power and voltage into ohms.

## Validation

- 377 complete measure Python tests passed
- 20 focused utility regression tests passed after the final lint adjustment
- Ruff passed for the changed files
- targeted mypy check passed

## Cleanup review

The live-sample callback's broad exception handler remains intentionally isolated as a UI feedback fail-safe; callback failures must not abort a physical measurement. No masking fallbacks, temporary workarounds, dependencies, or new abstraction layers were added.
