### PR TITLE
Remove the legacy OCR launcher

### DIFF
--- a/utils/measure/measure/ocr/requirements.txt
+++ b/utils/measure/measure/ocr/requirements.txt
@@ -1,5 +1,0 @@
-# Keep standalone OCR environments aligned with the optional project extra.
-numpy>=2.4
-opencv-python-headless>=4.7
-Pillow>=12.0
-pytesseract>=0.3

--- a/utils/measure/measure/ocr/run.sh
+++ b/utils/measure/measure/ocr/run.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-xhost +local:docker
-docker run --rm --name=measure --env-file=../.env -v "$(pwd)/export:/app/export" -v "$(pwd)/.persistent:/app/.persistent" -e DISPLAY=192.168.178.195:0 -v /tmp/.X11-unix:/tmp/.X11-unix -it measure_ocr python3 ocr/main.py -t /usr/bin/tesseract -s rtp://@127.0.0.1:9988
-xhost -local:docker


### PR DESCRIPTION
## Summary

- remove the hardcoded X11/Docker OCR launcher
- remove the duplicate OCR requirements file
- remove the empty nested OCR README
- keep the documented `uv --extra ocr` setup as the single supported installation path

## Validation

- repository search confirms no remaining references to the deleted files
- full Measure Python suite (397 passed)
- Ruff
- pre-commit hooks
