### PR TITLE
Remove unused power meter extension hook

### DIFF
--- a/utils/measure/measure/assembler.py
+++ b/utils/measure/measure/assembler.py
@@ -88,14 +88,12 @@ class MeasurementAssembler:
         *,
         home_assistant: HomeAssistantManager | None = None,
         tuya_device_key: str | None = None,
-        power_meter_decorator: Callable[[PowerMeter], PowerMeter] | None = None,
         on_sample: Callable[[float], None] | None = None,
         dummy_load_calibration_store: DummyLoadCalibrationStore | None = None,
     ) -> None:
         self._interaction = interaction
         self._home_assistant_manager = home_assistant
         self._tuya_device_key = tuya_device_key
-        self._power_meter_decorator = power_meter_decorator
         self._on_sample = on_sample
         self._dummy_load_calibration_store = dummy_load_calibration_store
 
@@ -103,8 +101,6 @@ class MeasurementAssembler:
         """Resolve a request once into a transport-independent runner graph."""
 
         power_meter = self.build_power_meter(request.power_meter)
-        if self._power_meter_decorator is not None:
-            power_meter = self._power_meter_decorator(power_meter)
         voltage_enabled = power_meter.has_voltage_support()
         parameters = request.parameters
         measure_util = MeasureUtil(

--- a/utils/measure/tests/test_assembler.py
+++ b/utils/measure/tests/test_assembler.py
@@ -25,13 +25,11 @@ def _assembler(
     *,
     home_assistant: HomeAssistantManager | None = None,
     tuya_device_key: str | None = None,
-    power_meter_decorator: MagicMock | None = None,
 ) -> MeasurementAssembler:
     return MeasurementAssembler(
         MagicMock(spec=RunInteraction),
         home_assistant=home_assistant,
         tuya_device_key=tuya_device_key,
-        power_meter_decorator=power_meter_decorator,
     )
 
 
@@ -115,15 +113,6 @@ def test_assembler_reads_tuya_key_from_cli_config_dependency() -> None:
         _assembler(tuya_device_key="device-key").assemble(request)
 
     power_meter.assert_called_once_with("device-id", "192.0.2.20", "device-key", "3.4")
-
-
-def test_assembler_applies_power_meter_decorator() -> None:
-    request = AverageMeasurementRequest(power_meter=DummyPowerMeterSpec())
-    decorator = MagicMock(side_effect=lambda meter: meter)
-
-    _assembler(power_meter_decorator=decorator).assemble(request)
-
-    decorator.assert_called_once()
 
 
 def test_assembler_rejects_a_controller_for_the_wrong_measurement_type() -> None:


### PR DESCRIPTION
## Summary

- remove the unused `power_meter_decorator` argument from the Measure composition root
- delete the self-referential test that was the only consumer
- reduce assembler state and extension surface without changing runtime behavior

## Validation

- full Measure Python suite (397 passed)
- Ruff
- strict mypy on `measure/assembler.py`
- pre-commit hooks
