### PR TITLE
Pass explicit session execution context

### DIFF
--- a/utils/measure/measure/ha_app/coordinator.py
+++ b/utils/measure/measure/ha_app/coordinator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import logging
 from pathlib import Path
 from threading import Lock, Thread
@@ -31,6 +31,14 @@ class SessionConflictError(Exception):
     """Raised when an operation conflicts with the active session state."""
 
 
+@dataclass(frozen=True)
+class SessionExecutionContext:
+    """Explicit identity and artifact location for one session execution."""
+
+    session_id: str
+    artifact_directory: Path
+
+
 class SessionMeasurementService(Protocol):
     """Run one session without exposing its adapter composition to the coordinator."""
 
@@ -38,7 +46,7 @@ class SessionMeasurementService(Protocol):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult: ...
 
 
@@ -190,10 +198,14 @@ class MeasurementCoordinator:
         control: SessionControl,
     ) -> None:
         try:
+            context = SessionExecutionContext(
+                session_id=session_id,
+                artifact_directory=self.storage.artifact_directory(session_id, request.model_id),
+            )
             result = self.service_factory().run(
                 request,
                 control,
-                self.storage.output_directory(session_id),
+                context,
             )
         except MeasurementCancelledError:
             self._finish(SessionState.CANCELLED)

--- a/utils/measure/measure/ha_app/service.py
+++ b/utils/measure/measure/ha_app/service.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 import re
 
 from measure.assembler import MeasurementAssembler
 from measure.dummy_load import DummyLoadCalibration, power_meter_fingerprint
 from measure.execution import DummyLoadCalibrationStore, MeasurementExecution
-from measure.ha_app.coordinator import SessionMeasurementService
+from measure.ha_app.coordinator import SessionExecutionContext, SessionMeasurementService
 from measure.ha_app.interaction import SessionInteraction
 from measure.ha_app.session import SessionControl, SessionEventType, utc_now
 from measure.ha_app.storage import SessionStorage
@@ -86,7 +85,7 @@ class MeasurementService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
         """Run with session logging and redact secrets from surfaced failures."""
 
@@ -97,7 +96,7 @@ class MeasurementService(SessionMeasurementService):
             _LOGGER.setLevel(logging.INFO)
         _LOGGER.addHandler(handler)
         try:
-            return self._run(request, control, output_root)
+            return self._run(request, control, context)
         except Exception as error:
             message = _redact(str(error), (self.home_assistant.token,))
             if message != str(error):
@@ -111,7 +110,7 @@ class MeasurementService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
         control.checkpoint()
         if isinstance(request.power_meter, DummyPowerMeterSpec):
@@ -119,7 +118,7 @@ class MeasurementService(SessionMeasurementService):
         interaction = SessionInteraction(control)
         control.phase("Preparing measurement devices")
         calibration_store = (
-            SessionDummyLoadCalibrationStore(self.storage, output_root.parent.name)
+            SessionDummyLoadCalibrationStore(self.storage, context.session_id)
             if request.dummy_load is not None and self.storage is not None
             else None
         )
@@ -129,12 +128,11 @@ class MeasurementService(SessionMeasurementService):
             on_sample=control.sample,
             dummy_load_calibration_store=calibration_store,
         ).assemble(request)
-        output_directory = output_root / request.model_id
         control.phase("Starting measurement")
         control.emit(SessionEventType.STATE, {"state": "running"})
 
         execution = MeasurementExecution(
             measurement=prepared,
-            output_directory=output_directory,
+            output_directory=context.artifact_directory,
         )
         return execution.run()

--- a/utils/measure/measure/ha_app/storage.py
+++ b/utils/measure/measure/ha_app/storage.py
@@ -193,6 +193,11 @@ class SessionStorage:
     def output_directory(self, session_id: str) -> Path:
         return self._contained(self.session_directory(session_id) / "output")
 
+    def artifact_directory(self, session_id: str, model_id: str) -> Path:
+        """Return the confined output directory for one session model."""
+
+        return self._contained(self.output_directory(session_id) / model_id)
+
     def load_settings(self) -> AppPreferences:
         path = self.data_root / "settings.json"
         if not path.exists():
@@ -253,7 +258,7 @@ class SessionStorage:
             return False
         if not isinstance(request, LightMeasurementRequest):
             return False
-        model_root = self.output_directory(session_id) / request.model_id
+        model_root = self.artifact_directory(session_id, request.model_id)
         for mode in request.modes:
             path = model_root / f"{mode.value}.csv"
             if self._has_complete_measurement_row(path, mode, request):

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -13,7 +13,7 @@ from measure.const import MeasureType
 from measure.dummy_load import DummyLoadCalibration, power_meter_fingerprint
 from measure.execution import LightOperatingPoint
 from measure.ha_app.api import create_app
