### PR TITLE
Separate app and CLI runtime dependencies

### DIFF
--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Run tests
         run: |
           cd ./utils/measure
-          uv run --extra dev --extra cli ruff check measure tests prepare_app_release.py
-          MYPYPATH=. uv run --extra dev --extra cli mypy \
+          uv run --extra dev --extra app --extra cli ruff check measure tests prepare_app_release.py
+          MYPYPATH=. uv run --extra dev --extra app --extra cli mypy \
             --explicit-package-bases \
             --follow-imports=silent \
             --ignore-missing-imports \
@@ -78,7 +78,7 @@ jobs:
             measure/ha_app/preflight.py \
             measure/ha_app/api.py \
             measure/ha_app/main.py
-          uv run --extra dev --extra cli pytest \
+          uv run --extra dev --extra app --extra cli pytest \
             -qq \
             --durations=10 \
             -o console_output_style=count \

--- a/docs/source/contributing/measure/setup.md
+++ b/docs/source/contributing/measure/setup.md
@@ -56,8 +56,8 @@ From the repository:
 ```bash
 cd utils/measure
 uv venv
-uv sync
-uv run python -m measure.measure
+uv sync --extra cli
+uv run --extra cli python -m measure.measure
 ```
 
 Native runs write output to `utils/measure/export`.
@@ -139,7 +139,7 @@ With `POWER_METER=ocr`, the tool reads power values from a camera pointed at the
 
     ```bash
     cd utils/measure
-    uv sync --extra ocr
+    uv sync --extra cli --extra ocr
     ```
 
 3. Start the OCR stream, passing the location of the tesseract executable:

--- a/utils/measure/Dockerfile
+++ b/utils/measure/Dockerfile
@@ -36,6 +36,8 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 FROM python-runtime AS ha-app
 
+RUN uv sync --locked --extra app
+
 ENV POWERCALC_MEASURE_DATA_ROOT=/data
 
 EXPOSE 8099

--- a/utils/measure/README.md
+++ b/utils/measure/README.md
@@ -22,13 +22,13 @@ uv manages the virtual environment and installs all dependencies declared by the
 ```
 cd utils/measure
 uv venv
-uv sync --extra dev
+uv sync --extra dev --extra app --extra cli
 ```
 
 Start the CLI with:
 
 ```
-uv run python -m measure.measure
+uv run --extra cli python -m measure.measure
 ```
 
 ### Visualize measurement output
