### PR TITLE
Block Measure releases with stale notes

### DIFF
--- a/.github/scripts/release_draft/tests/test_measure_draft.py
+++ b/.github/scripts/release_draft/tests/test_measure_draft.py
@@ -10,9 +10,16 @@ import update_measure_draft as entry
 
 
 class FakeClient:
-    def __init__(self, releases: list[dict[str, Any]], pull_requests: list[dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        releases: list[dict[str, Any]],
+        pull_requests: list[dict[str, Any]],
+        *,
+        missing_refs: set[str] | None = None,
+    ) -> None:
         self._releases = releases
         self._pull_requests = pull_requests
+        self._missing_refs = missing_refs or set()
         self.created: list[dict[str, Any]] = []
         self.updated: list[tuple[int, dict[str, Any]]] = []
         self.deleted: list[int] = []
@@ -22,6 +29,8 @@ class FakeClient:
         return self._releases
 
     def commit_sha(self, ref: str) -> str:
+        if ref in self._missing_refs:
+            raise ValueError(f"Unknown ref {ref}")
         return f"sha-of-{ref}"
 
     def commit_shas_since(self, base_sha: str | None, head_ref: str) -> list[str]:
@@ -56,11 +65,11 @@ def release(*, body: str = "", release_id: int = 1) -> dict[str, Any]:
     }
 
 
-def pull_request(number: int, title: str) -> dict[str, Any]:
+def pull_request(number: int, title: str, *, labels: tuple[str, ...] = ()) -> dict[str, Any]:
     return {
         "number": number,
         "title": title,
-        "labels": [],
+        "labels": [{"name": label} for label in labels],
         "user": {"login": "octocat"},
     }
 
@@ -74,7 +83,7 @@ def run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, client: FakeClient) -> 
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
     monkeypatch.setenv("HEAD_REF", "master")
     monkeypatch.delenv("COMMIT_SHAS", raising=False)
-    entry.main()
+    entry.main([])
     return client
 
 