-from measure.ha_app.coordinator import MeasurementCoordinator, SessionMeasurementService
+from measure.ha_app.coordinator import MeasurementCoordinator, SessionExecutionContext, SessionMeasurementService
 from measure.ha_app.session import SessionControl, SessionSnapshot, SessionState
 from measure.ha_app.storage import SessionStorage
 from measure.home_assistant import HomeAssistantEntityData, HomeAssistantManager
@@ -143,9 +143,9 @@ class CompletingService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
-        directory = output_root / request.model_id
+        directory = context.artifact_directory
         directory.mkdir(parents=True)
         (directory / "brightness.csv").write_text("bri,watt\n1,1.0\n", encoding="utf-8")
         control.log("Reading light.test with sensor.test_power")
@@ -159,7 +159,7 @@ class SummaryService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
         control.progress(completed=30, total=30, mode="Averaging", estimated_remaining="0s")
         summary = {"Average power": "42.3 W", "Duration": "30 s"}

--- a/utils/measure/tests/test_coordinator.py
+++ b/utils/measure/tests/test_coordinator.py
@@ -6,7 +6,12 @@ import time
 
 from measure.controller.light.spec import DummyLightControllerSpec
 from measure.execution import LightOperatingPoint
-from measure.ha_app.coordinator import MeasurementCoordinator, SessionConflictError, SessionMeasurementService
+from measure.ha_app.coordinator import (
+    MeasurementCoordinator,
+    SessionConflictError,
+    SessionExecutionContext,
+    SessionMeasurementService,
+)
 from measure.ha_app.session import SessionControl, SessionSnapshot, SessionState
 from measure.ha_app.storage import SessionStorage
 from measure.powermeter.spec import DummyPowerMeterSpec
@@ -43,9 +48,9 @@ class CompletingService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
-        directory = output_root / request.model_id
+        directory = context.artifact_directory
         directory.mkdir(parents=True)
         (directory / "brightness.csv").write_text("bri,watt\n1,1.0\n", encoding="utf-8")
         control.progress(completed=1, total=1, mode="brightness", estimated_remaining="0s")
@@ -60,7 +65,7 @@ class BlockingService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
         self.started.set()
         control.wait(60)
@@ -72,7 +77,7 @@ class SamplingService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
         control.sample(4.2)
         return RunnerResult(model_json_data={})
@@ -83,7 +88,7 @@ class OperatingPointService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
         control.operating_point(LightOperatingPoint(type="light", on=True, brightness=128))
         control.wait(60)
@@ -98,7 +103,7 @@ class CheckpointService(SessionMeasurementService):
         self,
         request: MeasurementRequest,
         control: SessionControl,
-        output_root: Path,
+        context: SessionExecutionContext,
     ) -> RunnerResult:
         control.phase("Preparing operator checkpoint")
         control.confirm("Place the device on its charger, then start the measurement.")

--- a/utils/measure/tests/test_service.py
+++ b/utils/measure/tests/test_service.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from measure.controller.light.dummy import DummyLightController
 from measure.controller.light.spec import HassLightControllerSpec
+from measure.ha_app.coordinator import SessionExecutionContext
 from measure.ha_app.service import MeasurementService, SessionDummyLoadCalibrationStore, _redact
 from measure.ha_app.session import SessionControl, SessionEventType, SessionSnapshot, SessionState, utc_now
 from measure.ha_app.storage import SessionStorage
@@ -12,6 +13,7 @@ from measure.home_assistant import HomeAssistantManager
 from measure.powermeter.dummy import DummyPowerMeter
 from measure.powermeter.spec import HassPowerMeterSpec
 from measure.request import DummyLoadCalibrationRequest, LightMeasurementRequest
+from measure.runner.runner import RunnerResult
 
 
 def test_service_runs_light_measurement_without_terminal(tmp_path: Path) -> None:
@@ -36,11 +38,14 @@ def test_service_runs_light_measurement_without_terminal(tmp_path: Path) -> None
         result = MeasurementService(HomeAssistantManager("ws://supervisor/core/websocket", "token")).run(
             request,
             control,
-            tmp_path,
+            SessionExecutionContext(
+                session_id="explicit-session",
+                artifact_directory=tmp_path / "custom-artifacts",
+            ),
         )
 
     assert result.model_json_data["device_type"] == "light"
-    assert (tmp_path / request.model_id / "brightness.csv").is_file()
+    assert (tmp_path / "custom-artifacts" / "brightness.csv").is_file()
     progress_events = [event for event in progress if event.type == SessionEventType.PROGRESS]
     assert progress_events[-1].data["completed"] == progress_events[-1].data["total"]
     phases = [event.data["message"] for event in progress if event.type == SessionEventType.PHASE]
@@ -51,6 +56,40 @@ def test_service_runs_light_measurement_without_terminal(tmp_path: Path) -> None
 
 def test_sensitive_values_are_redacted_from_session_messages() -> None:
     assert _redact("Authorization: Bearer secret-token", ("secret-token",)) == "Authorization: Bearer [REDACTED]"
