### PR TITLE
Probe power meters once during preflight

### DIFF
--- a/utils/measure/frontend/src/types.ts
+++ b/utils/measure/frontend/src/types.ts
@@ -279,6 +279,7 @@ export type DiagnosticStatus = "good" | "warning" | "poor" | "unsupported";
 export interface PowerMeterDiagnostic {
   success: boolean;
   power?: number | null;
+  supports_voltage?: boolean | null;
   status: DiagnosticStatus;
   precision_decimals?: number | null;
   max_report_interval_seconds?: number | null;

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -555,7 +555,6 @@ def _preflight(context: AppContext, payload: MeasurementRequest) -> PreflightRes
             verify_storage=context.storage.verify_writable,
             load_entities=load_entities,
             diagnose_power_meter=context.power_meter_diagnostics.evaluate,
-            supports_voltage=lambda spec: context.build_power_meter(spec).has_voltage_support(),
             developer_mode=context.developer_mode,
         ).validate(payload)
     except ActiveSessionError as error:

--- a/utils/measure/measure/ha_app/preflight.py
+++ b/utils/measure/measure/ha_app/preflight.py
@@ -68,14 +68,12 @@ class MeasurementPreflight:
         verify_storage: Callable[[], None],
         load_entities: EntityLoader,
         diagnose_power_meter: Callable[[PowerMeterSpec], PowerMeterDiagnostic] | None = None,
-        supports_voltage: Callable[[PowerMeterSpec], bool] | None = None,
         developer_mode: bool = False,
     ) -> None:
         self._has_active_session = has_active_session
         self._verify_storage = verify_storage
         self._load_entities = load_entities
         self._diagnose_power_meter = diagnose_power_meter
-        self._supports_voltage = supports_voltage
         self._developer_mode = developer_mode
 
     def validate(self, request: MeasurementRequest) -> PreflightResult:
@@ -90,6 +88,10 @@ class MeasurementPreflight:
             raise PreflightError("Persistent app storage is not writable") from error
 
         self._validate_power_meter(request)
+        diagnostic: PowerMeterDiagnostic | None = None
+        if request.dummy_load is not None and self._diagnose_power_meter is not None:
+            diagnostic = self._diagnose_power_meter(request.power_meter)
+            self._validate_dummy_load_voltage(diagnostic)
 
         if isinstance(request, LightMeasurementRequest):
             result = self._validate_light(request)
@@ -105,9 +107,9 @@ class MeasurementPreflight:
             )
             duration = (duration or 0) + DUMMY_LOAD_MEASUREMENT_COUNT * DUMMY_LOAD_MEASUREMENTS_DURATION
 
-        diagnostic: PowerMeterDiagnostic | None = None
         if self._diagnose_power_meter is not None:
-            diagnostic = self._diagnose_power_meter(request.power_meter)
+            if diagnostic is None:
+                diagnostic = self._diagnose_power_meter(request.power_meter)
             if not diagnostic.success:
                 raise PreflightError(diagnostic.message or "Could not read from the power meter")
             if diagnostic.status in {DiagnosticStatus.WARNING, DiagnosticStatus.POOR}:
@@ -167,9 +169,19 @@ class MeasurementPreflight:
             voltages = {entity.entity_id for entity in self._load_entities(None, DeviceClass.VOLTAGE)}
             if request.power_meter.voltage_entity_id not in voltages:
                 raise PreflightError("Selected voltage entity is unavailable or not measured in V")
-        if self._supports_voltage is not None and not self._supports_voltage(request.power_meter):
+
+    @staticmethod
+    def _validate_dummy_load_voltage(diagnostic: PowerMeterDiagnostic) -> None:
+        if diagnostic.supports_voltage is False:
             raise PreflightError(
                 "The selected power meter does not support voltage measurements required for dummy loads",
+            )
+        if diagnostic.supports_voltage is None:
+            if not diagnostic.success:
+                raise PreflightError(diagnostic.message or "Could not read from the power meter")
+            raise PreflightError(
+                "Could not determine whether the selected power meter supports voltage measurements "
+                "required for dummy loads",
             )
 
     def _validate_controller(self, request: MeasurementRequest) -> None:

