### PR TITLE
Bound recorder plot and diagnostics memory

### DIFF
--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -24,7 +24,7 @@ from measure.controller.light.const import LutMode
 from measure.dummy_load import DummyLoadCalibration, power_meter_fingerprint
 from measure.execution import ImmediateInteraction
 from measure.ha_app.coordinator import MeasurementCoordinator, SessionConflictError
-from measure.ha_app.diagnostics import build_session_diagnostics
+from measure.ha_app.diagnostics import DIAGNOSTIC_EVENT_LIMIT, build_session_diagnostics
 from measure.ha_app.preferences import AppPreferences
 from measure.ha_app.preflight import ActiveSessionError, MeasurementPreflight, PreflightError
 from measure.ha_app.registry import FieldControl, measurement_definitions, supported_light_modes
@@ -430,11 +430,14 @@ def _register_session_routes(router: APIRouter) -> None:  # noqa: C901
             _file_descriptor(context.storage.file_path(snapshot.id, name), name).model_dump()
             for name in context.storage.list_files(snapshot.id)
         ]
+        events = context.storage.load_events(snapshot.id, limit=DIAGNOSTIC_EVENT_LIMIT + 1)
+        events_truncated = len(events) > DIAGNOSTIC_EVENT_LIMIT
         payload = build_session_diagnostics(
             snapshot,
             context.storage.load_request(snapshot.id),
-            context.storage.load_events(snapshot.id, limit=None),
+            events[-DIAGNOSTIC_EVENT_LIMIT:],
             files,
+            events_truncated=events_truncated,
         )
         filename = f"powercalc-measure-diagnostics-{snapshot.id[:8]}.json"
         return Response(

--- a/utils/measure/measure/ha_app/diagnostics.py
+++ b/utils/measure/measure/ha_app/diagnostics.py
@@ -8,6 +8,7 @@ from measure.request import MeasurementRequest
 from measure.version import measure_version
 
 REDACTED = "<redacted>"
+DIAGNOSTIC_EVENT_LIMIT = 1000
 _SENSITIVE_KEYS = frozenset({"password", "secret", "token"})
 _SENSITIVE_SUFFIXES = ("_ip", "_key", "_password", "_secret", "_token")
 _LOG_EVENT_TYPES = frozenset({SessionEventType.LOG, SessionEventType.WARNING, SessionEventType.CHECKPOINT})
@@ -18,6 +19,8 @@ def build_session_diagnostics(
     request: MeasurementRequest,
     events: Collection[SessionEvent],
     files: Collection[dict[str, object]],
+    *,
+    events_truncated: bool = False,
 ) -> dict[str, object]:
     """Build a shareable session report without credentials or network addresses."""
 
@@ -43,6 +46,8 @@ def build_session_diagnostics(
             sensitive_values,
         ),
         "events": _redact(event_data, sensitive_values),
+        "events_truncated": events_truncated,
+        "event_limit": DIAGNOSTIC_EVENT_LIMIT,
         "files": _redact(file_data, sensitive_values),
         "privacy": {
             "redacted": True,

--- a/utils/measure/measure/visualization/core.py
+++ b/utils/measure/measure/visualization/core.py
@@ -306,15 +306,7 @@ def _linear_plot(path: Path, *, source: str, max_points: int | None) -> PlotSpec
 
 
 def _recorder_plot(path: Path, *, source: str, max_points: int | None) -> PlotSpec:
-    points: list[PlotPoint] = []
-    with _open_csv(path) as file:
-        for row in csv.reader(file):
-            if len(row) < 2:
-                continue
-            elapsed = _finite_float(row[0])
-            power = _finite_float(row[1])
-            if elapsed is not None and power is not None:
-                points.append(PlotPoint(x=elapsed, y=power))
+    points = _stream_recorder_points(path, max_points)
     if not points:
         raise PlotDataError("no valid recorder measurements found")
     return PlotSpec(
@@ -324,14 +316,80 @@ def _recorder_plot(path: Path, *, source: str, max_points: int | None) -> PlotSp
         x_label="Elapsed time (s)",
         y_label=_POWER_AXIS_LABEL,
         source=source,
-        series=(
-            PlotSeries(
-                label=None,
-                color=_DEFAULT_COLOR,
-                points=_limit_line(points, max_points),
-            ),
-        ),
+        series=(PlotSeries(label=None, color=_DEFAULT_COLOR, points=points),),
     )
+
+
+def _iter_recorder_points(path: Path) -> Iterable[PlotPoint]:
+    with _open_csv(path) as file:
+        for row in csv.reader(file):
+            if len(row) < 2:
+                continue
+            elapsed = _finite_float(row[0])
+            power = _finite_float(row[1])
+            if elapsed is not None and power is not None:
+                yield PlotPoint(x=elapsed, y=power)
+
+
+def _stream_recorder_points(path: Path, max_points: int | None) -> tuple[PlotPoint, ...]:
+    if max_points is None:
+        return tuple(_iter_recorder_points(path))
+
+    point_count = sum(1 for _ in _iter_recorder_points(path))
+    if point_count <= max_points:
+        return tuple(_iter_recorder_points(path))
+    return _downsample_recorder_points(path, point_count, max_points)
+
+
+def _downsample_recorder_points(path: Path, point_count: int, max_points: int) -> tuple[PlotPoint, ...]:
+    if max_points <= 1:
+        return tuple(point for index, point in enumerate(_iter_recorder_points(path)) if index == 0)
+    if max_points < 4:
+        selected_indexes = {round(index * (point_count - 1) / (max_points - 1)) for index in range(max_points)}
+        return tuple(point for index, point in enumerate(_iter_recorder_points(path)) if index in selected_indexes)
+    return _recorder_extrema(path, point_count, max_points)
+
+
+def _recorder_extrema(path: Path, point_count: int, max_points: int) -> tuple[PlotPoint, ...]:
+    bucket_count = max(1, (max_points - 2) // 2)
+    bucket_size = math.ceil((point_count - 2) / bucket_count)
+    selected: list[tuple[int, PlotPoint]] = []
+    bucket_minimum: tuple[int, PlotPoint] | None = None
+    bucket_maximum: tuple[int, PlotPoint] | None = None
+    current_bucket = -1
+    last: tuple[int, PlotPoint] | None = None
+    for index, point in enumerate(_iter_recorder_points(path)):
+        if index == 0:
+            selected.append((index, point))
+            continue
+        if index == point_count - 1:
+            last = (index, point)
+            continue
+        bucket_index = (index - 1) // bucket_size
+        if bucket_index != current_bucket:
+            _append_bucket_extrema(selected, bucket_minimum, bucket_maximum)
+            bucket_minimum = None
+            bucket_maximum = None
+            current_bucket = bucket_index
+        candidate = (index, point)
+        if bucket_minimum is None or point.y < bucket_minimum[1].y:
+            bucket_minimum = candidate
+        if bucket_maximum is None or point.y > bucket_maximum[1].y:
+            bucket_maximum = candidate
+    _append_bucket_extrema(selected, bucket_minimum, bucket_maximum)
+    if last is not None:
+        selected.append(last)
+    return tuple(point for _, point in selected[:max_points])
+
+
+def _append_bucket_extrema(
+    selected: list[tuple[int, PlotPoint]],
+    minimum: tuple[int, PlotPoint] | None,
+    maximum: tuple[int, PlotPoint] | None,
+) -> None:
+    if minimum is None or maximum is None:
+        return
+    selected.extend(sorted({minimum[0]: minimum, maximum[0]: maximum}.values()))
 
 
 def _preferred_file(files: Mapping[str, Path], name: str) -> tuple[Path, str] | None:

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -14,7 +14,7 @@ from measure.dummy_load import DummyLoadCalibration, power_meter_fingerprint
 from measure.execution import LightOperatingPoint
 from measure.ha_app.api import create_app
 from measure.ha_app.coordinator import MeasurementCoordinator, SessionExecutionContext, SessionMeasurementService
-from measure.ha_app.session import SessionControl, SessionSnapshot, SessionState
+from measure.ha_app.session import SessionControl, SessionEvent, SessionEventType, SessionSnapshot, SessionState
 from measure.ha_app.storage import SessionStorage
 from measure.home_assistant import HomeAssistantEntityData, HomeAssistantManager
 from measure.powermeter.diagnostics import PowerMeterDiagnostics
@@ -580,6 +580,36 @@ def test_session_lifecycle_and_file_download(tmp_path: Path) -> None:
     assert report["events"][-1]["data"]["state"] == "completed"
     assert report["files"][0]["name"] == "LCT010/brightness.csv"
     assert "test-token" not in diagnostics.text
+
+
+def test_diagnostics_retains_only_the_latest_thousand_events(tmp_path: Path) -> None:
+    test_client = client(tmp_path)
+    assert test_client.post("/api/sessions", json=payload()).status_code == 201
+    coordinator = test_client.app.state.context.coordinator
+    assert coordinator._worker is not None  # noqa: SLF001
+    coordinator._worker.join(timeout=5)  # noqa: SLF001
+    assert coordinator.current is not None
+    events = tuple(
+        SessionEvent(
+            sequence=sequence,
+            type=SessionEventType.LOG,
+            created_at="2026-07-12T12:00:00Z",
+            data={"message": str(sequence)},
+        )
+        for sequence in range(1, 1002)
+    )
+    storage = test_client.app.state.context.storage
+
+    with patch.object(storage, "load_events", return_value=events) as load_events:
+        response = test_client.get("/api/session/current/diagnostics")
+
+    assert response.status_code == 200
+    load_events.assert_called_once_with(coordinator.current.id, limit=1001)
+    report = response.json()
+    assert len(report["events"]) == 1000
+    assert report["events"][0]["sequence"] == 2
+    assert report["events_truncated"] is True
+    assert report["event_limit"] == 1000
 
 
 def test_session_summary_is_exposed(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_visualization.py
+++ b/utils/measure/tests/test_visualization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gzip
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from measure.request import MeasurementRequest, parse_measurement_request
 from measure.visualization import PlotKind, build_plot_from_file, build_session_plots
@@ -124,6 +125,35 @@ def test_builds_recorder_time_series_and_ignores_invalid_rows(tmp_path: Path) ->
     assert result.plots[0].kind is PlotKind.LINE
     assert result.plots[0].x_label == "Elapsed time (s)"
     assert [(point.x, point.y) for point in result.plots[0].series[0].points] == [(0.0, 1.2), (2.0, 3.4)]
+
+
+def test_downsamples_large_recorder_files_while_streaming(tmp_path: Path) -> None:
+    recording = tmp_path / "record.csv"
+    recording.write_text(
+        "\n".join(f"{index},{999 if index == 10_000 else index % 20}" for index in range(20_000)),
+        encoding="utf-8",
+    )
+    request = parse_measurement_request(
+        {
+            "measure_type": "recorder",
+            "model_id": "measurement",
+            "power_meter": {"type": "dummy"},
+            "export_filename": "record.csv",
+        },
+    )
+
+    with patch("measure.visualization.core._limit_line", side_effect=AssertionError("full input was materialized")):
+        result = build_session_plots(
+            request,
+            {"measurement/record.csv": recording},
+            max_line_points=8,
+        )
+
+    points = result.plots[0].series[0].points
+    assert len(points) <= 8
+    assert points[0].x == 0
+    assert points[-1].x == 19_999
+    assert max(point.y for point in points) == 999
 
 
 def test_reports_invalid_artifact_without_hiding_other_plots(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- downsample recorder CSV plots in two streaming passes instead of materializing every row
- retain the first and last point plus bucket extrema so short spikes remain visible
- cap diagnostics at the newest 1000 persisted events
- report the diagnostics limit and whether older events were omitted

The raw recorder CSV remains complete and downloadable.

## Validation

- measure tests: 377 passed
- Ruff
- strict mypy for visualization, diagnostics, and API modules
- repository pre-commit hooks

## Regression coverage

- a 20,000-row recording is plotted without calling the full-list downsampler
- first/last points and an outlier peak survive bounded downsampling
- diagnostics request at most 1001 events and emits the newest 1000 with truncation metadata