@@ -111,3 +120,173 @@ def test_removes_stale_draft_when_tag_has_no_new_measure_prs(
     assert client.deleted == [77]
     assert not client.created
     assert not client.updated
+
+
+def test_release_verification_accepts_exact_changelog_notes() -> None:
+    client = FakeClient([], [pull_request(10, "feat: Add measurement mode")])
+    changelog = """# Changelog
+
+## Unreleased
+
+## 0.1.0 - 2026-07-18
+
+### 🚀 Features
+
+- #10 feat: Add measurement mode @octocat
+
+## 0.0.1 - 2026-07-17
+
+- Initial release.
+"""
+
+    entry.verify_release(client, changelog, "0.1.0", head_ref="master")
+
+    assert client.history_requests == [("sha-of-measure-v0.0.1", "master")]
+
+
+def test_release_verification_reports_intervening_missing_pull_request() -> None:
+    client = FakeClient(
+        [],
+        [
+            pull_request(10, "feat: Add measurement mode"),
+            pull_request(11, "fix: Keep release notes complete"),
+        ],
+    )
+    changelog = """# Changelog
+
+## Unreleased
+
+## 0.1.0 - 2026-07-18
+
+### 🚀 Features
+
+- #10 feat: Add measurement mode @octocat
+
+## 0.0.1 - 2026-07-17
+
+- Initial release.
+"""
+
+    with pytest.raises(entry.ReleaseDraftDriftError) as error:
+        entry.verify_release(client, changelog, "0.1.0", head_ref="master")
+
+    assert "out of date" in str(error.value)
+    assert "#11 fix: Keep release notes complete" in str(error.value)
+
+
+def test_release_verification_ignores_excluded_pull_requests() -> None:
+    client = FakeClient(
+        [],
+        [
+            pull_request(10, "feat: Add measurement mode"),
+            pull_request(11, "chore: Prepare release", labels=("measure-tool", "skip-changelog")),
+            pull_request(12, "chore: Update dependencies", labels=("dependencies",)),
+        ],
+    )
+    changelog = """# Changelog
+
+## Unreleased
+
+## 0.1.0 - 2026-07-18
+
+### 🚀 Features
+
+- #10 feat: Add measurement mode @octocat
+
+## 0.0.1 - 2026-07-17
+
+- Initial release.
+"""
+
+    entry.verify_release(client, changelog, "0.1.0", head_ref="master")
+
+
+def test_release_verification_accepts_explicit_previous_tag() -> None:
+    client = FakeClient([], [pull_request(10, "fix: Correct meter probing")])
+    changelog = """# Changelog
+
+## Unreleased
+
+## 0.1.0 - 2026-07-18
+
+### 🐛 Bug Fixes
+
+- #10 fix: Correct meter probing @octocat
+
+## 0.0.1 - 2026-07-17
+
+- Initial release.
+"""
+
+    entry.verify_release(
+        client,
+        changelog,
+        "0.1.0",
+        head_ref="release-commit",
+        previous_tag="measure-v0.0.0",
+    )
+
+    assert client.history_requests == [("sha-of-measure-v0.0.0", "release-commit")]
+
+
+@pytest.mark.parametrize(
+    ("changelog", "message"),
+    [
+        ("# Changelog\n\n## Unreleased\n", "no section for target version 0.1.0"),
+        (
+            "# Changelog\n\n## Unreleased\n\n## 0.1.0 - 2026-07-18\n\n- Change.\n",
+            "no previous Measure release after 0.1.0",
+        ),
+        (
+            "# Changelog\n\n## Unreleased\n\n## 0.1.0 - 2026-07-18\n\n- Change.\n\n## Notes\n",
+            "next changelog section after 0.1.0 is not a Measure version",
+        ),
+    ],
+)
+def test_release_verification_rejects_malformed_changelog_boundaries(changelog: str, message: str) -> None:
+    with pytest.raises(entry.ReleaseDraftDriftError, match=message):
+        entry.verify_release(FakeClient([], []), changelog, "0.1.0", head_ref="master")
+
+
+def test_release_verification_reports_missing_previous_tag() -> None:
+    changelog = """# Changelog
+
+## Unreleased
+
+## 0.1.0 - 2026-07-18
+
+- Change.
+
+## 0.0.1 - 2026-07-17
+
+- Initial release.
+"""
+    client = FakeClient([], [], missing_refs={"measure-v0.0.1"})
+
+    with pytest.raises(entry.ReleaseDraftDriftError, match=r"could not resolve previous tag measure-v0\.0\.1"):
+        entry.verify_release(client, changelog, "0.1.0", head_ref="master")
+
+
+def test_verify_cli_exits_nonzero_with_actionable_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n## Unreleased\n\n## 0.1.0 - 2026-07-18\n\n- Stale.\n\n"
+        "## 0.0.1 - 2026-07-17\n\n- Initial release.\n",
+        encoding="utf-8",
+    )
+    client = FakeClient([], [pull_request(10, "fix: Correct release notes")])
+    monkeypatch.setattr(entry, "GitHubClient", lambda *_args, **_kwargs: client)
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+    with pytest.raises(SystemExit, match="2"):
+        entry.main(["--verify", "0.1.0", "--changelog", str(changelog), "--head-ref", "master"])
+
+    error = capsys.readouterr().err
+    assert "out of date" in error
+    assert "Regenerate the release from the current rolling draft" in error
+    assert "#10 fix: Correct release notes" in error

--- a/.github/scripts/release_draft/update_measure_draft.py
+++ b/.github/scripts/release_draft/update_measure_draft.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Maintain the rolling Powercalc Measure draft release.
+Maintain the rolling Powercalc Measure draft and verify prepared release notes.
 
 Runs on every push to master. The draft is rebuilt from all merged Measure
 pull requests since the current ``measure-v*`` tag. Rebuilding makes retries,
@@ -27,6 +27,9 @@ Requires:
 
 from __future__ import annotations
 
+import argparse
+from collections.abc import Sequence
+import difflib
 import os
 from pathlib import Path
 import re
@@ -48,6 +51,8 @@ from github_client import GitHubClient
 DRAFT_TAG = "measure-next"
 DRAFT_TITLE_PATTERN = "Powercalc Measure v{version} (unreleased)"
 CONFIG_PATH = Path("utils/measure/home-assistant-app/powercalc_measure/config.yaml")