--- a/utils/measure/measure/powermeter/diagnostics.py
+++ b/utils/measure/measure/powermeter/diagnostics.py
@@ -29,6 +29,7 @@ class PowerMeterDiagnostic(BaseModel):
 
     success: bool
     power: float | None = None
+    supports_voltage: bool | None = None
     status: DiagnosticStatus
     precision_decimals: int | None = None
     max_report_interval_seconds: float | None = None
@@ -72,6 +73,7 @@ class PowerMeterDiagnostics:
         if isinstance(spec, DummyPowerMeterSpec):
             return PowerMeterDiagnostic(
                 success=True,
+                supports_voltage=True,
                 status=DiagnosticStatus.UNSUPPORTED,
                 precision_status=DiagnosticStatus.UNSUPPORTED,
                 update_interval_status=DiagnosticStatus.UNSUPPORTED,
@@ -92,20 +94,31 @@ class PowerMeterDiagnostics:
     def _evaluate_uncached(self, spec: PowerMeterSpec) -> PowerMeterDiagnostic:
         started = self._monotonic()
         samples: list[_ObservedSample] = []
+        supports_voltage: bool | None = None
         try:
             meter = self._build_power_meter(spec)
+            supports_voltage = meter.has_voltage_support()
             samples.append(_ObservedSample(meter.diagnostic_sample(), self._monotonic() - started))
             if not isinstance(spec, HassPowerMeterSpec):
-                return _summarize_direct(samples[0], duration=round(self._monotonic() - started, 1))
+                return _summarize_direct(
+                    samples[0],
+                    supports_voltage=supports_voltage,
+                    duration=round(self._monotonic() - started, 1),
+                )
             deadline = started + self._duration
             while (remaining := deadline - self._monotonic()) > 0:
                 self._wait(min(self._poll_interval, remaining))
                 samples.append(_ObservedSample(meter.diagnostic_sample(), self._monotonic() - started))
-            return _summarize(samples, duration=round(self._monotonic() - started, 1))
+            return _summarize(
+                samples,
+                supports_voltage=supports_voltage,
+                duration=round(self._monotonic() - started, 1),
+            )
         except Exception as error:  # noqa: BLE001 - diagnostics must surface adapter and parsing failures
             message = str(error) or "Could not read from the power meter"
             return PowerMeterDiagnostic(
                 success=False,
+                supports_voltage=supports_voltage,
                 status=DiagnosticStatus.POOR,
                 precision_status=DiagnosticStatus.UNSUPPORTED,
                 update_interval_status=DiagnosticStatus.UNSUPPORTED,
@@ -121,12 +134,18 @@ class _ObservedSample:
     observed_after: float
 
 
-def _summarize_direct(observation: _ObservedSample, *, duration: float) -> PowerMeterDiagnostic:
+def _summarize_direct(
+    observation: _ObservedSample,
+    *,
+    supports_voltage: bool,
+    duration: float,
+) -> PowerMeterDiagnostic:
     if not math.isfinite(observation.sample.power):
         raise ValueError("Power meter returned a non-finite reading")
     return PowerMeterDiagnostic(
         success=True,
         power=observation.sample.power,
+        supports_voltage=supports_voltage,
         status=DiagnosticStatus.GOOD,
         reports_observed=1,
         duration_seconds=duration,
@@ -136,7 +155,12 @@ def _summarize_direct(observation: _ObservedSample, *, duration: float) -> Power
     )
 
 
-def _summarize(samples: list[_ObservedSample], *, duration: float) -> PowerMeterDiagnostic:
+def _summarize(
+    samples: list[_ObservedSample],
+    *,
+    supports_voltage: bool,
+    duration: float,
+) -> PowerMeterDiagnostic:
     precision = min(_decimal_places(observation.sample.raw_value) for observation in samples)
     precision_status = DiagnosticStatus.GOOD if precision >= 1 else DiagnosticStatus.POOR
     update_status, max_interval, reports_observed = _report_cadence(samples, duration)
@@ -149,6 +173,7 @@ def _summarize(samples: list[_ObservedSample], *, duration: float) -> PowerMeter
     return PowerMeterDiagnostic(
         success=True,
         power=samples[-1].sample.power,
+        supports_voltage=supports_voltage,
         status=status,
         precision_decimals=precision,
         max_report_interval_seconds=round(max_interval, 2) if max_interval is not None else None,

--- a/utils/measure/tests/powermeter/test_diagnostics.py
+++ b/utils/measure/tests/powermeter/test_diagnostics.py
@@ -10,7 +10,7 @@ from measure.home_assistant import HomeAssistantManager
 from measure.powermeter.diagnostics import DiagnosticStatus, PowerMeterDiagnostics
 from measure.powermeter.hass import HassPowerMeter
 from measure.powermeter.powermeter import PowerMeasurementResult, PowerMeter, PowerMeterDiagnosticSample
-from measure.powermeter.spec import HassPowerMeterSpec, ShellyPowerMeterSpec
+from measure.powermeter.spec import DummyPowerMeterSpec, HassPowerMeterSpec, ShellyPowerMeterSpec
 import pytest
 
 
@@ -26,16 +26,19 @@ class FakeClock:
 
 
 class SampledPowerMeter(PowerMeter):
-    def __init__(self, sample: Callable[[int], PowerMeterDiagnosticSample]) -> None:
+    def __init__(self, sample: Callable[[int], PowerMeterDiagnosticSample], *, supports_voltage: bool = False) -> None:
         self._sample = sample
+        self._supports_voltage = supports_voltage
         self.calls = 0
+        self.voltage_support_calls = 0
 
     def get_power(self, include_voltage: bool = False) -> PowerMeasurementResult:
         sample = self.diagnostic_sample()
         return PowerMeasurementResult(power=sample.power, updated=sample.reported_at)
 
     def has_voltage_support(self) -> bool:
-        return False
+        self.voltage_support_calls += 1
+        return self._supports_voltage
 
     def diagnostic_sample(self) -> PowerMeterDiagnosticSample:
         sample = self._sample(self.calls)
@@ -156,6 +159,63 @@ def test_diagnostics_reuses_recent_result_unless_forced() -> None:
     assert second is first
     assert forced is not first
     assert meter.calls == 6
+
+
+@pytest.mark.parametrize(
+    ("spec", "supports_voltage"),
+    [
+        (HassPowerMeterSpec(entity_id="sensor.power"), True),
+        (ShellyPowerMeterSpec(device_ip="192.0.2.1"), False),
+    ],
+)
+def test_diagnostics_report_voltage_capability_from_the_probed_meter(
+    spec: HassPowerMeterSpec | ShellyPowerMeterSpec,
+    supports_voltage: bool,
+) -> None:
+    meter = SampledPowerMeter(
+        lambda _: PowerMeterDiagnosticSample(power=4.2, raw_value="4.2", reported_at=100),
+        supports_voltage=supports_voltage,
+    )
+    diagnostics = PowerMeterDiagnostics(lambda _: meter, duration=0)
+
+    result = diagnostics.evaluate(spec)
+
+    assert result.supports_voltage is supports_voltage
+    assert meter.voltage_support_calls == 1
+    assert meter.calls == 1
+
+
+def test_dummy_diagnostics_advertise_voltage_without_building_a_meter() -> None:
+    builder = MagicMock()
+
+    result = PowerMeterDiagnostics(builder).evaluate(DummyPowerMeterSpec())
+
+    assert result.supports_voltage is True
+    builder.assert_not_called()
+
+
+def test_diagnostics_retain_known_voltage_capability_when_sampling_fails() -> None:
+    def fail(_: int) -> PowerMeterDiagnosticSample:
+        raise RuntimeError("Could not read power")
+
+    meter = SampledPowerMeter(fail, supports_voltage=True)
+
+    result = PowerMeterDiagnostics(lambda _: meter, duration=0).evaluate(
+        ShellyPowerMeterSpec(device_ip="192.0.2.1"),
+    )
+
+    assert result.success is False
+    assert result.supports_voltage is True
+
+
+def test_diagnostics_leave_voltage_capability_unknown_when_building_fails() -> None:
+    def fail(_: object) -> PowerMeter:
+        raise RuntimeError("Could not connect")
+
+    result = PowerMeterDiagnostics(fail).evaluate(ShellyPowerMeterSpec(device_ip="192.0.2.1"))
+
+    assert result.success is False
+    assert result.supports_voltage is None
 
 
 def test_hass_diagnostic_sample_uses_raw_state_and_never_forces_an_update() -> None:

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import time
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 from measure.const import MeasureType
@@ -18,6 +18,7 @@ from measure.ha_app.session import SessionControl, SessionSnapshot, SessionState
 from measure.ha_app.storage import SessionStorage
 from measure.home_assistant import HomeAssistantEntityData, HomeAssistantManager
 from measure.powermeter.diagnostics import PowerMeterDiagnostics
+from measure.powermeter.powermeter import PowerMeter, PowerMeterDiagnosticSample
 from measure.powermeter.spec import HassPowerMeterSpec
 from measure.request import MeasurementRequest
 from measure.runner.runner import RunnerResult
@@ -340,6 +341,28 @@ def test_dummy_load_preflight_requires_voltage_and_includes_calibration_time(tmp
     assert "voltage sensor is required" in response.json()["message"]
 
 
+def test_shelly_dummy_load_preflight_builds_and_probes_the_meter_once(tmp_path: Path) -> None:
+    test_client = client(tmp_path)
+    context = test_client.app.state.context
+    meter = MagicMock(spec=PowerMeter)
+    meter.has_voltage_support.return_value = True
+    meter.diagnostic_sample.return_value = PowerMeterDiagnosticSample(power=4.2, raw_value="4.2", reported_at=100)
+    builder = MagicMock(return_value=meter)
+    context.power_meter_diagnostics = PowerMeterDiagnostics(builder, duration=0)
+    request = payload() | {
+        "power_meter": {"type": "shelly", "device_ip": "192.0.2.1"},
+        "dummy_load": {"mode": "calibrate", "description": "40 W incandescent bulb"},
+    }
+
+    with patch.object(context, "build_power_meter", builder):
+        response = test_client.post("/api/preflight", json=request)
+
+    assert response.status_code == 200
+    builder.assert_called_once()
+    meter.has_voltage_support.assert_called_once_with()
+    meter.diagnostic_sample.assert_called_once_with()
+
+
 def test_app_closes_home_assistant_manager_at_shutdown(tmp_path: Path) -> None:
     app = create_app(data_root=tmp_path, hass_token="test-token", trusted_ingress_only=False)  # noqa: S106
     home_assistant = MagicMock(spec=HomeAssistantManager)
@@ -358,6 +381,7 @@ def test_power_meter_test_endpoint(tmp_path: Path) -> None:
     assert dummy.status_code == 200
     assert dummy.json()["success"] is True
     assert dummy.json()["status"] == "unsupported"
+    assert dummy.json()["supports_voltage"] is True
 
     shelly = test_client.post("/api/settings/test-power-meter", json={"power_meter": "shelly", "shelly_ip": None})
     assert shelly.json()["success"] is False
@@ -375,6 +399,7 @@ def test_power_meter_test_endpoint(tmp_path: Path) -> None:
         json={"power_meter": "hass", "default_power_entity_id": "sensor.test_power"},
     )
     assert validated.json()["success"] is True
+    assert validated.json()["supports_voltage"] is False
     assert validated.json()["precision_decimals"] == 1
     assert validated.json()["update_interval_status"] == "poor"
 
@@ -430,8 +455,9 @@ def test_preflight_exposes_quality_warnings_and_start_reuses_diagnostics(tmp_pat
     assert response.json()["power_meter_diagnostic"]["precision_status"] == "good"
     assert response.json()["power_meter_diagnostic"]["update_interval_status"] == "poor"
     assert "did not report often enough" in response.json()["warnings"][0]
+    assert home_assistant.state_calls == 2
     assert test_client.post("/api/sessions", json=payload()).status_code == 201
-    assert home_assistant.state_calls == 1
+    assert home_assistant.state_calls == 2
 
 
 def test_preflight_rejects_unavailable_entity(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_preflight.py
+++ b/utils/measure/tests/test_preflight.py
@@ -9,6 +9,7 @@ from measure.controller.light.const import LutMode
 from measure.controller.light.spec import DummyLightControllerSpec, HassLightControllerSpec
 from measure.controller.media.spec import HassMediaControllerSpec
 from measure.ha_app.preflight import ActiveSessionError, EntityRecord, MeasurementPreflight, PreflightError
+from measure.powermeter.diagnostics import DiagnosticStatus, PowerMeterDiagnostic
 from measure.powermeter.spec import DummyPowerMeterSpec, HassPowerMeterSpec, ShellyPowerMeterSpec
 from measure.request import (
     AverageMeasurementRequest,
@@ -35,7 +36,7 @@ def preflight(
     *,
     active: bool = False,
     writable: bool = True,
-    voltage_supported: bool = True,
+    voltage_supported: bool | None = True,
     developer_mode: bool = True,
 ) -> MeasurementPreflight:
     def verify() -> None:
@@ -46,7 +47,14 @@ def preflight(
         has_active_session=lambda: active,
         verify_storage=verify,
         load_entities=lambda domain, device_class: entities.get((domain, device_class), []),
-        supports_voltage=lambda _: voltage_supported,
+        diagnose_power_meter=lambda _: PowerMeterDiagnostic(
+            success=voltage_supported is not None,
+            status=DiagnosticStatus.GOOD if voltage_supported is not None else DiagnosticStatus.POOR,
+            precision_status=DiagnosticStatus.UNSUPPORTED,
+            update_interval_status=DiagnosticStatus.UNSUPPORTED,
+            supports_voltage=voltage_supported,
+            message="Could not inspect voltage capability" if voltage_supported is None else None,
+        ),
         developer_mode=developer_mode,
     )
 
@@ -113,6 +121,42 @@ def test_preflight_rejects_power_meter_without_dummy_load_voltage_support() -> N
 
     checker = preflight(base_entities(), voltage_supported=False)
     with pytest.raises(PreflightError, match="does not support voltage"):
+        checker.validate(request)
+
+
+def test_preflight_reports_unknown_dummy_load_voltage_capability() -> None:
+    request = AverageMeasurementRequest(
+        power_meter=ShellyPowerMeterSpec(device_ip="192.168.1.50"),
+        dummy_load=DummyLoadCalibrationRequest(description="40 W incandescent bulb"),
+    )
+
+    with pytest.raises(PreflightError, match="Could not inspect voltage capability"):
+        preflight(base_entities(), voltage_supported=None).validate(request)
+
+
+def test_dummy_load_sampling_failure_does_not_mask_controller_validation() -> None:
+    diagnostic = PowerMeterDiagnostic(
+        success=False,
+        supports_voltage=True,
+        status=DiagnosticStatus.POOR,
+        precision_status=DiagnosticStatus.UNSUPPORTED,
+        update_interval_status=DiagnosticStatus.UNSUPPORTED,
+        message="Could not read power",
+    )
+    checker = MeasurementPreflight(
+        has_active_session=lambda: False,
+        verify_storage=lambda: None,
+        load_entities=lambda domain, device_class: base_entities().get((domain, device_class), []),
+        diagnose_power_meter=lambda _: diagnostic,
+        developer_mode=True,
+    )
+    request = SpeakerMeasurementRequest(
+        power_meter=ShellyPowerMeterSpec(device_ip="192.168.1.50"),
+        controller=HassMediaControllerSpec(entity_id="media_player.missing"),
+        dummy_load=DummyLoadCalibrationRequest(description="40 W incandescent bulb"),
+    )
+
+    with pytest.raises(PreflightError, match="media player"):
         checker.validate(request)
 
 


### PR DESCRIPTION
## Summary

- collect voltage capability and measurement-quality evidence from the same power-meter instance
- reuse the diagnostic result during dummy-load preflight instead of probing direct meters twice
- preserve existing validation order, diagnostics caching, and error messages
- expose voltage capability in the backend and frontend diagnostic contracts

## Validation

- full Measure Python suite (402 passed)
- frontend suite (95 passed)
- Ruff
- strict mypy on all touched production Python files
- frontend typecheck and production build
- pre-commit hooks
