### PR TITLE
Load Measure entity selectors from one snapshot

### DIFF
--- a/utils/measure/frontend/src/api-client.test.ts
+++ b/utils/measure/frontend/src/api-client.test.ts
@@ -74,6 +74,23 @@ describe("MeasureApiClient", () => {
     expect(powers).toEqual([{ entity_id: "light.desk", name: "Desk" }]);
   });
 
+  it("loads the entity catalog with one request", async () => {
+    const catalog = {
+      lights: [{ entity_id: "light.desk", name: "Desk" }],
+      powers: [{ entity_id: "sensor.plug_power", name: "Plug power" }],
+      voltages: [{ entity_id: "sensor.plug_voltage", name: "Plug voltage" }],
+    };
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(catalog));
+    const client = new MeasureApiClient(fetcher, "http://ha.local/prefix/");
+
+    await expect(client.getEntityCatalog()).resolves.toEqual(catalog);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(
+      new URL("http://ha.local/prefix/api/entity-catalog"),
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+  });
+
   it("discovers Shelly power meters below the ingress prefix", async () => {
     const discovery = { available: true, message: null, devices: [] };
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(discovery));

--- a/utils/measure/frontend/src/api-client.ts
+++ b/utils/measure/frontend/src/api-client.ts
@@ -4,6 +4,7 @@ import type {
   Capabilities,
   DeviceClass,
   DummyLoadCalibration,
+  EntityCatalog,
   EntityDescriptor,
   MeasurementRequest,
   MeasureDefinition,
@@ -64,6 +65,10 @@ export class MeasureApiClient {
 
   getShellyDevices(): Promise<ShellyDiscoveryResponse> {
     return this.request("api/power-meters/shelly");
+  }
+
+  getEntityCatalog(): Promise<EntityCatalog> {
+    return this.request<EntityCatalog>("api/entity-catalog");
   }
 
   getEntitiesByDomain(domain: string): Promise<EntityDescriptor[]> {

--- a/utils/measure/frontend/src/app-controller.test.ts
+++ b/utils/measure/frontend/src/app-controller.test.ts
@@ -48,6 +48,7 @@ function api(overrides: Partial<MeasureAppApi> = {}): MeasureAppApi {
       messages: [],
     }),
     getShellyDevices: async () => ({ available: true, message: null, devices: [] }),
+    getEntityCatalog: async () => ({ lights: [], powers: [], voltages: [] }),
     getEntitiesByDomain: async () => [],
     getEntitiesByDeviceClass: async () => [],
     getDummyLoadCalibration: async () => null,
@@ -132,8 +133,18 @@ describe("measure app controller", () => {
 
   it("boots core data and lazily fetches entities for the selected measurement", async () => {
     const requestedDomains: string[] = [];
+    let catalogCalls = 0;
+    let deviceClassCalls = 0;
     const appState = state();
     const appApi = api({
+      getEntityCatalog: async () => {
+        catalogCalls += 1;
+        return {
+          lights: [{ entity_id: "light.desk", name: "Desk" }],
+          powers: [{ entity_id: "sensor.plug_power", name: "Plug power" }],
+          voltages: [{ entity_id: "sensor.plug_voltage", name: "Plug voltage" }],
+        };
+      },
       getMeasureDefinitions: async () => [{
         measure_type: "fan", label: "Fan", description: "Measure fan power.", supports_profile: true, supports_resume: false,
         fields: [{ name: "fan_entity_id", label: "Fan", control: "entity", required: true, entity_domains: ["fan"], options: [] }],
@@ -142,17 +153,26 @@ describe("measure app controller", () => {
         requestedDomains.push(domain);
         return [{ entity_id: "fan.bedroom", name: "Bedroom fan" }];
       },
+      getEntitiesByDeviceClass: async () => {
+        deviceClassCalls += 1;
+        return [];
+      },
     });
     const controller = new MeasureAppController(appState, () => appApi, () => connection(), () => undefined);
 
     await controller.boot();
     expect(appState.view).toBe("setup");
-    expect(requestedDomains).toEqual(["light"]);
+    expect(catalogCalls).toBe(1);
+    expect(appState.lights[0]?.entity_id).toBe("light.desk");
+    expect(appState.powers[0]?.entity_id).toBe("sensor.plug_power");
+    expect(appState.voltages[0]?.entity_id).toBe("sensor.plug_voltage");
+    expect(requestedDomains).toEqual([]);
+    expect(deviceClassCalls).toBe(0);
 
     controller.selectMeasureType("fan");
     expect(appState.selectedMeasureType).toBe("fan");
     await vi.waitFor(() => expect(appState.deviceEntities.fan?.[0]?.entity_id).toBe("fan.bedroom"));
-    expect(requestedDomains).toEqual(["light", "fan"]);
+    expect(requestedDomains).toEqual(["fan"]);
   });
 
   it("retains entity discovery errors and updates session state from the event port", async () => {

--- a/utils/measure/frontend/src/app-controller.ts
+++ b/utils/measure/frontend/src/app-controller.ts
@@ -5,6 +5,7 @@ import type {
   Capabilities,
   DeviceClass,
   DummyLoadCalibration,
+  EntityCatalog,
   EntityDescriptor,
   MeasureDefinition,
   MeasureType,
@@ -60,6 +61,7 @@ export interface MeasureAppApi {
   saveSettings(settings: AppSettings): Promise<AppSettings>;
   testPowerMeter(settings: AppSettings): Promise<PowerMeterDiagnostic>;
   getShellyDevices(): Promise<ShellyDiscoveryResponse>;
+  getEntityCatalog(): Promise<EntityCatalog>;
   getEntitiesByDomain(domain: string): Promise<EntityDescriptor[]>;
   getEntitiesByDeviceClass(deviceClass: DeviceClass): Promise<EntityDescriptor[]>;
   getDummyLoadCalibration(): Promise<DummyLoadCalibration | null>;
@@ -116,23 +118,20 @@ export class MeasureAppController {
         throw error;
       });
       const calibrationPromise = this.refreshDummyLoadCalibration();
-      [
-        this.state.capabilities,
-        this.state.lights,
-        this.state.powers,
-        this.state.voltages,
-        this.state.settings,
-        this.state.snapshot,
-        this.state.definitions,
-      ] = await Promise.all([
+      const [capabilities, entities, settings, snapshot, definitions] = await Promise.all([
         api.getCapabilities(),
-        api.getEntitiesByDomain("light"),
-        api.getEntitiesByDeviceClass("power"),
-        api.getEntitiesByDeviceClass("voltage"),
+        api.getEntityCatalog(),
         api.getSettings(),
         currentPromise,
         api.getMeasureDefinitions(),
       ]);
+      this.state.capabilities = capabilities;
+      this.state.lights = entities.lights;
+      this.state.powers = entities.powers;
+      this.state.voltages = entities.voltages;
+      this.state.settings = settings;
+      this.state.snapshot = snapshot;
+      this.state.definitions = definitions;
       await calibrationPromise;
       this.state.request = this.state.snapshot.request;
       if (this.state.request) await this.loadTypeEntities(this.state.request.measure_type);

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -1145,6 +1145,7 @@ describe("app shell device entities", () => {
     const element = new AppShell();
     (element as unknown as { api: unknown }).api = {
       getCapabilities: async () => capabilities,
+      getEntityCatalog: async () => ({ lights: [], powers: [], voltages: [] }),
       getEntitiesByDeviceClass: async () => [],
       getSettings: async () => defaultSettings,
       getDummyLoadCalibration: async () => null,
@@ -1158,17 +1159,18 @@ describe("app shell device entities", () => {
 
     await (element as unknown as { boot: () => Promise<void> }).boot();
 
-    expect(requestedDomains).toEqual(["light"]);
+    expect(requestedDomains).toEqual([]);
     (element as unknown as { measureTypeSelected: (event: CustomEvent<"fan">) => void })
       .measureTypeSelected(new CustomEvent("measure-type-selected", { detail: "fan" }));
     await vi.waitFor(() => expect(element.deviceEntities.fan).toEqual([{ entity_id: "fan.bedroom", name: "Bedroom fan" }]));
-    expect(requestedDomains).toEqual(["light", "fan"]);
+    expect(requestedDomains).toEqual(["fan"]);
   });
 
   it("restores a generic request into the generic setup flow", async () => {
     const element = new AppShell();
     (element as unknown as { api: unknown }).api = {
       getCapabilities: async () => capabilities,
+      getEntityCatalog: async () => ({ lights: [], powers: [], voltages: [] }),
       getEntitiesByDeviceClass: async () => [],
       getSettings: async () => defaultSettings,
       getDummyLoadCalibration: async () => null,

--- a/utils/measure/frontend/src/types.ts
+++ b/utils/measure/frontend/src/types.ts
@@ -31,6 +31,12 @@ export interface EntityDescriptor {
   related_voltage_entity_id?: string;
 }
 
+export interface EntityCatalog {
+  lights: EntityDescriptor[];
+  powers: EntityDescriptor[];
+  voltages: EntityDescriptor[];
+}
+
 export interface MeasurementParameters {
   sleep_time: number;
   sample_count: number;

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -72,6 +72,12 @@ class PreflightResponse(BaseModel):
     power_meter_diagnostic: PowerMeterDiagnostic | None = None
 
 
+class EntityCatalogResponse(BaseModel):
+    lights: list[EntityDescriptor]
+    powers: list[EntityDescriptor]
+    voltages: list[EntityDescriptor]
+
+
 class SessionFile(BaseModel):
     name: str
     size: int
@@ -294,6 +300,17 @@ def _register_measurement_routes(router: APIRouter) -> None:  # noqa: C901
     @router.get("/dummy-load/calibration")
     async def dummy_load_calibration(request: Request) -> DummyLoadCalibration | None:
         return await run_in_threadpool(_matching_dummy_load_calibration, _context(request))
+
+    @router.get("/entity-catalog")
+    async def entity_catalog(request: Request) -> EntityCatalogResponse:
+        snapshot = await run_in_threadpool(
+            HomeAssistantEntityCatalog(_context(request).home_assistant).load_snapshot,
+        )
+        return EntityCatalogResponse(
+            lights=snapshot.select(domain=EntityDomain.LIGHT),
+            powers=snapshot.select(device_class=DeviceClass.POWER),
+            voltages=snapshot.select(device_class=DeviceClass.VOLTAGE),
+        )
 
     @router.get("/entities", responses={400: _ERROR})
     async def entities(

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -35,6 +35,7 @@ def entity(entity_id: str, state: str, **attributes: Any) -> SimpleNamespace:  #
 class FakeClient:
     def __init__(self) -> None:
         self.state_calls = 0
+        self.entity_data_calls = 0
 
     def close(self) -> None:
         return None
@@ -120,6 +121,7 @@ class FakeClient:
         }
 
     def get_entity_data(self) -> HomeAssistantEntityData:
+        self.entity_data_calls += 1
         return HomeAssistantEntityData(
             entities=self.get_entities(),  # type: ignore[arg-type]
             entity_registry=self.list_entity_registry(),  # type: ignore[arg-type]
@@ -264,6 +266,22 @@ def test_capabilities_and_entity_filters(tmp_path: Path) -> None:
         response = test_client.get(f"/api/entities?domain={domain}")
         assert response.status_code == 200, domain
         assert [item["entity_id"] for item in response.json()] == [expected]
+
+
+def test_entity_catalog_categorizes_one_fresh_snapshot(tmp_path: Path) -> None:
+    test_client = client(tmp_path)
+    home_assistant = test_client.app.state.context.home_assistant
+
+    response = test_client.get("/api/entity-catalog")
+
+    assert response.status_code == 200
+    assert home_assistant.entity_data_calls == 1
+    assert [item["entity_id"] for item in response.json()["lights"]] == ["light.test"]
+    assert [item["entity_id"] for item in response.json()["powers"]] == ["sensor.test_power"]
+    assert [item["entity_id"] for item in response.json()["voltages"]] == ["sensor.test_voltage"]
+
+    assert test_client.get("/api/entity-catalog").status_code == 200
+    assert home_assistant.entity_data_calls == 2
 
 
 def test_dummy_load_calibration_is_returned_only_for_the_configured_meter(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- load the startup light, power, and voltage selectors from one fresh Home Assistant entity snapshot
- retain the existing entity endpoint for lazy measurement-specific selectors
- avoid server-side caching so every catalog request reflects current Home Assistant state

## Validation

- `uv run --extra dev --extra cli ruff check measure tests prepare_app_release.py`
- `uv run --extra dev --extra cli pytest -q` (376 passed)
- `npm test -- --run` (92 passed)
- `npm run typecheck`
- `npm run build`
- pre-commit hooks