+CHANGELOG_PATH = Path("utils/measure/home-assistant-app/powercalc_measure/CHANGELOG.md")
+VERSION_PATTERN = r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?"
 
 # Mirrors the measure-tool globs in .github/labeler.yml.
 MEASURE_DIRECTORIES = (
@@ -79,6 +84,10 @@ CATEGORIES = [
 SECTION_ORDER = [UNCATEGORIZED, *[category.title for category in CATEGORIES]]
 
 
+class ReleaseDraftDriftError(ValueError):
+    """Raised when prepared release notes differ from merged Measure pull requests."""
+
+
 def _touches_measure(client: GitHubClient, number: int) -> bool:
     return any(
         filename.startswith(MEASURE_DIRECTORIES) or filename in MEASURE_FILES
@@ -91,6 +100,93 @@ def _qualifies(client: GitHubClient, pull_request: dict[str, Any]) -> bool:
     if labels & EXCLUDE_LABELS:
         return False
     return INCLUDE_LABEL in labels or _touches_measure(client, pull_request["number"])
+
+
+def _qualified_pull_requests_since(
+    client: GitHubClient,
+    previous_tag: str,
+    head_ref: str,
+) -> list[dict[str, Any]]:
+    try:
+        base_sha = client.commit_sha(previous_tag)
+    except Exception as error:
+        raise ReleaseDraftDriftError(f"could not resolve previous tag {previous_tag}: {error}") from error
+    commit_shas = client.commit_shas_since(base_sha, head_ref)
+    return [
+        pull_request
+        for pull_request in client.merged_pull_requests(commit_shas)
+        if _qualifies(client, pull_request)
+    ]
+
+
+def _render_release_notes(pull_requests: list[dict[str, Any]]) -> str:
+    sections: dict[str, list[str]] = {UNCATEGORIZED: []}
+    for pull_request in pull_requests:
+        sections.setdefault(category_title(pull_request, CATEGORIES), []).append(format_entry(pull_request))
+    return render_sections(sections, SECTION_ORDER)
+
+
+def _changelog_release(changelog: str, target_version: str) -> tuple[str, str]:
+    normalized = changelog.replace("\r\n", "\n")
+    headings = list(re.finditer(r"^## (?P<title>.+?)[ \t]*$", normalized, re.MULTILINE))
+    target_pattern = re.compile(rf"{re.escape(target_version)}(?:\s+-\s+.+)?")
+    target_indexes = [
+        index
+        for index, heading in enumerate(headings)
+        if target_pattern.fullmatch(heading.group("title"))
+    ]
+    if not target_indexes:
+        raise ReleaseDraftDriftError(f"Changelog has no section for target version {target_version}")
+    if len(target_indexes) > 1:
+        raise ReleaseDraftDriftError(f"Changelog has multiple sections for target version {target_version}")
+
+    target_index = target_indexes[0]
+    if target_index + 1 >= len(headings):
+        raise ReleaseDraftDriftError(f"Changelog has no previous Measure release after {target_version}")
+    target = headings[target_index]
+    previous = headings[target_index + 1]
+    previous_match = re.fullmatch(rf"(?P<version>{VERSION_PATTERN})(?:\s+-\s+.+)?", previous.group("title"))
+    if previous_match is None:
+        raise ReleaseDraftDriftError(
+            f"The next changelog section after {target_version} is not a Measure version: {previous.group('title')!r}",
+        )
+    notes = normalized[target.end() : previous.start()].strip("\r\n")
+    return notes, f"measure-v{previous_match.group('version')}"
+
+
+def verify_release(
+    client: GitHubClient,
+    changelog: str,
+    target_version: str,
+    *,
+    head_ref: str,
+    previous_tag: str | None = None,
+) -> None:
+    """Verify prepared changelog notes against qualifying Measure pull requests."""
+
+    actual_notes, derived_previous_tag = _changelog_release(changelog, target_version)
+    boundary_tag = previous_tag or derived_previous_tag
+    if re.fullmatch(rf"measure-v{VERSION_PATTERN}", boundary_tag) is None:
+        raise ReleaseDraftDriftError(f"Invalid previous Measure tag: {boundary_tag}")
+    pull_requests = _qualified_pull_requests_since(client, boundary_tag, head_ref)
+    expected_notes = _render_release_notes(pull_requests).strip("\r\n")
+    if actual_notes == expected_notes:
+        return
+
+    difference = "\n".join(
+        difflib.unified_diff(
+            actual_notes.splitlines(),
+            expected_notes.splitlines(),
+            fromfile=f"CHANGELOG.md {target_version}",
+            tofile=f"merged Measure PRs since {boundary_tag}",
+            lineterm="",
+        ),
+    )
+    raise ReleaseDraftDriftError(
+        f"Measure changelog notes for {target_version} are out of date. "
+        "Regenerate the release from the current rolling draft before tagging.\n"
+        f"{difference}",
+    )
 
 
 def _current_version() -> tuple[int, int, int]:
@@ -107,19 +203,32 @@ def _rolling_draft(client: GitHubClient) -> dict[str, Any] | None:
     )
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Maintain or verify the rolling Powercalc Measure release draft")
+    parser.add_argument("--verify", metavar="VERSION", help="Verify a prepared changelog release before tagging")
+    parser.add_argument("--previous-tag", help="Override the previous measure-v* tag derived from the changelog")
+    parser.add_argument("--changelog", type=Path, default=CHANGELOG_PATH, help=argparse.SUPPRESS)
+    parser.add_argument("--head-ref", help="Git ref containing merged pull requests; defaults to HEAD_REF or master")
+    args = parser.parse_args(argv)
     client = GitHubClient(os.environ["GITHUB_TOKEN"], os.environ["GITHUB_REPOSITORY"])
-    head_ref = os.environ.get("HEAD_REF", "master")
+    head_ref = args.head_ref or os.environ.get("HEAD_REF", "master")
+    if args.verify is not None:
+        try:
+            verify_release(
+                client,
+                args.changelog.read_text(encoding="utf-8"),
+                args.verify,
+                head_ref=head_ref,
+                previous_tag=args.previous_tag,
+            )
+        except (OSError, ReleaseDraftDriftError) as error:
+            parser.error(str(error))
+        print(f"Verified Measure {args.verify} notes against merged pull requests through {head_ref}")
+        return
+
     current = _current_version()
     current_version = format_version(current)
-    base_sha = client.commit_sha(f"measure-v{current_version}")
-    commit_shas = client.commit_shas_since(base_sha, head_ref)
-
-    pull_requests = [
-        pull_request
-        for pull_request in client.merged_pull_requests(commit_shas)
-        if _qualifies(client, pull_request)
-    ]
+    pull_requests = _qualified_pull_requests_since(client, f"measure-v{current_version}", head_ref)
     draft = _rolling_draft(client)
     if not pull_requests:
         if draft is not None:
@@ -129,19 +238,17 @@ def main() -> None:
             print(f"No merged Measure pull requests on {head_ref} since measure-v{current_version}")
         return
 
-    sections: dict[str, list[str]] = {UNCATEGORIZED: []}
     levels: list[int] = []
     for pull_request in pull_requests:
         entry = format_entry(pull_request)
         levels.append(bump_level(pull_request, CATEGORIES))
-        sections.setdefault(category_title(pull_request, CATEGORIES), []).append(entry)
         print(f"Adding {entry}")
 
     next_version = format_version(bump(current, max(levels)))
     payload = {
         "tag_name": DRAFT_TAG,
         "name": DRAFT_TITLE_PATTERN.format(version=next_version),
-        "body": render_sections(sections, SECTION_ORDER),
+        "body": _render_release_notes(pull_requests),
         "draft": True,
     }
     if draft is None:

--- a/.github/workflows/measure-release.yml
+++ b/.github/workflows/measure-release.yml
@@ -45,6 +45,7 @@ jobs:
     permissions:
       contents: write
       actions: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -63,6 +64,13 @@ jobs:
             exit 0
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Verify release notes against merged Measure pull requests
+        if: steps.release.outputs.version != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.sha }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: python3 .github/scripts/release_draft/update_measure_draft.py --verify "$VERSION"
       - name: Create release tag
         if: steps.release.outputs.version != ''
         env:


### PR DESCRIPTION
## Summary

- rebuild expected release notes from all qualifying Measure pull requests since the previous tag
- share qualification and rendering with the rolling Measure draft
- compare the prepared changelog against the exact commit that will be tagged
- stop before tagging with an actionable diff when a release PR has become stale

## Validation

- complete release-draft suite (49 passed)
- scoped Ruff and strict mypy
- GitHub workflow schema validation
- actionlint and zizmor
- pre-commit hooks
