### PR TITLE
Enforce strict typing across the Measure package

### DIFF
--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -39,45 +39,13 @@ jobs:
           cd ./utils/measure
           uv run --extra dev --extra app --extra cli ruff check measure tests prepare_app_release.py
           MYPYPATH=. uv run --extra dev --extra app --extra cli mypy \
+            --strict \
             --explicit-package-bases \
             --follow-imports=silent \
             --ignore-missing-imports \
             --config-file ../../pyproject.toml \
             prepare_app_release.py \
-            measure/request.py \
-            measure/tuning.py \
-            measure/assembler.py \
-            measure/execution.py \
-            measure/model.py \
-            measure/dummy_load.py \
-            measure/visualization/__init__.py \
-            measure/visualization/core.py \
-            measure/visualization/renderer.py \
-            measure/visualization/cli.py \
-            measure/home_assistant.py \
-            measure/home_assistant_entities.py \
-            measure/cli/interaction.py \
-            measure/cli/dummy_load.py \
-            measure/cli/main.py \
-            measure/cli/measurements.py \
-            measure/cli/questions.py \
-            measure/controller/charging/spec.py \
-            measure/controller/light/capabilities.py \
-            measure/controller/light/hass.py \
-            measure/controller/light/hue.py \
-            measure/runner/light_plan.py \
-            measure/runner/light.py \
-            measure/runner/speaker.py \
-            measure/runner/fan.py \
-            measure/runner/charging.py \
-            measure/ha_app/interaction.py \
-            measure/ha_app/session.py \
-            measure/ha_app/storage.py \
-            measure/ha_app/coordinator.py \
-            measure/ha_app/service.py \
-            measure/ha_app/preflight.py \
-            measure/ha_app/api.py \
-            measure/ha_app/main.py
+            measure
           uv run --extra dev --extra app --extra cli pytest \
             -qq \
             --durations=10 \

--- a/utils/measure/measure/cli/environment.py
+++ b/utils/measure/measure/cli/environment.py
@@ -1,5 +1,7 @@
+from collections.abc import Callable
+from enum import StrEnum
 import logging
-from typing import Any
+from typing import Any, cast, overload
 
 from decouple import Choices, UndefinedValueError, config
 
@@ -15,9 +17,38 @@ _LOGGER = logging.getLogger("measure")
 
 # Shared tuning defaults; the environment variables below only override these.
 _DEFAULTS = MeasurementParameters()
+_UNSET = object()
 
 
-def _clamp(name: str, value: float) -> Any:  # noqa: ANN401  # int env values must stay int; typing per call site
+def _config_value[T](
+    key: str,
+    *,
+    converter: Callable[[Any], T],
+    default: object = _UNSET,
+) -> T:
+    if default is _UNSET:
+        return cast(T, config(key, cast=converter))
+    return cast(T, config(key, default=default, cast=converter))
+
+
+def _enum_value[T: StrEnum](key: str, enum_type: type[T], default: T) -> T:
+    choices = Choices([item.value for item in enum_type])
+    return _config_value(
+        key,
+        converter=lambda value: enum_type(choices(value)),
+        default=default.value,
+    )
+
+
+@overload
+def _clamp(name: str, value: int) -> int: ...
+
+
+@overload
+def _clamp(name: str, value: float) -> float: ...
+
+
+def _clamp(name: str, value: float) -> int | float:
     minimum, maximum = PARAMETER_LIMITS[name]
     if minimum <= value <= maximum:
         return value
@@ -30,12 +61,18 @@ def _clamp(name: str, value: float) -> Any:  # noqa: ANN401  # int env values mu
         maximum,
         clamped,
     )
-    return clamped
+    return int(clamped) if isinstance(value, int) else float(clamped)
 
 
-def _bounded(name: str, *, cast: type = int) -> Any:  # noqa: ANN401  # int env values must stay int; typing per call site
+def _bounded_int(name: str) -> int:
     """Read the env override (NAME uppercased), fall back to the shared tuning default, clamp to the table."""
-    return _clamp(name, config(name.upper(), default=getattr(_DEFAULTS, name), cast=cast))
+    value = _config_value(name.upper(), default=getattr(_DEFAULTS, name), converter=int)
+    return _clamp(name, value)
+
+
+def _bounded_float(name: str) -> float:
+    value = _config_value(name.upper(), default=getattr(_DEFAULTS, name), converter=float)
+    return _clamp(name, value)
 
 
 class CliEnvironment:
