### PR TITLE
Warn before loud speaker measurements

### DIFF
--- a/utils/measure/frontend/src/components/app-shell.ts
+++ b/utils/measure/frontend/src/components/app-shell.ts
@@ -153,7 +153,7 @@ export class AppShell extends LitElement implements MeasureAppState {
     if (this.view === "review" && this.preflight && this.request) return html`
       <measure-preflight-view .metrics=${this.reviewMetrics()} .summary=${this.reviewSummary()} .warnings=${this.preflight.warnings} .powerMeterDiagnostic=${this.preflight.power_meter_diagnostic} .canOverwrite=${this.reviewCanOverwrite()} .confirmationAction=${this.confirmationAction()} .busy=${this.busy} .errorMessage=${this.errorMessage} @back=${this.backToSetup} @start=${this.start}></measure-preflight-view>`;
     if (this.view === "running" && this.snapshot) return html`
-      <measure-running-view .snapshot=${this.snapshot} .confirmationAction=${this.confirmationAction()} .connected=${this.connectedToEvents} .logs=${this.logs} .samples=${this.samples} .diagnosticsUrl=${this.api.diagnosticsUrl()} .busy=${this.busy} @cancel=${this.cancel} @confirm=${this.confirm}></measure-running-view>`;
+      <measure-running-view .snapshot=${this.snapshot} .confirmationAction=${this.confirmationAction()} .warningConfirmation=${this.confirmationIsWarning()} .connected=${this.connectedToEvents} .logs=${this.logs} .samples=${this.samples} .diagnosticsUrl=${this.api.diagnosticsUrl()} .busy=${this.busy} @cancel=${this.cancel} @confirm=${this.confirm}></measure-running-view>`;
     if (this.view === "result" && this.snapshot) return html`
       <measure-result-view .snapshot=${this.snapshot} .files=${this.files} .plotCollection=${this.plotCollection} .fileUrl=${(name: string) => this.api.fileUrl(name)} .downloadAll=${this.downloadAllFiles.bind(this)} .diagnosticsUrl=${this.api.diagnosticsUrl()} .busy=${this.busy} .canResume=${this.canResumeSession()} .errorMessage=${this.errorMessage} @new=${this.newMeasurement} @resume=${this.resume}></measure-result-view>`;
     return html`
@@ -236,6 +236,10 @@ export class AppShell extends LitElement implements MeasureAppState {
   private confirmationAction(): string {
     const type = this.snapshot?.request?.measure_type ?? this.request?.measure_type;
     return this.definitions.find((definition) => definition.measure_type === type)?.confirmation_action ?? "";
+  }
+
+  private confirmationIsWarning(): boolean {
+    return (this.snapshot?.request?.measure_type ?? this.request?.measure_type) === "speaker";
   }
 
   private duration(seconds: number): string {

--- a/utils/measure/frontend/src/components/running-view.ts
+++ b/utils/measure/frontend/src/components/running-view.ts
@@ -26,6 +26,7 @@ export class RunningView extends LitElement {
   static readonly properties = {
     snapshot: { attribute: false },
     confirmationAction: { type: String },
+    warningConfirmation: { type: Boolean },
     connected: { type: Boolean },
     logs: { attribute: false },
     samples: { attribute: false },
@@ -36,6 +37,7 @@ export class RunningView extends LitElement {
 
   snapshot!: SessionSnapshot;
   confirmationAction = "";
+  warningConfirmation = false;
   connected = false;
   logs: string[] = [];
   samples: number[] = [];
@@ -88,9 +90,13 @@ export class RunningView extends LitElement {
     .preparation-track { position: relative; width: min(360px, 100%); height: 8px; margin-top: 0.4rem; overflow: hidden; border-radius: 99px; background: var(--track); }
     .preparation-bar { position: absolute; inset-block: 0; inset-inline-start: 0; width: 38%; border-radius: inherit; background: var(--signal); animation: prepare 1.35s ease-in-out infinite; }
     .ready-card { display: grid; justify-items: center; gap: 0.8rem; padding: clamp(1.5rem, 6vw, 3rem); border: 1px solid color-mix(in srgb, var(--good) 42%, var(--line)); border-radius: 16px; background: color-mix(in srgb, var(--good) 6%, var(--well)); text-align: center; }
+    .ready-card.warning { border-color: color-mix(in srgb, var(--warning) 58%, var(--line)); background: color-mix(in srgb, var(--warning) 8%, var(--well)); }
     .ready-announcement { display: grid; justify-items: center; gap: 0.8rem; }
     .ready-announcement h3, .ready-announcement p { margin: 0; }
     .ready-icon { display: grid; place-items: center; width: 46px; height: 46px; border-radius: 50%; background: color-mix(in srgb, var(--good) 16%, transparent); color: var(--good); font-size: 1.4rem; }
+    .ready-card.warning .ready-icon { width: 52px; height: 52px; border-radius: 14px; background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); }
+    .ready-card.warning .ready-icon svg { width: 34px; height: 34px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+    .ready-card.warning .ready-eyebrow { color: var(--warning); }
     .ready-message { max-width: 620px; color: var(--muted); line-height: 1.6; white-space: pre-line; }
     .ready-topline { display: flex; justify-content: flex-end; align-items: center; gap: 0.9rem; width: 100%; }
     @keyframes spin { to { transform: rotate(360deg); } }
@@ -143,19 +149,25 @@ export class RunningView extends LitElement {
 
   private renderReady() {
     const message = this.snapshot.confirmation_message ?? "Preparation is complete. Start the measurement when the device is ready.";
+    const warning = this.warningConfirmation;
     return html`
       <section class="panel" aria-labelledby="running-title">
         <p class="eyebrow">03 / Measurement</p>
         <h2 id="running-title">Ready when you are</h2>
-        <div class="ready-card">
+        <div class="ready-card ${warning ? "warning" : ""}">
           <span class="ready-topline">
             ${this.logs.length ? html`<button class="log-toggle" type="button" @click=${this.toggleLog} aria-expanded=${this.logOpen}>Log <span class="log-count">${this.logs.length}</span></button>` : nothing}
             <span class="connection ${this.connected ? "connected" : ""}">${this.connected ? "Live" : "Reconnecting"}</span>
           </span>
-          <div class="ready-announcement" role="status" aria-live="polite">
-            <span class="ready-icon" aria-hidden="true">✓</span>
-            <p class="eyebrow">Preparation complete</p>
-            <h3>Everything is ready</h3>
+          <div class="ready-announcement" role=${warning ? "alert" : "status"} aria-live=${warning ? "assertive" : "polite"}>
+            <span class="ready-icon" aria-hidden="true">${warning ? svg`
+              <svg viewBox="0 0 24 24">
+                <path d="M10.3 3.7 2.2 18a2 2 0 0 0 1.7 3h16.2a2 2 0 0 0 1.7-3L13.7 3.7a2 2 0 0 0-3.4 0Z"></path>
+                <path d="M12 9v4"></path><path d="M12 17h.01"></path>
+              </svg>
+            ` : "✓"}</span>
+            <p class="eyebrow ready-eyebrow">${warning ? "High volume warning" : "Preparation complete"}</p>
+            <h3>${warning ? "Protect your hearing" : "Everything is ready"}</h3>
             <p class="ready-message">${message}</p>
           </div>
           <button class="primary confirm" type="button" @click=${this.confirm} ?disabled=${this.busy}>${this.busy ? "Starting…" : this.confirmationAction || "Start measurement"}</button>

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -768,6 +768,28 @@ describe("running view", () => {
     expect(element.shadowRoot.querySelector("progress")).toBeNull();
   });
 
+  it("renders speaker confirmation as a high-volume warning", async () => {
+    const element = document.createElement("measure-running-view") as HTMLElement & {
+      snapshot: SessionSnapshot; confirmationAction: string; warningConfirmation: boolean;
+      updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
+    };
+    element.snapshot = {
+      state: "awaiting_confirmation",
+      confirmation_message: "Speaker measurements can become very loud.",
+    };
+    element.confirmationAction = "Start speaker measurement";
+    element.warningConfirmation = true;
+    document.body.append(element);
+    await element.updateComplete;
+
+    const warning = element.shadowRoot.querySelector(".ready-card.warning");
+    expect(warning).toBeTruthy();
+    expect(warning?.querySelector(".ready-announcement")?.getAttribute("role")).toBe("alert");
+    expect(warning?.textContent).toContain("High volume warning");
+    expect(warning?.textContent).toContain("Protect your hearing");
+    expect(warning?.querySelector(".ready-icon svg")).toBeTruthy();
+  });
+
   it("shows progress, phase, connection state, and cancellation", async () => {
     const element = document.createElement("measure-running-view") as HTMLElement & {
       snapshot: SessionSnapshot;
@@ -1445,8 +1467,46 @@ describe("app shell", () => {
     element.snapshot = { state: "awaiting_confirmation", request: element.request };
     element.view = "running";
     await element.updateComplete;
-    const running = element.shadowRoot?.querySelector("measure-running-view") as HTMLElement & { confirmationAction: string; updateComplete: Promise<boolean> };
+    const running = element.shadowRoot?.querySelector("measure-running-view") as HTMLElement & {
+      confirmationAction: string; warningConfirmation: boolean; updateComplete: Promise<boolean>;
+    };
     expect(running.confirmationAction).toBe("Start averaging");
+    expect(running.warningConfirmation).toBe(false);
+  });
+
+  it("marks speaker confirmation as a warning", async () => {
+    vi.spyOn(AppShell.prototype as unknown as { boot: () => Promise<void> }, "boot").mockResolvedValue();
+    const element = document.createElement("powercalc-measure-app") as AppShell;
+    element.definitions = [{
+      measure_type: "speaker",
+      label: "Speaker",
+      description: "Measure a speaker.",
+      fields: [],
+      supports_profile: true,
+      supports_resume: false,
+      confirmation_action: "Start speaker measurement",
+    }];
+    element.request = {
+      measure_type: "speaker",
+      model_id: "speaker",
+      product_name: "Speaker",
+      measure_device: "Shelly Plug S",
+      generate_model: true,
+      parameters: capabilities.defaults,
+      power_meter: { type: "hass", entity_id: "sensor.plug_power" },
+      controller: { type: "dummy" },
+      disable_streaming: false,
+      resume_policy: "new",
+    };
+    element.snapshot = { state: "awaiting_confirmation", request: element.request };
+    element.view = "running";
+    document.body.append(element);
+    await element.updateComplete;
+
+    const running = element.shadowRoot?.querySelector("measure-running-view") as HTMLElement & {
+      warningConfirmation: boolean; updateComplete: Promise<boolean>;
+    };
+    expect(running.warningConfirmation).toBe(true);
   });
 
   it("loads the Powercalc SVG logo", async () => {

--- a/utils/measure/frontend/src/styles.ts
+++ b/utils/measure/frontend/src/styles.ts
@@ -17,6 +17,7 @@ export const sharedStyles = css`
     --signal-strong: #93b5f4;
     --on-signal: #ffffff;
     --good: #61d4a3;
+    --warning: #f2b84b;
     --danger: #ff7b72;
     --radius: 14px;
     color-scheme: dark;

--- a/utils/measure/measure/runner/speaker.py
+++ b/utils/measure/measure/runner/speaker.py
@@ -43,11 +43,10 @@ class SpeakerRunner(MeasurementRunner[SpeakerMeasurementRequest]):
             f"Prepare to start measuring the power for {duration} seconds on each volume level "
             "starting with 10 until 100 (with steps of 10 between)",
         )
-        self.interaction.notify(
-            "WARNING: during the measurement session the volume will be increased to the maximum, "
-            "which can be harmful for your ears",
+        self.interaction.confirm(
+            "Speaker measurements can become very loud at higher volume levels. "
+            "Wear hearing protection or move to another room before starting.",
         )
-        self.interaction.confirm("Ready to start speaker measurement. Volume will increase to maximum.")
         self.interaction.phase("Starting speaker measurement")
         self.interaction.progress(0, 11, phase="Measuring volume levels", remaining_seconds=self._remaining_seconds(0))
 

--- a/utils/measure/tests/runner/test_speaker.py
+++ b/utils/measure/tests/runner/test_speaker.py
@@ -65,6 +65,10 @@ def test_run_reports_volume_and_muted_operating_points() -> None:
 
     runner.run(request, "")
 
+    interaction.confirm.assert_called_once_with(
+        "Speaker measurements can become very loud at higher volume levels. "
+        "Wear hearing protection or move to another room before starting.",
+    )
     interaction.phase.assert_any_call("Starting speaker measurement")
     interaction.phase.assert_any_call("Measuring speaker at 10% volume")
     # Progress must be reported before the first volume level so the UI leaves the preparing state.


### PR DESCRIPTION
## Summary

- show a clear safety warning in the mandatory confirmation step before speaker measurements
- recommend hearing protection or moving to another room
- remove the separate duplicate warning notification
- cover the warning text with a runner regression test

## Testing

- `uv run --extra dev --extra app --extra cli pytest -q tests` (411 passed)
- `uv run --extra dev --extra app --extra cli ruff check measure tests`
- strict mypy over 102 source files