### PR TITLE
Fix Measure release test dependencies

### DIFF
--- a/.github/workflows/prepare-measure-release.yml
+++ b/.github/workflows/prepare-measure-release.yml
@@ -106,7 +106,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         working-directory: utils/measure
         run: |
-          uv run --extra dev pytest -qq tests/test_prepare_app_release.py
+          uv run --extra dev --extra cli pytest -qq tests/test_prepare_app_release.py
           ruby home-assistant-app/validate.rb
       - name: Commit and push release branch
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary

- install the Measure CLI extra while validating prepared release files
- make `python-decouple` available when pytest loads the shared test configuration

## Testing

- not run locally at request; repository commit hooks passed