@@ -43,10 +80,10 @@ class CliEnvironment:
     def min_brightness(self) -> int:
         return _clamp(
             "min_brightness",
-            config(
+            _config_value(
                 "MIN_BRIGHTNESS",
-                default=config("START_BRIGHTNESS", default=_DEFAULTS.min_brightness, cast=int),
-                cast=int,
+                default=_config_value("START_BRIGHTNESS", default=_DEFAULTS.min_brightness, converter=int),
+                converter=int,
             ),
         )
 
@@ -56,31 +93,31 @@ class CliEnvironment:
 
     @property
     def min_sat(self) -> int:
-        return _bounded("min_sat")
+        return _bounded_int("min_sat")
 
     @property
     def max_sat(self) -> int:
-        return _bounded("max_sat")
+        return _bounded_int("max_sat")
 
     @property
     def min_hue(self) -> int:
-        return _bounded("min_hue")
+        return _bounded_int("min_hue")
 
     @property
     def max_hue(self) -> int:
-        return _bounded("max_hue")
+        return _bounded_int("max_hue")
 
     @property
     def ct_bri_steps(self) -> int:
         if self.selected_power_meter == PowerMeterType.MANUAL:
             return CT_BRI_STEPS_MANUAL
-        return _bounded("ct_bri_steps")
+        return _bounded_int("ct_bri_steps")
 
     @property
     def ct_mired_steps(self) -> int:
         if self.selected_power_meter == PowerMeterType.MANUAL:
             return CT_MIRED_STEPS_MANUAL
-        return _bounded("ct_mired_steps")
+        return _bounded_int("ct_mired_steps")
 
     @property
     def bri_bri_steps(self) -> int:
@@ -90,7 +127,7 @@ class CliEnvironment:
 
     @property
     def hs_bri_precision(self) -> float:
-        hs_bri_precision = config("HS_BRI_PRECISION", default=1, cast=float)
+        hs_bri_precision = _config_value("HS_BRI_PRECISION", default=1, converter=float)
         hs_bri_precision = min(hs_bri_precision, 4)
         return max(hs_bri_precision, 0.5)
 
@@ -100,7 +137,7 @@ class CliEnvironment:
 
     @property
     def hs_hue_precision(self) -> float:
-        hs_hue_precision = config("HS_HUE_PRECISION", default=1, cast=float)
+        hs_hue_precision = _config_value("HS_HUE_PRECISION", default=1, converter=float)
         hs_hue_precision = min(hs_hue_precision, 4)
         return max(hs_hue_precision, 0.5)
 
@@ -110,7 +147,7 @@ class CliEnvironment:
 
     @property
     def hs_sat_precision(self) -> float:
-        hs_sat_precision = config("HS_SAT_PRECISION", default=1, cast=float)
+        hs_sat_precision = _config_value("HS_SAT_PRECISION", default=1, converter=float)
         hs_sat_precision = min(hs_sat_precision, 4)
         return max(hs_sat_precision, 0.5)
 
@@ -120,98 +157,78 @@ class CliEnvironment:
 
     @property
     def effect_bri_steps(self) -> int:
-        return _bounded("effect_bri_steps")
+        return _bounded_int("effect_bri_steps")
 
     @property
     def selected_light_controller(self) -> LightControllerType:
-        return config(
-            "LIGHT_CONTROLLER",
-            cast=Choices([t.value for t in LightControllerType]),
-            default=LightControllerType.HASS.value,
-        )
+        return _enum_value("LIGHT_CONTROLLER", LightControllerType, LightControllerType.HASS)
 
     @property
     def selected_media_controller(self) -> MediaControllerType:
-        return config(
-            "MEDIA_CONTROLLER",
-            cast=Choices([t.value for t in MediaControllerType]),
-            default=MediaControllerType.HASS.value,
-        )
+        return _enum_value("MEDIA_CONTROLLER", MediaControllerType, MediaControllerType.HASS)
 
     @property
     def selected_charging_controller(self) -> ChargingControllerType:
-        return config(
-            "CHARGING_CONTROLLER",
-            cast=Choices([t.value for t in ChargingControllerType]),
-            default=ChargingControllerType.HASS.value,
-        )
+        return _enum_value("CHARGING_CONTROLLER", ChargingControllerType, ChargingControllerType.HASS)
 
     @property
     def selected_fan_controller(self) -> FanControllerType:
-        return config(
-            "FAN_CONTROLLER",
-            cast=Choices([t.value for t in FanControllerType]),
-            default=FanControllerType.HASS.value,
-        )
+        return _enum_value("FAN_CONTROLLER", FanControllerType, FanControllerType.HASS)
 
     @property
     def selected_power_meter(self) -> PowerMeterType:
-        return config(
-            "POWER_METER",
-            cast=Choices([t.value for t in PowerMeterType]),
-            default=PowerMeterType.HASS.value,
-        )
+        return _enum_value("POWER_METER", PowerMeterType, PowerMeterType.HASS)
 
     @property
-    def log_level(self) -> int:
-        return config("LOG_LEVEL", default=logging.INFO)
+    def log_level(self) -> str:
+        return _config_value("LOG_LEVEL", default=logging.getLevelName(logging.INFO), converter=str)
 
     @property
     def sleep_initial(self) -> int:
-        return _bounded("sleep_initial")
+        return _bounded_int("sleep_initial")
 
     @property
     def sleep_standby(self) -> int:
-        return _bounded("sleep_standby")
+        return _bounded_int("sleep_standby")
 
     @property
     def sleep_time(self) -> float:
-        return _bounded("sleep_time", cast=float)
+        return _bounded_float("sleep_time")
 
     @property
     def sleep_time_sample(self) -> int:
-        return _bounded("sleep_time_sample")
+        return _bounded_int("sleep_time_sample")
 
     @property
     def sleep_time_hue(self) -> int:
-        return config("SLEEP_TIME_HUE", default=_DEFAULTS.sleep_time_hue, cast=int)
+        return _config_value("SLEEP_TIME_HUE", default=_DEFAULTS.sleep_time_hue, converter=int)
 
     @property
     def sleep_time_sat(self) -> int:
-        return config("SLEEP_TIME_SAT", default=_DEFAULTS.sleep_time_sat, cast=int)
+        return _config_value("SLEEP_TIME_SAT", default=_DEFAULTS.sleep_time_sat, converter=int)
 
     @property
     def sleep_time_ct(self) -> int:
-        return config("SLEEP_TIME_CT", default=_DEFAULTS.sleep_time_ct, cast=int)
+        return _config_value("SLEEP_TIME_CT", default=_DEFAULTS.sleep_time_ct, converter=int)
 
     @property
     def measure_time_effect(self) -> int:
         """Maximum seconds to measure each effect/brightness combination."""
-        return _bounded("measure_time_effect")
+        return _bounded_int("measure_time_effect")
 
     @property
     def measure_time_effect_min(self) -> int:
         """Minimum seconds before effect measurement can stop on convergence."""
-        return min(_bounded("measure_time_effect_min"), self.measure_time_effect)
+        return min(_bounded_int("measure_time_effect_min"), self.measure_time_effect)
 
     @property
     def measure_time_effect_convergence_window(self) -> int:
         """Seconds between cumulative-average snapshots used for convergence checks."""
         return min(
-            config(
+            _config_value(
                 "MEASURE_TIME_EFFECT_CONVERGENCE_WINDOW",
                 default=_DEFAULTS.measure_time_effect_convergence_window,
-                cast=int,
+                converter=int,
             ),
             self.measure_time_effect_min,
         )
@@ -219,60 +236,60 @@ class CliEnvironment:
     @property
     def measure_time_effect_convergence_abs(self) -> float:
         """Maximum watt change allowed for effect average convergence."""
-        return config(
+        return _config_value(
             "MEASURE_TIME_EFFECT_CONVERGENCE_ABS",
             default=_DEFAULTS.measure_time_effect_convergence_abs,
-            cast=float,
+            converter=float,
         )
 
     @property
     def measure_time_effect_convergence_rel(self) -> float:
         """Maximum percentage change allowed for effect average convergence."""
         return (
-            config(
+            _config_value(
                 "MEASURE_TIME_EFFECT_CONVERGENCE_REL",
                 default=_DEFAULTS.measure_time_effect_convergence_rel * 100,
-                cast=float,
+                converter=float,
             )
             / 100
         )
 
     @property
     def sleep_time_effect_change(self) -> int:
-        return config("SLEEP_TIME_EFFECT_CHANGE", default=_DEFAULTS.sleep_time_effect_change, cast=int)
+        return _config_value("SLEEP_TIME_EFFECT_CHANGE", default=_DEFAULTS.sleep_time_effect_change, converter=int)
 
     @property
     def sleep_time_nudge(self) -> float:
-        return config("SLEEP_TIME_NUDGE", default=_DEFAULTS.sleep_time_nudge, cast=float)
+        return _config_value("SLEEP_TIME_NUDGE", default=_DEFAULTS.sleep_time_nudge, converter=float)
 
     @property
     def pulse_time_nudge(self) -> float:
-        return config("PULSE_TIME_NUDGE", default=_DEFAULTS.pulse_time_nudge, cast=float)
+        return _config_value("PULSE_TIME_NUDGE", default=_DEFAULTS.pulse_time_nudge, converter=float)
 
     @property
     def max_retries(self) -> int:
-        return _bounded("max_retries")
+        return _bounded_int("max_retries")
 
     @property
     def max_nudges(self) -> int:
-        return _bounded("max_nudges")
+        return _bounded_int("max_nudges")
 
     @property
     def sample_count(self) -> int:
         if self.selected_power_meter == PowerMeterType.MANUAL:
             return 1
-        return _bounded("sample_count")
+        return _bounded_int("sample_count")
 
     @property
     def selected_measure_type(self) -> MeasureType | None:
         try:
-            return parse_measure_type(config("SELECTED_MEASURE_TYPE"))
+            return parse_measure_type(_config_value("SELECTED_MEASURE_TYPE", converter=str))
         except UndefinedValueError:
             return None
 
     @property
     def resume(self) -> bool:
-        return config("RESUME", default=True, cast=bool)
+        return _config_value("RESUME", default=True, converter=bool)
 
     @property
     def prompt_resume(self) -> bool:
@@ -280,73 +297,77 @@ class CliEnvironment:
 
     @property
     def shelly_ip(self) -> str:
-        return config("SHELLY_IP")
+        return _config_value("SHELLY_IP", converter=str)
 
     @property
     def shelly_timeout(self) -> int:
-        return config("SHELLY_TIMEOUT", default=5, cast=int)
+        return _config_value("SHELLY_TIMEOUT", default=5, converter=int)
 
     @property
     def tuya_device_id(self) -> str:
-        return config("TUYA_DEVICE_ID")
+        return _config_value("TUYA_DEVICE_ID", converter=str)
 
     @property
     def tuya_device_ip(self) -> str:
-        return config("TUYA_DEVICE_IP")
+        return _config_value("TUYA_DEVICE_IP", converter=str)
 
     @property
     def tuya_device_key(self) -> str:
-        return config("TUYA_DEVICE_KEY")
+        return _config_value("TUYA_DEVICE_KEY", converter=str)
 
     @property
     def tuya_device_version(self) -> str:
-        return config("TUYA_DEVICE_VERSION", default="3.3")
+        return _config_value("TUYA_DEVICE_VERSION", default="3.3", converter=str)
 
     @property
     def hue_bridge_ip(self) -> str:
-        return config("HUE_BRIDGE_IP")
+        return _config_value("HUE_BRIDGE_IP", converter=str)
 
     @property
     def hass_url(self) -> str:
-        return config("HASS_URL")
+        return _config_value("HASS_URL", converter=str)
 
     @property
     def hass_token(self) -> str:
-        return config("HASS_TOKEN")
+        return _config_value("HASS_TOKEN", converter=str)
 
     @property
     def hass_call_update_entity_service(self) -> bool:
-        return config(
+        return _config_value(
             "HASS_CALL_UPDATE_ENTITY_SERVICE",
             default=False,
-            cast=bool,
+            converter=bool,
         )
 
     @property
     def light_transition_time(self) -> int:
-        return config(
+        return _config_value(
             "LIGHT_TRANSITION_TIME",
             default=DEFAULT_LIGHT_TRANSITION_TIME,
-            cast=int,
+            converter=int,
         )
 
     @property
     def tasmota_device_ip(self) -> str:
-        return config("TASMOTA_DEVICE_IP")
+        return _config_value("TASMOTA_DEVICE_IP", converter=str)
 
     @property
     def kasa_device_ip(self) -> str:
-        return config("KASA_DEVICE_IP")
+        return _config_value("KASA_DEVICE_IP", converter=str)
 
     @property
     def mystrom_device_ip(self) -> str:
-        return config("MYSTROM_DEVICE_IP")
+        return _config_value("MYSTROM_DEVICE_IP", converter=str)
 
     @property
     def csv_add_datetime_column(self) -> bool:
-        return config("CSV_ADD_DATETIME_COLUMN", default=_DEFAULTS.csv_add_datetime_column, cast=bool)
+        return _config_value(
+            "CSV_ADD_DATETIME_COLUMN",
+            default=_DEFAULTS.csv_add_datetime_column,
+            converter=bool,
+        )
 
     @staticmethod
     def get_conf_value(key: str) -> str | None:
         """Get configuration value from environment variable"""
-        return config(key, default=None)
+        return cast(str | None, config(key, default=None))

--- a/utils/measure/measure/ha_app/shelly_discovery.py
+++ b/utils/measure/measure/ha_app/shelly_discovery.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv6Address, ip_address
 import logging
@@ -89,7 +89,7 @@ class ShellyDiscoveryService:
         )
 
     @staticmethod
-    def _candidates(services: tuple[dict[str, object], ...]) -> list[_ShellyCandidate]:
+    def _candidates(services: Iterable[dict[str, object]]) -> list[_ShellyCandidate]:
         candidates: dict[str, _ShellyCandidate] = {}
         for service in services:
             service_type = service.get("type")

--- a/utils/measure/measure/ocr/ocr.py
+++ b/utils/measure/measure/ocr/ocr.py
@@ -9,6 +9,7 @@ import sys
 import threading
 from threading import Thread
 import time
+from typing import TextIO
 
 import cv2
 import numpy as np
@@ -45,7 +46,7 @@ class RateCounter:
     """Track and render the processing rate of the OCR loop."""
 
     def __init__(self) -> None:
-        self.start_time = None
+        self.start_time: float | None = None
         self.iterations: int = 0
 
     def start(self) -> RateCounter:
@@ -56,6 +57,8 @@ class RateCounter:
         self.iterations += 1
 
     def rate(self) -> float:
+        if self.start_time is None:
+            return 0.0
         elapsed_time = time.perf_counter() - self.start_time
         return self.iterations / elapsed_time
 
@@ -127,8 +130,8 @@ class OcrRegionSelection:
     """Manage the user-selected crop region used for OCR."""
 
     def __init__(self, video_stream: VideoStream) -> None:
-        self.selection = None
-        self.drag_start = None
+        self.selection: tuple[int, int, int, int] | None = None
+        self.drag_start: tuple[int, int] | None = None
         self.is_selecting = False
         self.stream = video_stream
 
@@ -140,8 +143,16 @@ class OcrRegionSelection:
         cv2.setMouseCallback(WINDOW_NAME, self.draw_rectangle)
 
     # Method to track mouse events
-    def draw_rectangle(self, event: int, x: int, y: int) -> None:
-        x, y = np.int16([x, y])
+    def draw_rectangle(
+        self,
+        event: int,
+        x: int,
+        y: int,
+        _flags: int,
+        _parameter: object | None,
+    ) -> None:
+        x = int(np.int16(x))
+        y = int(np.int16(y))
 
         if event == cv2.EVENT_LBUTTONDOWN:
             # Start selection
@@ -150,6 +161,7 @@ class OcrRegionSelection:
                 self.is_selecting = True
             # Confirm selection
             else:
+                assert self.drag_start is not None
                 x_start, y_start = self.drag_start
                 self.selection = (x_start, y_start, x, y)
                 self.is_selecting = False
@@ -200,6 +212,7 @@ class OcrRegionSelection:
         return self.selection is not None
 
     def get_cropped_frame(self, frame: np.ndarray) -> np.ndarray:
+        assert self.selection is not None
         return frame[
             self.selection[1] : self.selection[3],
             self.selection[0] : self.selection[2],
@@ -218,7 +231,7 @@ class OCR:
         self.stopped: bool = False
         self.region_selection = region_selection
         self.video_stream = video_stream
-        self.file = None
+        self.file: TextIO | None = None
 
     def start(self) -> OCR:
         Thread(target=self.do_ocr, args=()).start()
@@ -267,7 +280,8 @@ class OCR:
         self.file.flush()
 
     def stop_process(self) -> None:
-        self.file.close()
+        if self.file is not None:
+            self.file.close()
         self.stopped = True
 
     def render(self, frame: np.ndarray) -> np.ndarray:

--- a/utils/measure/measure/powermeter/ocr.py
+++ b/utils/measure/measure/powermeter/ocr.py
@@ -22,10 +22,8 @@ class OcrPowerMeter(PowerMeter):
             raise UnsupportedFeatureError("Voltage measurement are not supported for OCR mode.")
 
         last_line = self.read_last_line()
-        (timestamp, power) = last_line.strip().split(";")
-        power = float(power)
-        timestamp = float(timestamp)
-        return PowerMeasurementResult(power=power, updated=timestamp)
+        timestamp_value, power_value = last_line.strip().split(";")
+        return PowerMeasurementResult(power=float(power_value), updated=float(timestamp_value))
 
     def read_last_line(self) -> str:
         try:

--- a/utils/measure/measure/runner/charging.py
+++ b/utils/measure/measure/runner/charging.py
@@ -132,7 +132,7 @@ class ChargingRunner(MeasurementRunner[ChargingMeasurementRequest]):
         if wait_message_printed:
             self.interaction.notify("Charging device started charging, starting measurements")
 
-    def _build_model_json_data(self, measurements: dict[int, list[float]]) -> dict:
+    def _build_model_json_data(self, measurements: dict[int, list[float]]) -> dict[str, object]:
         """Build the model JSON data from the measurements"""
         if self.charging_device_type is None:
             raise RuntimeError("Charging runner is not configured")

--- a/utils/measure/measure/runner/fan.py
+++ b/utils/measure/measure/runner/fan.py
@@ -57,7 +57,7 @@ class FanRunner(MeasurementRunner[FanMeasurementRequest]):
         return (20 - completed_steps) * (SLEEP_TIME_PERCENTAGE_CHANGE + MEASURE_DURATION_PER_STEP)
 
     @staticmethod
-    def _build_model_json_data(measurements: dict) -> dict:
+    def _build_model_json_data(measurements: dict[int, float]) -> dict[str, object]:
         calibrate_list = [f"{percentage} -> {power:.2f}" for percentage, power in measurements.items()]
 
         return {

--- a/utils/measure/measure/runner/speaker.py
+++ b/utils/measure/measure/runner/speaker.py
@@ -102,7 +102,7 @@ class SpeakerRunner(MeasurementRunner[SpeakerMeasurementRequest]):
         )
 
     @staticmethod
-    def _build_model_json_data(summary: dict) -> dict:
+    def _build_model_json_data(summary: dict[int, float]) -> dict[str, object]:
         calibrate_list = [f"{volume} -> {summary[volume]}" for volume in summary]
 
         return {

--- a/utils/measure/tests/test_config.py
+++ b/utils/measure/tests/test_config.py
@@ -51,6 +51,12 @@ def test_cli_environment_preserves_value_normalization(monkeypatch: pytest.Monke
     assert config.selected_measure_type == MeasureType.AVERAGE
 
 
+def test_cli_environment_preserves_named_log_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+    assert CliEnvironment().log_level == "DEBUG"
+
+
 @pytest.mark.parametrize("name", _ENV_BACKED_LIMIT_FIELDS)
 def test_cli_environment_clamps_env_values_to_parameter_limits(
     name: str,


### PR DESCRIPTION
## Summary

- run strict mypy against the complete Measure package instead of a hand-maintained file list
- add typed boundaries around the untyped CLI environment configuration library
- make OCR state and OpenCV callbacks type-safe
- tighten runner result and Shelly discovery collection types

## Validation

- `uv run --extra dev --extra cli ruff check measure tests prepare_app_release.py`
- `MYPYPATH=. uv run --extra dev --extra cli mypy --strict --explicit-package-bases --follow-imports=silent --ignore-missing-imports --config-file ../../pyproject.toml prepare_app_release.py measure` (102 source files)
- `uv run --extra dev --extra cli pytest -q` (376 passed)
- pre-commit hooks