@@ -56,7 +56,7 @@ See the [measurement tool architecture](../../docs/source/contributing/measure/a
 
 **Terminal 1 — backend** (from `utils/measure`):
 ```
-uv run python -m measure.ha_app.main \
+uv run --extra app python -m measure.ha_app.main \
   --host 127.0.0.1 --port 8099 \
   --data-root .dev-data \
   --hass-url ws://127.0.0.1:8123/api/websocket \

--- a/utils/measure/measure/assembler.py
+++ b/utils/measure/measure/assembler.py
@@ -40,7 +40,6 @@ from measure.home_assistant import HomeAssistantManager
 from measure.powermeter.dummy import DummyPowerMeter
 from measure.powermeter.errors import PowerMeterError
 from measure.powermeter.hass import HassPowerMeter
-from measure.powermeter.kasa import KasaPowerMeter
 from measure.powermeter.manual import ManualPowerMeter
 from measure.powermeter.mystrom import MyStromPowerMeter
 from measure.powermeter.ocr import OcrPowerMeter
@@ -59,7 +58,6 @@ from measure.powermeter.spec import (
     TuyaPowerMeterSpec,
 )
 from measure.powermeter.tasmota import TasmotaPowerMeter
-from measure.powermeter.tuya import TuyaPowerMeter
 from measure.request import (
     AverageMeasurementRequest,
     ChargingMeasurementRequest,
@@ -151,6 +149,8 @@ class MeasurementAssembler:
                 wait=self._interaction.wait,
             )
         if isinstance(spec, KasaPowerMeterSpec):
+            from measure.powermeter.kasa import KasaPowerMeter
+
             return KasaPowerMeter(spec.device_ip)
         if isinstance(spec, ManualPowerMeterSpec):
             return ManualPowerMeter()
@@ -165,6 +165,8 @@ class MeasurementAssembler:
         if isinstance(spec, TuyaPowerMeterSpec):
             if self._tuya_device_key is None:
                 raise PowerMeterError("Tuya device key is required")
+            from measure.powermeter.tuya import TuyaPowerMeter
+
             return TuyaPowerMeter(spec.device_id, spec.device_ip, self._tuya_device_key, spec.version)
         raise PowerMeterError(f"Unsupported power meter specification: {type(spec).__name__}")
 

--- a/utils/measure/pyproject.toml
+++ b/utils/measure/pyproject.toml
@@ -8,25 +8,23 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.14,<4.0"
 dependencies = [
-    "chardet>=5.1",
-    "charset-normalizer>=3.1",
-    "fastapi>=0.116",
     "homeassistant-api~=6.0",
-    "inquirer>=3.1",
     "pydantic>=2.13",
-    "python-decouple>=3.4",
-    "python-kasa>=0.7",
-    "readchar>=4.0",
     "requests>=2.28",
-    "tuyapower>=0.2",
-    "typing-extensions>=4.6",
-    "uvicorn>=0.35",
-    "pycryptodome",
 ]
 
 [project.optional-dependencies]
+app = [
+    "fastapi>=0.116",
+    "uvicorn>=0.35",
+]
 cli = [
     "aiohue>=4.8.1,<5",
+    "inquirer>=3.1",
+    "pycryptodome>=3.20",
+    "python-decouple>=3.4",
+    "python-kasa>=0.7",
+    "tuyapower>=0.2",
 ]
 ocr = [
     "numpy>=2.4",

--- a/utils/measure/tests/test_architecture.py
+++ b/utils/measure/tests/test_architecture.py
@@ -12,6 +12,11 @@ EXECUTION_BOUNDARIES = {
     Path("cli/request_adapter.py"),
     Path("ha_app/service.py"),
 }
+OPTIONAL_ADAPTER_MODULES = {
+    "measure.controller.light.hue",
+    "measure.powermeter.kasa",
+    "measure.powermeter.tuya",
+}
 
 
 def test_shared_modules_do_not_import_transport_packages() -> None:
@@ -90,6 +95,12 @@ def test_only_home_assistant_manager_constructs_websocket_clients() -> None:
     assert violations == []
 
 
+def test_assembler_imports_optional_adapters_only_when_selected() -> None:
+    imports = _top_level_imports(MEASURE_ROOT / "assembler.py")
+
+    assert not imports.intersection(OPTIONAL_ADAPTER_MODULES)
+
+
 def _call_name(node: ast.Call) -> str | None:
     if isinstance(node.func, ast.Name):
         return node.func.id
@@ -106,4 +117,15 @@ def _imports(path: Path) -> list[str]:
             imports.extend(alias.name for alias in node.names)
         elif isinstance(node, ast.ImportFrom) and node.module:
             imports.append(node.module)
+    return imports
+
+
+def _top_level_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
     return imports

--- a/utils/measure/tests/test_assembler.py
+++ b/utils/measure/tests/test_assembler.py
@@ -110,7 +110,7 @@ def test_assembler_reads_tuya_key_from_cli_config_dependency() -> None:
         ),
     )
 
-    with patch("measure.assembler.TuyaPowerMeter") as power_meter:
+    with patch("measure.powermeter.tuya.TuyaPowerMeter") as power_meter:
         power_meter.return_value.has_voltage_support.return_value = False
         _assembler(tuya_device_key="device-key").assemble(request)
 

--- a/utils/measure/uv.lock
+++ b/utils/measure/uv.lock
@@ -283,15 +283,6 @@ wheels = [
 ]
 
 [[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -597,7 +588,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon" },
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981, upload-time = "2024-07-31T22:39:18.854Z" }
 wheels = [
@@ -727,25 +718,23 @@ name = "measure"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "chardet" },
-    { name = "charset-normalizer" },
-    { name = "fastapi" },
     { name = "homeassistant-api" },
-    { name = "inquirer" },
-    { name = "pycryptodome" },
     { name = "pydantic" },
-    { name = "python-decouple" },
-    { name = "python-kasa" },
-    { name = "readchar" },
     { name = "requests" },
-    { name = "tuyapower" },
-    { name = "typing-extensions" },
-    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
+app = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
 cli = [
     { name = "aiohue" },
+    { name = "inquirer" },
+    { name = "pycryptodome" },
+    { name = "python-decouple" },
+    { name = "python-kasa" },
+    { name = "tuyapower" },
 ]
 dev = [
     { name = "httpx2" },
@@ -769,31 +758,27 @@ visualize = [
 [package.metadata]
 requires-dist = [
     { name = "aiohue", marker = "extra == 'cli'", specifier = ">=4.8.1,<5" },
-    { name = "chardet", specifier = ">=5.1" },
-    { name = "charset-normalizer", specifier = ">=3.1" },
-    { name = "fastapi", specifier = ">=0.116" },
+    { name = "fastapi", marker = "extra == 'app'", specifier = ">=0.116" },
     { name = "homeassistant-api", specifier = "~=6.0" },
     { name = "httpx2", marker = "extra == 'dev'", specifier = ">=0.1" },
-    { name = "inquirer", specifier = ">=3.1" },
+    { name = "inquirer", marker = "extra == 'cli'", specifier = ">=3.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "numpy", marker = "extra == 'ocr'", specifier = ">=2.4" },
     { name = "opencv-python-headless", marker = "extra == 'ocr'", specifier = ">=4.7" },
     { name = "pillow", marker = "extra == 'ocr'", specifier = ">=12.0" },
-    { name = "pycryptodome" },
+    { name = "pycryptodome", marker = "extra == 'cli'", specifier = ">=3.20" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "python-decouple", specifier = ">=3.4" },
-    { name = "python-kasa", specifier = ">=0.7" },
-    { name = "readchar", specifier = ">=4.0" },
+    { name = "python-decouple", marker = "extra == 'cli'", specifier = ">=3.4" },
+    { name = "python-kasa", marker = "extra == 'cli'", specifier = ">=0.7" },
     { name = "requests", specifier = ">=2.28" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
-    { name = "tuyapower", specifier = ">=0.2" },
-    { name = "typing-extensions", specifier = ">=4.6" },
-    { name = "uvicorn", specifier = ">=0.35" },
+    { name = "tuyapower", marker = "extra == 'cli'", specifier = ">=0.2" },
+    { name = "uvicorn", marker = "extra == 'app'", specifier = ">=0.35" },
 ]
-provides-extras = ["cli", "ocr", "dev"]
+provides-extras = ["app", "cli", "ocr", "dev"]
 
 [package.metadata.requires-dev]
 visualize = [{ name = "matplotlib", specifier = ">=3.11" }]


### PR DESCRIPTION
## Summary

- separate the Home Assistant app and CLI dependency sets
- load Kasa and Tuya adapters only when their power meter type is selected
- keep the HA app image free of CLI-only integrations while preserving all CLI adapters
- update CI and setup documentation to select the required extras explicitly

## Validation

- `uv run --extra dev --extra app --extra cli pytest -q` (376 passed)
- Ruff, focused strict mypy, and `uv lock --check`
- Zensical documentation build
- isolated app-only virtual environment import test
- HA app and CLI Docker target builds
- runtime smoke tests for both Docker images
- frontend typecheck, 91 tests, and production build through the Docker build