+
+
+def test_service_uses_explicit_session_id_for_dummy_load_storage(tmp_path: Path) -> None:
+    storage = SessionStorage(tmp_path / "storage")
+    request = LightMeasurementRequest(
+        model_id="LCT010",
+        product_name="Test light",
+        measure_device="Test meter",
+        controller=HassLightControllerSpec(entity_id="light.test"),
+        power_meter=HassPowerMeterSpec(
+            entity_id="sensor.test_power",
+            voltage_entity_id="sensor.test_voltage",
+        ),
+        dummy_load=DummyLoadCalibrationRequest(description="40 W incandescent bulb"),
+    )
+    context = SessionExecutionContext(
+        session_id="explicit-session-id",
+        artifact_directory=tmp_path / "unrelated" / "artifacts",
+    )
+
+    with (
+        patch("measure.ha_app.service.SessionDummyLoadCalibrationStore") as calibration_store,
+        patch("measure.ha_app.service.MeasurementAssembler") as assembler,
+        patch("measure.ha_app.service.MeasurementExecution") as execution,
+    ):
+        assembler.return_value.assemble.return_value = MagicMock()
+        execution.return_value.run.return_value = RunnerResult(model_json_data={})
+        MeasurementService(HomeAssistantManager("ws://supervisor/core/websocket", "token"), storage).run(
+            request,
+            SessionControl(),
+            context,
+        )
+
+    calibration_store.assert_called_once_with(storage, "explicit-session-id")
 
 
 def test_session_dummy_load_store_persists_for_resume_and_future_sessions(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_storage.py
+++ b/utils/measure/tests/test_storage.py
@@ -95,7 +95,7 @@ def test_storage_recovers_from_truncated_final_event(tmp_path: Path, caplog: pyt
 def test_running_session_becomes_resumable_after_restart(tmp_path: Path) -> None:
     storage = SessionStorage(tmp_path)
     storage.create(snapshot(SessionState.RUNNING), light_request())
-    output = storage.output_directory("a1b2-c3d4") / "LCT010"
+    output = storage.artifact_directory("a1b2-c3d4", "LCT010")
     output.mkdir()
     (output / "brightness.csv").write_text("bri,watt\n2,1.0\n", encoding="utf-8")
 
@@ -139,7 +139,7 @@ def test_every_orphaned_nonterminal_session_is_recovered(tmp_path: Path, state: 
 def test_interrupted_session_without_compatible_complete_row_fails(tmp_path: Path, contents: str) -> None:
     storage = SessionStorage(tmp_path)
     storage.create(snapshot(SessionState.RUNNING), light_request())
-    output = storage.output_directory("a1b2-c3d4") / "LCT010"
+    output = storage.artifact_directory("a1b2-c3d4", "LCT010")
     output.mkdir()
     (output / "brightness.csv").write_text(contents, encoding="utf-8")
 
@@ -162,7 +162,7 @@ def test_effect_output_is_recognized_as_resumable(tmp_path: Path) -> None:
     storage = SessionStorage(tmp_path)
     request = light_request().model_copy(update={"modes": {LutMode.EFFECT}})
     storage.create(snapshot(SessionState.RUNNING), request)
-    output = storage.output_directory("a1b2-c3d4") / "LCT010"
+    output = storage.artifact_directory("a1b2-c3d4", "LCT010")
     output.mkdir()
     (output / "effect.csv").write_text("effect,bri,watt\nnightlight,205,3.0\n", encoding="utf-8")
 
@@ -176,7 +176,7 @@ def test_effect_output_off_the_measurement_grid_is_not_resumable(tmp_path: Path)
     storage = SessionStorage(tmp_path)
     request = light_request().model_copy(update={"modes": {LutMode.EFFECT}})
     storage.create(snapshot(SessionState.RUNNING), request)
-    output = storage.output_directory("a1b2-c3d4") / "LCT010"
+    output = storage.artifact_directory("a1b2-c3d4", "LCT010")
     output.mkdir()
     # bri=200 is not produced by the effect brightness grid, so the runner could not resume it.
     (output / "effect.csv").write_text("effect,bri,watt\nnightlight,200,3.0\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

- pass an explicit session execution context from coordinator to service
- include both session identity and the exact artifact directory in that context
- make `SessionStorage` the single owner of session model artifact paths
- use the same storage path API for execution and resume detection

## Why

The service inferred the session ID from `output_root.parent.name` and separately appended `request.model_id` to construct its artifact path. That coupled execution behavior to an undocumented directory layout.

## Impact

Session calibration persistence and measurement artifacts now use explicit inputs. Changing the on-disk layout no longer silently changes session identity, and the service no longer knows how storage paths are structured.

## Validation

- 376 complete measure Python tests passed
- 57 focused coordinator, service, storage, and API tests passed
- Ruff passed for all changed files
- targeted mypy check passed

## Cleanup review

Existing recovery behavior for truncated or incompatible persisted state and logging failure isolation remain as grounded fail-safe boundaries. No new fallback paths or dependencies were added.
