### PR TITLE
Ignore release-only changes in Measure notes

### DIFF
--- a/.github/scripts/release_draft/tests/test_measure_draft.py
+++ b/.github/scripts/release_draft/tests/test_measure_draft.py
@@ -15,10 +15,12 @@ class FakeClient:
         releases: list[dict[str, Any]],
         pull_requests: list[dict[str, Any]],
         *,
+        files_by_pull_request: dict[int, list[str]] | None = None,
         missing_refs: set[str] | None = None,
     ) -> None:
         self._releases = releases
         self._pull_requests = pull_requests
+        self._files_by_pull_request = files_by_pull_request or {}
         self._missing_refs = missing_refs or set()
         self.created: list[dict[str, Any]] = []
         self.updated: list[tuple[int, dict[str, Any]]] = []
@@ -41,7 +43,7 @@ class FakeClient:
         return self._pull_requests
 
     def pull_request_files(self, number: int) -> list[str]:
-        return ["utils/measure/measure/runner/runner.py"]
+        return self._files_by_pull_request.get(number, ["utils/measure/measure/runner/runner.py"])
 
     def create_release(self, payload: dict[str, Any]) -> dict[str, Any]:
         self.created.append(payload)
@@ -199,6 +201,61 @@ def test_release_verification_ignores_excluded_pull_requests() -> None:
 """
 
     entry.verify_release(client, changelog, "0.1.0", head_ref="master")
+
+
+def test_release_verification_ignores_release_infrastructure_only_pull_requests() -> None:
+    client = FakeClient(
+        [],
+        [
+            pull_request(10, "feat: Add measurement mode"),
+            pull_request(11, "fix: Repair release preparation"),
+        ],
+        files_by_pull_request={
+            11: [".github/workflows/prepare-measure-release.yml"],
+        },
+    )
+    changelog = """# Changelog
+
+## Unreleased
+
+## 0.1.0 - 2026-07-18
+
+### 🚀 Features
+
+- #10 feat: Add measurement mode @octocat
+
+## 0.0.1 - 2026-07-17
+
+- Initial release.
+"""
+
+    entry.verify_release(client, changelog, "0.1.0", head_ref="master")
+
+
+def test_release_verification_keeps_mixed_release_and_measure_pull_requests() -> None:
+    client = FakeClient(
+        [],
+        [pull_request(10, "fix: Repair release preparation and app metadata")],
+        files_by_pull_request={
+            10: [
+                ".github/workflows/prepare-measure-release.yml",
+                "utils/measure/home-assistant-app/powercalc_measure/config.yaml",
+            ],
+        },
+    )
+    changelog = """# Changelog
+
+## Unreleased
+
+## 0.1.0 - 2026-07-18
+
+## 0.0.1 - 2026-07-17
+
+- Initial release.
+"""
+
+    with pytest.raises(entry.ReleaseDraftDriftError, match="Repair release preparation and app metadata"):
+        entry.verify_release(client, changelog, "0.1.0", head_ref="master")
 
 
 def test_release_verification_accepts_explicit_previous_tag() -> None:

--- a/.github/scripts/release_draft/update_measure_draft.py
+++ b/.github/scripts/release_draft/update_measure_draft.py
@@ -68,6 +68,13 @@ MEASURE_FILES = frozenset(
         ".github/workflows/test-measure.yml",
     },
 )
+RELEASE_INFRASTRUCTURE_DIRECTORIES = (".github/scripts/release_draft/",)
+RELEASE_INFRASTRUCTURE_FILES = frozenset(
+    {
+        ".github/workflows/measure-release.yml",
+        ".github/workflows/prepare-measure-release.yml",
+    },
+)
 INCLUDE_LABEL = "measure-tool"
 EXCLUDE_LABELS = frozenset({"skip-changelog", "dependencies"})
 
@@ -88,10 +95,17 @@ class ReleaseDraftDriftError(ValueError):
     """Raised when prepared release notes differ from merged Measure pull requests."""
 
 
-def _touches_measure(client: GitHubClient, number: int) -> bool:
+def _touches_measure(files: list[str]) -> bool:
     return any(
         filename.startswith(MEASURE_DIRECTORIES) or filename in MEASURE_FILES
-        for filename in client.pull_request_files(number)
+        for filename in files
+    )
+
+
+def _only_touches_release_infrastructure(files: list[str]) -> bool:
+    return bool(files) and all(
+        filename.startswith(RELEASE_INFRASTRUCTURE_DIRECTORIES) or filename in RELEASE_INFRASTRUCTURE_FILES
+        for filename in files
     )
 
 
@@ -99,7 +113,10 @@ def _qualifies(client: GitHubClient, pull_request: dict[str, Any]) -> bool:
     labels = labels_of(pull_request)
     if labels & EXCLUDE_LABELS:
         return False
-    return INCLUDE_LABEL in labels or _touches_measure(client, pull_request["number"])
+    files = client.pull_request_files(pull_request["number"])
+    if _only_touches_release_infrastructure(files):
+        return False
+    return INCLUDE_LABEL in labels or _touches_measure(files)
 
 
 def _qualified_pull_requests_since(


### PR DESCRIPTION
## Summary

- exclude pull requests that only modify Measure release automation from rolling notes and release drift verification
- keep mixed pull requests containing actual Measure or app changes in the release notes
- avoid relying on a manually applied `skip-changelog` label for release infrastructure fixes

## Testing

- `uv run pytest .github/scripts/release_draft/tests -q` (51 passed)
- Ruff on changed files with existing script-specific INP001/T201 exclusions
- repository commit hooks passed