### PR TITLE
Report the Measure app runtime version

### DIFF
--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -46,6 +46,7 @@ from measure.powermeter.powermeter import PowerMeter
 from measure.powermeter.spec import DummyPowerMeterSpec, HassPowerMeterSpec, PowerMeterSpec, ShellyPowerMeterSpec
 from measure.request import MeasurementRequest
 from measure.tuning import MeasurementParameters
+from measure.version import measure_version
 from measure.visualization import PlotSpec, build_session_plots
 
 _LOGGER = logging.getLogger("measure")
@@ -184,7 +185,13 @@ def create_app(
         trusted_ingress_only=trusted_ingress_only,
         developer_mode=developer_mode,
     )
-    app = FastAPI(title="Powercalc Measure", version="0.1.0", docs_url=None, redoc_url=None, lifespan=_lifespan)
+    app = FastAPI(
+        title="Powercalc Measure",
+        version=measure_version(),
+        docs_url=None,
+        redoc_url=None,
+        lifespan=_lifespan,
+    )
     app.state.context = context
     app.include_router(_router())
 

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -22,6 +22,7 @@ from measure.powermeter.spec import HassPowerMeterSpec
 from measure.request import MeasurementRequest
 from measure.runner.runner import RunnerResult
 from measure.tuning import MeasurementParameters
+from measure.version import measure_version
 import pytest
 
 
@@ -212,6 +213,13 @@ def client(tmp_path: Path, *, trusted_ingress_only: bool = False, developer_mode
     )
     app.state.context.coordinator = MeasurementCoordinator(SessionStorage(tmp_path), CompletingService)
     return TestClient(app)
+
+
+def test_app_metadata_uses_the_runtime_measure_version(tmp_path: Path) -> None:
+    test_client = client(tmp_path)
+
+    assert test_client.app.version == measure_version()
+    assert test_client.get("/openapi.json").json()["info"]["version"] == measure_version()
 
 
 def test_capabilities_and_entity_filters(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- use the runtime `.VERSION` value for FastAPI and OpenAPI metadata
- report `master` during development and `vX.Y.Z:app` in released app images
- keep API metadata aligned with generated model and diagnostics versions

## Validation

- full Measure Python suite (398 passed)
- Ruff
- strict mypy on `measure/ha_app/api.py`
- pre-commit hooks
