### PR TITLE
Show dummy-load calibration lookup failures

### DIFF
--- a/utils/measure/frontend/src/app-controller.test.ts
+++ b/utils/measure/frontend/src/app-controller.test.ts
@@ -23,7 +23,7 @@ function state(): MeasureAppState {
     view: "loading", errorMessage: "", busy: false, connectedToEvents: false,
     files: [], plotCollection: { partial: false, plots: [], warnings: [] },
     logs: [], samples: [], lights: [], powers: [], voltages: [], definitions: [],
-    dummyLoadCalibration: null,
+    dummyLoadCalibration: null, dummyLoadCalibrationError: "",
     deviceEntities: {}, deviceEntityErrors: {}, testingPowerMeter: false,
     shellyDiscoveryDevices: [], discoveringShellys: false, shellyDiscoveryError: "",
   };
@@ -79,6 +79,19 @@ describe("measure app controller", () => {
     await controller.boot();
 
     expect(appState.dummyLoadCalibration).toEqual(calibration);
+  });
+
+  it("surfaces calibration lookup failures without blocking boot", async () => {
+    const appState = state();
+    const controller = new MeasureAppController(appState, () => api({
+      getDummyLoadCalibration: async () => { throw new Error("Calibration API unavailable"); },
+    }), () => connection(), () => undefined);
+
+    await controller.boot();
+
+    expect(appState.view).toBe("setup");
+    expect(appState.dummyLoadCalibration).toBeNull();
+    expect(appState.dummyLoadCalibrationError).toContain("Calibration API unavailable");
   });
 
   it("loads files and plots for a persisted terminal session", async () => {
@@ -216,6 +229,36 @@ describe("measure app controller", () => {
 
     expect(calibrationCalls).toBe(2);
     expect(appState.dummyLoadCalibration?.description).toBe("Heater");
+  });
+
+  it("retains the previous calibration and can retry after a refresh failure", async () => {
+    const appState = state();
+    const calibration = {
+      description: "Heater",
+      resistance: 1200,
+      calibrated_at: "2026-07-16T11:00:00Z",
+    };
+    let calibrationResult: "success" | "failure" = "success";
+    const controller = new MeasureAppController(appState, () => api({
+      getDummyLoadCalibration: async () => {
+        if (calibrationResult === "failure") throw new Error("Calibration API unavailable");
+        return calibration;
+      },
+    }), () => connection(), () => undefined);
+    await controller.boot();
+    controller.openSettings();
+    calibrationResult = "failure";
+
+    await controller.saveSettings(settings);
+
+    expect(appState.dummyLoadCalibration).toEqual(calibration);
+    expect(appState.dummyLoadCalibrationError).toContain("Calibration API unavailable");
+
+    calibrationResult = "success";
+    await controller.retryDummyLoadCalibration();
+
+    expect(appState.dummyLoadCalibrationError).toBe("");
+    expect(appState.dummyLoadCalibration).toEqual(calibration);
   });
 
   it("ignores a validation result after the meter configuration changes", async () => {

--- a/utils/measure/frontend/src/app-controller.ts
+++ b/utils/measure/frontend/src/app-controller.ts
@@ -39,6 +39,7 @@ export interface MeasureAppState {
   powers: EntityDescriptor[];
   voltages: EntityDescriptor[];
   dummyLoadCalibration: DummyLoadCalibration | null;
+  dummyLoadCalibrationError: string;
   settings?: AppSettings;
   definitions: MeasureDefinition[];
   deviceEntities: Record<string, EntityDescriptor[]>;
@@ -114,6 +115,7 @@ export class MeasureAppController {
         if (error instanceof ApiError && error.status === 404) return { state: "idle" } satisfies SessionSnapshot;
         throw error;
       });
+      const calibrationPromise = this.refreshDummyLoadCalibration();
       [
         this.state.capabilities,
         this.state.lights,
@@ -122,7 +124,6 @@ export class MeasureAppController {
         this.state.settings,
         this.state.snapshot,
         this.state.definitions,
-        this.state.dummyLoadCalibration,
       ] = await Promise.all([
         api.getCapabilities(),
         api.getEntitiesByDomain("light"),
@@ -131,8 +132,8 @@ export class MeasureAppController {
         api.getSettings(),
         currentPromise,
         api.getMeasureDefinitions(),
-        api.getDummyLoadCalibration().catch(() => null),
       ]);
+      await calibrationPromise;
       this.state.request = this.state.snapshot.request;
       if (this.state.request) await this.loadTypeEntities(this.state.request.measure_type);
       await this.routeSnapshot();
@@ -315,9 +316,9 @@ export class MeasureAppController {
     this.changed();
     try {
       this.state.settings = await this.api().saveSettings(settings);
-      [this.state.capabilities, this.state.dummyLoadCalibration] = await Promise.all([
+      [this.state.capabilities] = await Promise.all([
         this.api().getCapabilities(),
-        this.api().getDummyLoadCalibration().catch(() => null),
+        this.refreshDummyLoadCalibration(),
       ]);
       this.state.view = this.settingsReturnView;
     } catch (error) {
@@ -325,6 +326,20 @@ export class MeasureAppController {
     } finally {
       this.state.busy = false;
       this.changed();
+    }
+  }
+
+  async retryDummyLoadCalibration(): Promise<void> {
+    await this.refreshDummyLoadCalibration();
+    this.changed();
+  }
+
+  private async refreshDummyLoadCalibration(): Promise<void> {
+    try {
+      this.state.dummyLoadCalibration = await this.api().getDummyLoadCalibration();
+      this.state.dummyLoadCalibrationError = "";
+    } catch (error) {
+      this.state.dummyLoadCalibrationError = `Could not load the saved dummy-load calibration: ${message(error)}`;
     }
   }
 

--- a/utils/measure/frontend/src/components/app-shell.ts
+++ b/utils/measure/frontend/src/components/app-shell.ts
@@ -21,7 +21,7 @@ export class AppShell extends LitElement implements MeasureAppState {
     files: { state: true }, plotCollection: { state: true }, logs: { state: true }, settings: { state: true },
     samples: { state: true }, testingPowerMeter: { state: true }, powerMeterTestResult: { state: true },
     deviceEntities: { state: true }, deviceEntityErrors: { state: true },
-    dummyLoadCalibration: { state: true },
+    dummyLoadCalibration: { state: true }, dummyLoadCalibrationError: { state: true },
     shellyDiscoveryDevices: { state: true }, discoveringShellys: { state: true }, shellyDiscoveryError: { state: true },
     shellyDiscoveryAvailable: { state: true }, shellyDiscoveryMessage: { state: true },
   };
@@ -44,6 +44,7 @@ export class AppShell extends LitElement implements MeasureAppState {
   powers: EntityDescriptor[] = [];
   voltages: EntityDescriptor[] = [];
   dummyLoadCalibration: DummyLoadCalibration | null = null;
+  dummyLoadCalibrationError = "";
   settings?: AppSettings;
   definitions: MeasureDefinition[] = [];
   deviceEntities: Record<string, EntityDescriptor[]> = {};
@@ -80,6 +81,8 @@ export class AppShell extends LitElement implements MeasureAppState {
     .sequence > li { position: relative; display: grid; gap: 0.45rem; min-width: 0; color: var(--muted); font: 700 0.68rem/1.15 ui-monospace, monospace; letter-spacing: 0.08em; text-transform: uppercase; }
     .sequence > li:not(:last-child)::after { content: ""; position: absolute; top: 10px; left: calc(20px + 0.45rem); width: calc(100% - 40px - 0.45rem); height: 2px; border-radius: 99px; background: var(--line); }
     .step-number { display: grid; place-items: center; width: 20px; height: 20px; border: 1px solid var(--line); border-radius: 50%; background: var(--canvas); color: var(--muted); font-size: 0.66rem; z-index: 1; }
+    .calibration-warning { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+    .calibration-warning button { flex: 0 0 auto; }
     .sequence > li.active { color: var(--ink); } .sequence > li.done { color: var(--signal-strong); }
     .sequence > li.active .step-number { border-color: var(--signal); box-shadow: 0 0 0 4px color-mix(in srgb, var(--signal) 16%, transparent); color: var(--on-signal); background: var(--signal); }
     .sequence > li.done .step-number { border-color: var(--signal); color: var(--on-signal); background: var(--signal); }
@@ -88,7 +91,7 @@ export class AppShell extends LitElement implements MeasureAppState {
     .pulse { width: 40px; height: 40px; margin: 0 auto 1rem; border: 2px solid var(--line); border-top-color: var(--signal); border-radius: 50%; animation: spin 850ms linear infinite; }
     @keyframes spin { to { transform: rotate(360deg); } }
     footer { margin-top: 1rem; color: var(--muted); font-size: 0.72rem; text-align: right; }
-    @media (max-width: 700px) { .intro { grid-template-columns: 1fr; } h1 { grid-column: auto; } .sequence { max-width: 560px; } }
+    @media (max-width: 700px) { .intro { grid-template-columns: 1fr; } h1 { grid-column: auto; } .sequence { max-width: 560px; } .calibration-warning { align-items: flex-start; flex-direction: column; } }
     @media (max-width: 460px) { .shell { width: min(100% - 1.25rem, 980px); } .sequence { gap: 0.3rem; } .sequence > li { font-size: 0.58rem; letter-spacing: 0.04em; } .sequence > li:not(:last-child)::after { left: calc(20px + 0.3rem); width: calc(100% - 40px - 0.3rem); } }
   `];
 
@@ -115,6 +118,12 @@ export class AppShell extends LitElement implements MeasureAppState {
             </nav>
           </div>
         </header>
+        ${this.dummyLoadCalibrationError ? html`
+          <div class="notice calibration-warning" role="status">
+            <span>${this.dummyLoadCalibrationError}</span>
+            <button type="button" @click=${this.retryDummyLoadCalibration}>Retry</button>
+          </div>
+        ` : nothing}
         ${this.renderView()}
         <footer>Keep this app running while the measurement is in progress.</footer>
       </main>
@@ -296,6 +305,9 @@ export class AppShell extends LitElement implements MeasureAppState {
   }
   private saveSettings(event: CustomEvent<AppSettings>): void {
     void this.controller.saveSettings(event.detail);
+  }
+  private retryDummyLoadCalibration(): void {
+    void this.controller.retryDummyLoadCalibration();
   }
   private stepClass(index: number): string {
     const current = this.currentStep();

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -1457,6 +1457,20 @@ describe("app shell", () => {
     expect(logo?.src).toContain("image/svg+xml");
   });
 
+  it("renders calibration lookup failures as a retryable warning", async () => {
+    vi.spyOn(AppShell.prototype as unknown as { boot: () => Promise<void> }, "boot").mockResolvedValue();
+    const element = document.createElement("powercalc-measure-app") as AppShell;
+    element.view = "setup";
+    element.dummyLoadCalibrationError = "Could not load the saved dummy-load calibration: API unavailable";
+    document.body.append(element);
+    await element.updateComplete;
+
+    const warning = element.shadowRoot?.querySelector(".calibration-warning");
+    expect(warning?.getAttribute("role")).toBe("status");
+    expect(warning?.textContent).toContain("API unavailable");
+    expect(warning?.querySelector("button")?.textContent).toContain("Retry");
+  });
+
   it("does not restore a stale validation result after meter settings change", async () => {
     vi.spyOn(AppShell.prototype as unknown as { boot: () => Promise<void> }, "boot").mockResolvedValue();
     const element = document.createElement("powercalc-measure-app") as AppShell;


### PR DESCRIPTION
## Summary

- keep the last known dummy-load calibration when refreshing it fails
- surface calibration API failures without blocking the measurement wizard
- provide an explicit Retry action on every app view
- keep the warning action visible on narrow mobile screens

## Validation

- Node 24 TypeScript typecheck
- frontend tests: 94 passed
- Vite production build
- repository pre-commit hooks
- desktop and mobile headless screenshots; visual verdict 94/100 (pass)

## Regression coverage

- boot continues with a visible calibration warning
- settings refresh retains the previous calibration
- retry clears the warning after a successful lookup
- app shell renders the warning as a status with a Retry action
