### PR TITLE
Prevent Measure release draft update races

### DIFF
--- a/.github/scripts/release_draft/github_client.py
+++ b/.github/scripts/release_draft/github_client.py
@@ -7,7 +7,7 @@ runner without any dependency install, exactly like the previous scripts.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 import urllib.request
 
 API_ROOT = "https://api.github.com"
@@ -92,7 +92,10 @@ class GitHubClient:
         return self._paginate(f"/repos/{self.repository}/releases")
 
     def create_release(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return self._request("POST", f"/repos/{self.repository}/releases", payload)
+        return cast(dict[str, Any], self._request("POST", f"/repos/{self.repository}/releases", payload))
 
     def update_release(self, release_id: int, payload: dict[str, Any]) -> dict[str, Any]:
-        return self._request("PATCH", f"/repos/{self.repository}/releases/{release_id}", payload)
+        return cast(dict[str, Any], self._request("PATCH", f"/repos/{self.repository}/releases/{release_id}", payload))
+
+    def delete_release(self, release_id: int) -> None:
+        self._request("DELETE", f"/repos/{self.repository}/releases/{release_id}")

--- a/.github/scripts/release_draft/tests/test_measure_draft.py
+++ b/.github/scripts/release_draft/tests/test_measure_draft.py
@@ -1,0 +1,113 @@
+"""Behavioural tests for the rolling Measure release draft."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import update_measure_draft as entry
+
+
+class FakeClient:
+    def __init__(self, releases: list[dict[str, Any]], pull_requests: list[dict[str, Any]]) -> None:
+        self._releases = releases
+        self._pull_requests = pull_requests
+        self.created: list[dict[str, Any]] = []
+        self.updated: list[tuple[int, dict[str, Any]]] = []
+        self.deleted: list[int] = []
+        self.history_requests: list[tuple[str | None, str]] = []
+
+    def releases(self) -> list[dict[str, Any]]:
+        return self._releases
+
+    def commit_sha(self, ref: str) -> str:
+        return f"sha-of-{ref}"
+
+    def commit_shas_since(self, base_sha: str | None, head_ref: str) -> list[str]:
+        self.history_requests.append((base_sha, head_ref))
+        return ["sha1", "sha2"]
+
+    def merged_pull_requests(self, commit_shas: list[str]) -> list[dict[str, Any]]:
+        return self._pull_requests
+
+    def pull_request_files(self, number: int) -> list[str]:
+        return ["utils/measure/measure/runner/runner.py"]
+
+    def create_release(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.created.append(payload)
+        return {"id": 999, **payload}
+
+    def update_release(self, release_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        self.updated.append((release_id, payload))
+        return {"id": release_id, **payload}
+
+    def delete_release(self, release_id: int) -> None:
+        self.deleted.append(release_id)
+
+
+def release(*, body: str = "", release_id: int = 1) -> dict[str, Any]:
+    return {
+        "id": release_id,
+        "tag_name": "measure-next",
+        "name": "Powercalc Measure v0.0.2 (unreleased)",
+        "body": body,
+        "draft": True,
+    }
+
+
+def pull_request(number: int, title: str) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": title,
+        "labels": [],
+        "user": {"login": "octocat"},
+    }
+
+
+def run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, client: FakeClient) -> FakeClient:
+    config = tmp_path / "config.yaml"
+    config.write_text('version: "0.0.1"\n', encoding="utf-8")
+    monkeypatch.setattr(entry, "CONFIG_PATH", config)
+    monkeypatch.setattr(entry, "GitHubClient", lambda *_args, **_kwargs: client)
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("HEAD_REF", "master")
+    monkeypatch.delenv("COMMIT_SHAS", raising=False)
+    entry.main()
+    return client
+
+
+def test_rebuilds_draft_from_all_measure_prs_since_current_tag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = FakeClient(
+        releases=[release(body="- #99 stale entry @octocat\n", release_id=77)],
+        pull_requests=[
+            pull_request(10, "Add measurement mode"),
+            pull_request(11, "Fix adapter cleanup"),
+        ],
+    )
+
+    run(monkeypatch, tmp_path, client)
+
+    assert client.history_requests == [("sha-of-measure-v0.0.1", "master")]
+    assert client.updated[0][0] == 77
+    body = client.updated[0][1]["body"]
+    assert "#10 Add measurement mode" in body
+    assert "#11 Fix adapter cleanup" in body
+    assert "#99 stale entry" not in body
+
+
+def test_removes_stale_draft_when_tag_has_no_new_measure_prs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = FakeClient(releases=[release(release_id=77)], pull_requests=[])
+
+    run(monkeypatch, tmp_path, client)
+
+    assert client.deleted == [77]
+    assert not client.created
+    assert not client.updated

--- a/.github/scripts/release_draft/update_measure_draft.py
+++ b/.github/scripts/release_draft/update_measure_draft.py
@@ -2,10 +2,9 @@
 """
 Maintain the rolling Powercalc Measure draft release.
 
-Runs on every push to master. Each pushed commit is resolved to its merged
-pull request; when that pull request touches the Measure tool, a changelog
-line is appended to the body of the single rolling draft release with the
-`measure-next` tag.
+Runs on every push to master. The draft is rebuilt from all merged Measure
+pull requests since the current ``measure-v*`` tag. Rebuilding makes retries,
+queued workflow replacement, and overlapping pushes idempotent.
 
 The draft title carries the automatically resolved next version, following
 semantic versioning: breaking changes (a `!` conventional-commit marker or a
@@ -22,22 +21,18 @@ repository instead, driven by the Publish Measure Docker Image workflow.
 Requires:
 - Python 3.11+ (standard library only)
 - `GITHUB_TOKEN` with contents write and pull-requests read
-- `GITHUB_REPOSITORY` and `COMMIT_SHAS` (JSON array of pushed commit SHAs)
+- `GITHUB_REPOSITORY` and `HEAD_REF`
 - a repository checkout as the working directory (reads the app config)
 """
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 import re
 from typing import Any
 
 from changelog import (
-    MAJOR,
-    MINOR,
-    PATCH,
     UNCATEGORIZED,
     Category,
     bump,
@@ -46,7 +41,6 @@ from changelog import (
     format_entry,
     format_version,
     labels_of,
-    parse_sections,
     render_sections,
 )
 from github_client import GitHubClient
@@ -106,17 +100,6 @@ def _current_version() -> tuple[int, int, int]:
     return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
-def _pending_level(draft_name: str, current: tuple[int, int, int]) -> int:
-    """Infer the bump level already accumulated in the draft from its title."""
-    match = re.search(r"v(\d+)\.(\d+)\.(\d+)", draft_name)
-    if match is not None:
-        pending = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
-        for level in (MAJOR, MINOR, PATCH):
-            if bump(current, level) == pending:
-                return level
-    return PATCH
-
-
 def _rolling_draft(client: GitHubClient) -> dict[str, Any] | None:
     return next(
         (release for release in client.releases() if release["draft"] and release["tag_name"] == DRAFT_TAG),
@@ -126,36 +109,33 @@ def _rolling_draft(client: GitHubClient) -> dict[str, Any] | None:
 
 def main() -> None:
     client = GitHubClient(os.environ["GITHUB_TOKEN"], os.environ["GITHUB_REPOSITORY"])
-    commit_shas = json.loads(os.environ["COMMIT_SHAS"])
+    head_ref = os.environ.get("HEAD_REF", "master")
+    current = _current_version()
+    current_version = format_version(current)
+    base_sha = client.commit_sha(f"measure-v{current_version}")
+    commit_shas = client.commit_shas_since(base_sha, head_ref)
 
     pull_requests = [
         pull_request
         for pull_request in client.merged_pull_requests(commit_shas)
         if _qualifies(client, pull_request)
     ]
+    draft = _rolling_draft(client)
     if not pull_requests:
-        print("No merged Measure pull requests in this push")
+        if draft is not None:
+            client.delete_release(draft["id"])
+            print(f"Removed empty rolling draft after measure-v{current_version}")
+        else:
+            print(f"No merged Measure pull requests on {head_ref} since measure-v{current_version}")
         return
 
-    draft = _rolling_draft(client)
-    body = draft["body"] or "" if draft is not None else ""
-    sections = parse_sections(body)
-
-    current = _current_version()
-    levels = [] if draft is None else [_pending_level(draft["name"] or "", current)]
-    added = 0
+    sections: dict[str, list[str]] = {UNCATEGORIZED: []}
+    levels: list[int] = []
     for pull_request in pull_requests:
         entry = format_entry(pull_request)
         levels.append(bump_level(pull_request, CATEGORIES))
-        if f"- #{pull_request['number']} " in body:
-            print(f"Draft already lists #{pull_request['number']}")
-            continue
         sections.setdefault(category_title(pull_request, CATEGORIES), []).append(entry)
         print(f"Adding {entry}")
-        added += 1
-
-    if not added:
-        return
 
     next_version = format_version(bump(current, max(levels)))
     payload = {
@@ -166,10 +146,10 @@ def main() -> None:
     }
     if draft is None:
         client.create_release(payload)
-        print(f"Created rolling draft {DRAFT_TAG} for v{next_version} with {added} entries")
+        print(f"Created rolling draft {DRAFT_TAG} for v{next_version} with {len(pull_requests)} entries")
     else:
         client.update_release(draft["id"], payload)
-        print(f"Updated rolling draft {DRAFT_TAG} for v{next_version} with {added} new entries")
+        print(f"Rebuilt rolling draft {DRAFT_TAG} for v{next_version} with {len(pull_requests)} entries")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/measure-release.yml
+++ b/.github/workflows/measure-release.yml
@@ -14,13 +14,16 @@ on:
 
 permissions: {}
 
-# No concurrency group: a pending queued run would be cancelled by the next
-# master push, silently dropping its changelog entries. Parallel runs are
-# safe because draft updates are deduplicated per pull request number.
+concurrency:
+  # A newer queued run may replace an older pending one. That is safe because
+  # every run rebuilds the draft from the full history since the release tag.
+  group: measure-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   update-draft:
     name: Update rolling draft
+    needs: tag-release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,10 +33,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - name: Append merged Measure pull requests to the draft
+      - name: Rebuild draft from merged Measure pull requests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMIT_SHAS: ${{ toJSON(github.event.commits.*.id) }}
+          HEAD_REF: ${{ github.ref_name }}
         run: python3 .github/scripts/release_draft/update_measure_draft.py
 
   tag-release:

--- a/.github/workflows/publish-measure-image.yml
+++ b/.github/workflows/publish-measure-image.yml
@@ -279,16 +279,3 @@ jobs:
               --title "Powercalc Measure v${VERSION}" \
               --notes-file "$RUNNER_TEMP/measure-release-notes.md"
           fi
-      - name: Clear rolling draft
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          release_id=$(gh api "repos/${REPOSITORY}/releases" --paginate \
-            --jq '.[] | select(.draft == true and .tag_name == "measure-next") | .id' | head -n 1)
-          if [[ -n "$release_id" ]]; then
-            gh api -X DELETE "repos/${REPOSITORY}/releases/${release_id}"
-            echo "Removed rolling measure-next draft"
-          else
-            echo "No rolling measure-next draft to remove"
-          fi

--- a/utils/measure/home-assistant-app/README.md
+++ b/utils/measure/home-assistant-app/README.md
@@ -40,7 +40,7 @@ To release:
 2. Run the **Prepare Measure Release** workflow. Leave the version empty to use the resolved version from the draft title, or pass one to override. Enable `dry_run` to preview and validate without creating a branch.
 3. Review and merge the generated release pull request. Everything after the merge is automatic.
 
-On merge, the **Measure Release** workflow detects the new changelog section, pushes the `measure-v0.2.0` tag, and dispatches the publish workflow on that tag. That builds both artifacts with distinct embedded versions (`v0.2.0:cli` for the CLI image, `v0.2.0:app` for the Home Assistant app), mirrors the app metadata to this repository after the images are pullable, creates the `v0.2.0` GitHub release here with the changelog notes, and finally deletes the rolling draft in the main repository so the next cycle starts empty. Measure pull requests merged while the publish pipeline is still running should be re-added to the fresh draft by hand if the draft deletion swallowed them.
+On merge, the **Measure Release** workflow detects the new changelog section, pushes the `measure-v0.2.0` tag, and dispatches the publish workflow on that tag. That builds both artifacts with distinct embedded versions (`v0.2.0:cli` for the CLI image, `v0.2.0:app` for the Home Assistant app), mirrors the app metadata to this repository after the images are pullable, and creates the `v0.2.0` GitHub release here with the changelog notes. The rolling draft in the main repository is rebuilt from Measure pull requests merged after the new tag, so concurrent merges cannot be lost while the publish pipeline is running.
 
 For local troubleshooting, export the draft body to a file and run from `utils/measure`:
 


### PR DESCRIPTION
## Summary

- rebuild the rolling Measure draft from every qualifying PR since the current Measure tag
- serialize draft workflows without losing entries when GitHub replaces a pending run
- reset stale drafts immediately after a release tag becomes the new history boundary
- stop the later image-publish job from deleting drafts that may already contain newer changes

## Validation

- release-draft engine tests: 40 passed
- strict mypy on the changed release-draft modules and regression tests
- repository pre-commit hooks, including Ruff, workflow validation, actionlint, and zizmor

## Regression coverage

- reconstructs a stale draft from complete Measure history
- removes the old rolling draft when no qualifying PR exists after the current tag
