### PR TITLE
Auto-discover charging battery source

### DIFF
--- a/utils/measure/frontend/src/components/app-shell.ts
+++ b/utils/measure/frontend/src/components/app-shell.ts
@@ -223,6 +223,13 @@ export class AppShell extends LitElement implements MeasureAppState {
         label: "Power",
         value: this.request.power_meter.type === "hass" ? this.request.power_meter.entity_id : this.request.power_meter.type,
       });
+      if (this.request.measure_type === "charging" && this.preflight) {
+        const battery = this.preflight.battery_level_entity_id
+          ?? (this.preflight.battery_level_attribute && this.request.controller.type === "hass"
+            ? `${this.request.controller.entity_id} · ${this.preflight.battery_level_attribute} attribute`
+            : undefined);
+        if (battery) rows.push({ label: "Battery", value: battery });
+      }
       if (this.request.dummy_load) rows.push({ label: "Dummy load", value: this.dummyLoadSummary(this.request.dummy_load) });
       return rows;
     }

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -1433,6 +1433,48 @@ describe("preflight power meter diagnostics", () => {
 });
 
 describe("app shell", () => {
+  it("shows the auto-discovered battery sensor in the charging preflight review", async () => {
+    vi.spyOn(AppShell.prototype as unknown as { boot: () => Promise<void> }, "boot").mockResolvedValue();
+    const element = document.createElement("powercalc-measure-app") as AppShell;
+    element.definitions = [{
+      measure_type: "charging",
+      label: "Charging device",
+      description: "Measure charging power.",
+      fields: [],
+      supports_profile: true,
+      supports_resume: false,
+    }];
+    element.request = {
+      measure_type: "charging",
+      model_id: "vacuum",
+      product_name: "Vacuum",
+      measure_device: "Shelly Plug S",
+      generate_model: true,
+      parameters: capabilities.defaults,
+      power_meter: { type: "hass", entity_id: "sensor.plug_power" },
+      controller: { type: "hass", entity_id: "vacuum.robot" },
+      charging_device_type: "vacuum_robot",
+      resume_policy: "new",
+    };
+    element.preflight = {
+      valid: true,
+      warnings: [],
+      battery_level_entity_id: "sensor.robot_battery",
+      battery_level_attribute: null,
+    };
+    element.view = "review";
+    document.body.append(element);
+    await element.updateComplete;
+
+    const review = element.shadowRoot?.querySelector("measure-preflight-view") as HTMLElement & {
+      updateComplete: Promise<boolean>;
+      shadowRoot: ShadowRoot;
+    };
+    await review.updateComplete;
+    expect(review.shadowRoot.textContent).toContain("Battery");
+    expect(review.shadowRoot.textContent).toContain("sensor.robot_battery");
+  });
+
   it("passes a workflow-specific confirmation action through review and ready states", async () => {
     vi.spyOn(AppShell.prototype as unknown as { boot: () => Promise<void> }, "boot").mockResolvedValue();
     const element = document.createElement("powercalc-measure-app") as AppShell;

--- a/utils/measure/frontend/src/types.ts
+++ b/utils/measure/frontend/src/types.ts
@@ -165,6 +165,8 @@ export interface PreflightResponse {
   estimated_duration_seconds?: number;
   supported_modes?: LutMode[];
   power_meter_diagnostic?: PowerMeterDiagnostic | null;
+  battery_level_entity_id?: string | null;
+  battery_level_attribute?: string | null;
 }
 
 export interface SessionProgress {

--- a/utils/measure/measure/assembler.py
+++ b/utils/measure/measure/assembler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from measure.controller.charging.const import ATTR_BATTERY_LEVEL, BatteryLevelSourceType
 from measure.controller.charging.controller import ChargingController
 from measure.controller.charging.dummy import DummyChargingController
 from measure.controller.charging.hass import HassChargingController
@@ -190,21 +189,12 @@ class MeasurementAssembler:
         if isinstance(request, AverageMeasurementRequest):
             return AverageRunner(measure_util, interaction=interaction)
         if isinstance(request, ChargingMeasurementRequest):
-            charging_spec = request.controller
-            charging_controller = self._charging_controller(charging_spec)
-            battery_level_attribute: str | None = ATTR_BATTERY_LEVEL
-            if isinstance(charging_spec, HassChargingControllerSpec):
-                battery_level_attribute = (
-                    charging_spec.battery_level_attribute or ATTR_BATTERY_LEVEL
-                    if charging_spec.battery_level_source_type == BatteryLevelSourceType.ATTRIBUTE
-                    else None
-                )
+            charging_controller = self._charging_controller(request.controller)
             return ChargingRunner(
                 measure_util,
                 parameters,
                 charging_controller,
                 interaction,
-                battery_level_attribute=battery_level_attribute,
             )
         if isinstance(request, FanMeasurementRequest):
             fan_controller = self._fan_controller(request.controller)
@@ -244,9 +234,6 @@ class MeasurementAssembler:
             return HassChargingController(
                 hass,
                 entity_id=spec.entity_id,
-                battery_level_source_type=spec.battery_level_source_type,
-                battery_level_attribute=spec.battery_level_attribute,
-                battery_level_entity_id=spec.battery_level_entity_id,
             )
         raise ValueError(f"Expected a charging controller specification, got {type(spec).__name__}")
 

--- a/utils/measure/measure/cli/questions.py
+++ b/utils/measure/measure/cli/questions.py
@@ -7,14 +7,7 @@ import inquirer
 from inquirer.questions import Question
 
 from measure.const import QUESTION_DUMMY_LOAD, QUESTION_ENTITY_ID, QUESTION_GENERATE_MODEL_JSON
-from measure.controller.charging.const import (
-    ATTR_BATTERY_LEVEL,
-    QUESTION_BATTERY_LEVEL_ATTRIBUTE,
-    QUESTION_BATTERY_LEVEL_ENTITY,
-    QUESTION_BATTERY_LEVEL_SOURCE_TYPE,
-    BatteryLevelSourceType,
-    ChargingDeviceType,
-)
+from measure.controller.charging.const import ChargingDeviceType
 from measure.controller.charging.spec import charging_entity_domain
 from measure.controller.light.const import LutMode
 from measure.home_assistant_entities import (
@@ -135,41 +128,11 @@ def hass_charging_controller_questions(entity_catalog: HomeAssistantEntityCatalo
         domain = EntityDomain(charging_entity_domain(device_type))
         return _entity_choices(entity_catalog.load_snapshot().select(domain=domain))
 
-    def attribute_choices(answers: dict[str, Any]) -> list[str]:
-        entity_id = answers.get(QUESTION_ENTITY_ID)
-        return entity_catalog.load_snapshot().attribute_names(str(entity_id)) if entity_id else []
-
     return [
         inquirer.List(
             name=QUESTION_ENTITY_ID,
             message="Select the charging device entity",
             choices=entity_choices,
-        ),
-        inquirer.List(
-            name=QUESTION_BATTERY_LEVEL_SOURCE_TYPE,
-            message="How is the battery level exposed?",
-            choices=[
-                ("As an attribute of the main entity", BatteryLevelSourceType.ATTRIBUTE),
-                ("As a separate entity", BatteryLevelSourceType.ENTITY),
-            ],
-        ),
-        inquirer.List(
-            name=QUESTION_BATTERY_LEVEL_ATTRIBUTE,
-            message="Select the battery level attribute",
-            choices=attribute_choices,
-            default=ATTR_BATTERY_LEVEL,
-            ignore=lambda answers: (
-                answers.get(QUESTION_BATTERY_LEVEL_SOURCE_TYPE) == BatteryLevelSourceType.ENTITY
-                or ATTR_BATTERY_LEVEL in attribute_choices(answers)
-            ),
-        ),
-        inquirer.List(
-            name=QUESTION_BATTERY_LEVEL_ENTITY,
-            message="Select the battery level entity",
-            choices=lambda _: _entity_choices(
-                entity_catalog.load_snapshot().select(domain=EntityDomain.SENSOR),
-            ),
-            ignore=lambda answers: answers.get(QUESTION_BATTERY_LEVEL_SOURCE_TYPE) == BatteryLevelSourceType.ATTRIBUTE,
         ),
     ]
 

--- a/utils/measure/measure/cli/request_adapter.py
+++ b/utils/measure/measure/cli/request_adapter.py
@@ -12,14 +12,7 @@ from measure.const import (
     QUESTION_MODEL_NAME,
     MeasureType,
 )
-from measure.controller.charging.const import (
-    QUESTION_BATTERY_LEVEL_ATTRIBUTE,
-    QUESTION_BATTERY_LEVEL_ENTITY,
-    QUESTION_BATTERY_LEVEL_SOURCE_TYPE,
-    BatteryLevelSourceType,
-    ChargingControllerType,
-    ChargingDeviceType,
-)
+from measure.controller.charging.const import ChargingControllerType, ChargingDeviceType
 from measure.controller.charging.spec import DummyChargingControllerSpec, HassChargingControllerSpec
 from measure.controller.fan.const import FanControllerType
 from measure.controller.fan.spec import DummyFanControllerSpec, HassFanControllerSpec
@@ -194,11 +187,6 @@ def _charging_controller_spec(
     if selected == ChargingControllerType.HASS:
         return HassChargingControllerSpec(
             entity_id=_required_answer(answers, QUESTION_ENTITY_ID),
-            battery_level_source_type=BatteryLevelSourceType(
-                answers.get(QUESTION_BATTERY_LEVEL_SOURCE_TYPE, BatteryLevelSourceType.ATTRIBUTE),
-            ),
-            battery_level_attribute=_optional_answer(answers, QUESTION_BATTERY_LEVEL_ATTRIBUTE),
-            battery_level_entity_id=_optional_answer(answers, QUESTION_BATTERY_LEVEL_ENTITY),
         )
     raise ValueError(f"Unsupported CLI charging controller: {selected}")
 

--- a/utils/measure/measure/controller/charging/const.py
+++ b/utils/measure/measure/controller/charging/const.py
@@ -11,12 +11,4 @@ class ChargingDeviceType(StrEnum):
     LAWN_MOWER_ROBOT = "lawn_mower_robot"
 
 
-class BatteryLevelSourceType(StrEnum):
-    ATTRIBUTE = "attribute"
-    ENTITY = "entity"
-
-
-QUESTION_BATTERY_LEVEL_ATTRIBUTE = "battery_level_attribute"
-QUESTION_BATTERY_LEVEL_ENTITY = "battery_level_entity"
-QUESTION_BATTERY_LEVEL_SOURCE_TYPE = "battery_level_source_type"
 ATTR_BATTERY_LEVEL = "battery_level"

--- a/utils/measure/measure/controller/charging/controller.py
+++ b/utils/measure/measure/controller/charging/controller.py
@@ -4,6 +4,11 @@ from typing import Protocol
 
 
 class ChargingController(Protocol):
+    @property
+    def battery_level_attribute(self) -> str | None:
+        """Return the entity attribute used for profiles, or None for a sensor state."""
+        ...
+
     def get_battery_level(self) -> int:
         """Get actual battery level of the device"""
         ...

--- a/utils/measure/measure/controller/charging/dummy.py
+++ b/utils/measure/measure/controller/charging/dummy.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+from measure.controller.charging.const import ATTR_BATTERY_LEVEL
 from measure.controller.charging.controller import ChargingController
 
 
 class DummyChargingController(ChargingController):
     def __init__(self) -> None:
         self._battery_level = 0
+
+    @property
+    def battery_level_attribute(self) -> str:
+        """Dummy charging profiles use the conventional entity attribute."""
+        return ATTR_BATTERY_LEVEL
 
     def get_battery_level(self) -> int:
         self._battery_level += 1

--- a/utils/measure/measure/controller/charging/hass.py
+++ b/utils/measure/measure/controller/charging/hass.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from measure.controller.charging.const import (
-    ATTR_BATTERY_LEVEL,
-    BatteryLevelSourceType,
-)
+from measure.controller.charging.const import ATTR_BATTERY_LEVEL
 from measure.controller.charging.controller import ChargingController
 from measure.controller.charging.errors import BatteryLevelRetrievalError
 from measure.controller.hass_controller import HassControllerBase
 from measure.home_assistant import HomeAssistantManager
+from measure.home_assistant_entities import DeviceClass, HomeAssistantEntityCatalog
 
 
 class HassChargingController(HassControllerBase, ChargingController):
@@ -16,35 +14,55 @@ class HassChargingController(HassControllerBase, ChargingController):
         home_assistant: HomeAssistantManager,
         *,
         entity_id: str | None = None,
-        battery_level_source_type: BatteryLevelSourceType = BatteryLevelSourceType.ATTRIBUTE,
-        battery_level_attribute: str | None = None,
-        battery_level_entity_id: str | None = None,
     ) -> None:
-        self.battery_level_attribute = (
-            battery_level_attribute or ATTR_BATTERY_LEVEL
-            if battery_level_source_type == BatteryLevelSourceType.ATTRIBUTE
-            else None
-        )
-        self.battery_level_source_type = battery_level_source_type
-        self.battery_level_entity_id = battery_level_entity_id
+        self._battery_source_resolved = False
+        self._battery_sensor_entity_id: str | None = None
         super().__init__(home_assistant, entity_id=entity_id)
+
+    @property
+    def battery_level_attribute(self) -> str | None:
+        """Return the profile attribute only when attribute fallback was resolved."""
+        if not self._battery_source_resolved or self._battery_sensor_entity_id is not None:
+            return None
+        return ATTR_BATTERY_LEVEL
 
     def get_battery_level(self) -> int:
         """Get actual battery level of the device"""
 
-        if self.battery_level_source_type == BatteryLevelSourceType.ATTRIBUTE:
-            state = self.get_entity_state()
-            if self.battery_level_attribute not in state.attributes:
-                raise BatteryLevelRetrievalError(
-                    f"Attribute {self.battery_level_attribute} not found in entity {self.entity_id}",
-                )
-            return int(state.attributes[self.battery_level_attribute])
+        # Modern Home Assistant integrations (e.g. dreame-vacuum) expose the battery level as a
+        # separate battery sensor rather than an attribute of the main entity. Prefer such a
+        # sensor on the same device, falling back to the battery_level attribute when none exists.
+        sensor_entity_id = self._resolve_battery_sensor()
+        if sensor_entity_id is not None:
+            return self._read_battery_level_entity(sensor_entity_id)
 
-        if not self.battery_level_entity_id:
-            raise BatteryLevelRetrievalError("Battery level entity ID is not set")
-        entity = self.client.get_entity(entity_id=self.battery_level_entity_id)
+        state = self.get_entity_state()
+        if ATTR_BATTERY_LEVEL not in state.attributes:
+            raise BatteryLevelRetrievalError(
+                f"No battery level sensor found on the same device and attribute "
+                f"{ATTR_BATTERY_LEVEL} not found in entity {self.entity_id}",
+            )
+        return int(state.attributes[ATTR_BATTERY_LEVEL])
+
+    def _discover_battery_sensor(self) -> str | None:
+        """Find a battery sensor belonging to the same device as the charging entity."""
+
+        if not self.entity_id:
+            return None
+        snapshot = HomeAssistantEntityCatalog(self.client).load_snapshot()
+        return snapshot.related_entity_id(self.entity_id, DeviceClass.BATTERY)
+
+    def _resolve_battery_sensor(self) -> str | None:
+        """Resolve and cache the battery source for the lifetime of this controller."""
+        if not self._battery_source_resolved:
+            self._battery_sensor_entity_id = self._discover_battery_sensor()
+            self._battery_source_resolved = True
+        return self._battery_sensor_entity_id
+
+    def _read_battery_level_entity(self, entity_id: str) -> int:
+        entity = self.client.get_entity(entity_id=entity_id)
         if not entity:
-            raise BatteryLevelRetrievalError(f"Battery level entity {self.battery_level_entity_id} not found")
+            raise BatteryLevelRetrievalError(f"Battery level entity {entity_id} not found")
         try:
             return int(float(entity.state.state))
         except ValueError, TypeError:

--- a/utils/measure/measure/controller/charging/spec.py
+++ b/utils/measure/measure/controller/charging/spec.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
-from measure.controller.charging.const import BatteryLevelSourceType, ChargingControllerType, ChargingDeviceType
+from measure.controller.charging.const import ChargingControllerType, ChargingDeviceType
 
 
 def charging_entity_domain(device_type: ChargingDeviceType) -> str:
@@ -27,15 +27,6 @@ class DummyChargingControllerSpec(_ChargingControllerSpec):
 class HassChargingControllerSpec(_ChargingControllerSpec):
     type: Literal[ChargingControllerType.HASS] = ChargingControllerType.HASS
     entity_id: str = Field(pattern=r"^(vacuum|lawn_mower)\.[a-z0-9_]+$")
-    battery_level_source_type: BatteryLevelSourceType = BatteryLevelSourceType.ATTRIBUTE
-    battery_level_attribute: str | None = None
-    battery_level_entity_id: str | None = Field(default=None, pattern=r"^sensor\.[a-z0-9_]+$")
-
-    @model_validator(mode="after")
-    def validate_battery_level_source(self) -> HassChargingControllerSpec:
-        if self.battery_level_source_type == BatteryLevelSourceType.ENTITY and self.battery_level_entity_id is None:
-            raise ValueError("battery_level_entity_id is required when the battery level source is an entity")
-        return self
 
 
 ChargingControllerSpec = Annotated[

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -71,6 +71,8 @@ class PreflightResponse(BaseModel):
     estimated_duration_seconds: int | None = None
     supported_modes: list[LutMode] | None = None
     power_meter_diagnostic: PowerMeterDiagnostic | None = None
+    battery_level_entity_id: str | None = None
+    battery_level_attribute: str | None = None
 
 
 class EntityCatalogResponse(BaseModel):
@@ -578,6 +580,8 @@ def _preflight(context: AppContext, payload: MeasurementRequest) -> PreflightRes
         estimated_duration_seconds=result.estimated_duration_seconds,
         supported_modes=list(result.supported_modes) if result.supported_modes is not None else None,
         power_meter_diagnostic=result.power_meter_diagnostic,
+        battery_level_entity_id=result.battery_level_entity_id,
+        battery_level_attribute=result.battery_level_attribute,
     )
 
 

--- a/utils/measure/measure/ha_app/preflight.py
+++ b/utils/measure/measure/ha_app/preflight.py
@@ -6,7 +6,7 @@ import math
 from typing import Protocol
 
 from measure.const import DUMMY_LOAD_MEASUREMENT_COUNT, DUMMY_LOAD_MEASUREMENTS_DURATION
-from measure.controller.charging.const import ATTR_BATTERY_LEVEL, BatteryLevelSourceType
+from measure.controller.charging.const import ATTR_BATTERY_LEVEL
 from measure.controller.charging.spec import (
     DummyChargingControllerSpec,
     HassChargingControllerSpec,
@@ -42,6 +42,7 @@ class ActiveSessionError(PreflightError):
 
 class EntityRecord(Protocol):
     entity_id: str
+    device_id: str | None
     state: str
     attribute_names: list[str]
     supported_modes: list[LutMode] | None
@@ -60,6 +61,8 @@ class PreflightResult:
     estimated_duration_seconds: int | None = None
     supported_modes: tuple[LutMode, ...] | None = None
     power_meter_diagnostic: PowerMeterDiagnostic | None = None
+    battery_level_entity_id: str | None = None
+    battery_level_attribute: str | None = None
 
 
 class MeasurementPreflight:
@@ -100,8 +103,7 @@ class MeasurementPreflight:
         if isinstance(request, LightMeasurementRequest):
             result = self._validate_light(request)
         else:
-            self._validate_controller(request)
-            result = PreflightResult()
+            result = self._validate_controller(request)
 
         warnings = list(result.warnings)
         duration = result.estimated_duration_seconds
@@ -125,6 +127,8 @@ class MeasurementPreflight:
             estimated_duration_seconds=duration,
             supported_modes=result.supported_modes,
             power_meter_diagnostic=diagnostic,
+            battery_level_entity_id=result.battery_level_entity_id,
+            battery_level_attribute=result.battery_level_attribute,
         )
 
     def _validate_adapters(self, request: MeasurementRequest) -> None:
@@ -188,7 +192,7 @@ class MeasurementPreflight:
                 "required for dummy loads",
             )
 
-    def _validate_controller(self, request: MeasurementRequest) -> None:
+    def _validate_controller(self, request: MeasurementRequest) -> PreflightResult:
         if isinstance(request, SpeakerMeasurementRequest):
             if isinstance(request.controller, HassMediaControllerSpec):
                 self._require_entity(
@@ -209,30 +213,42 @@ class MeasurementPreflight:
                     domain,
                     "Selected charging device is unavailable",
                 )
-                self._validate_charging_battery_source(request.controller, charging_entity)
+                return self._validate_charging_battery_source(charging_entity)
+        return PreflightResult()
 
-    def _validate_charging_battery_source(
-        self,
-        controller: HassChargingControllerSpec,
-        charging_entity: EntityRecord,
-    ) -> None:
-        if controller.battery_level_source_type == BatteryLevelSourceType.ATTRIBUTE:
-            attribute = controller.battery_level_attribute or ATTR_BATTERY_LEVEL
-            if attribute not in charging_entity.attribute_names:
-                raise PreflightError(f"Battery level attribute {attribute} is not available on the charging device")
-            return
+    def _validate_charging_battery_source(self, charging_entity: EntityRecord) -> PreflightResult:
+        # Prefer a separate battery sensor on the same device (the modern HA default),
+        # falling back to the battery_level attribute when none is available.
+        battery_sensor = self._find_related_battery_sensor(charging_entity)
+        if battery_sensor is not None:
+            try:
+                level = float(battery_sensor.state)
+            except ValueError, TypeError:
+                level = math.nan
+            if not math.isfinite(level) or not 0 <= level <= 100:
+                raise PreflightError("Battery level sensor must report a numeric percentage between 0 and 100")
+            return PreflightResult(battery_level_entity_id=battery_sensor.entity_id)
 
-        battery_entity = self._require_entity(
-            controller.battery_level_entity_id,
-            EntityDomain.SENSOR,
-            "Selected battery level sensor is unavailable",
+        if ATTR_BATTERY_LEVEL in charging_entity.attribute_names:
+            return PreflightResult(battery_level_attribute=ATTR_BATTERY_LEVEL)
+        raise PreflightError(
+            f"No battery level sensor was found on the same device, and attribute "
+            f"{ATTR_BATTERY_LEVEL} is not available on the charging device",
         )
-        try:
-            level = float(battery_entity.state)
-        except ValueError, TypeError:
-            level = math.nan
-        if not math.isfinite(level) or not 0 <= level <= 100:
-            raise PreflightError("Battery level sensor must report a numeric percentage between 0 and 100")
+
+    def _find_related_battery_sensor(self, charging_entity: EntityRecord) -> EntityRecord | None:
+        """Return a battery sensor on the same device as the charging entity, if any."""
+
+        if charging_entity.device_id is None:
+            return None
+        return next(
+            (
+                sensor
+                for sensor in self._load_entities(None, DeviceClass.BATTERY)
+                if sensor.device_id == charging_entity.device_id
+            ),
+            None,
+        )
 
     def _validate_light(self, request: LightMeasurementRequest) -> PreflightResult:
         if isinstance(request.controller, DummyLightControllerSpec):

--- a/utils/measure/measure/home_assistant_entities.py
+++ b/utils/measure/measure/home_assistant_entities.py
@@ -30,10 +30,15 @@ class EntityDomain(StrEnum):
 class DeviceClass(StrEnum):
     POWER = "power"
     VOLTAGE = "voltage"
+    BATTERY = "battery"
 
     @property
     def unit_of_measurement(self) -> str:
-        return "W" if self is DeviceClass.POWER else "V"
+        return {
+            DeviceClass.POWER: "W",
+            DeviceClass.VOLTAGE: "V",
+            DeviceClass.BATTERY: "%",
+        }[self]
 
 
 class EntityDescriptor(BaseModel):

--- a/utils/measure/measure/runner/charging.py
+++ b/utils/measure/measure/runner/charging.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from measure.controller.charging.const import ATTR_BATTERY_LEVEL, ChargingDeviceType
+from measure.controller.charging.const import ChargingDeviceType
 from measure.controller.charging.controller import ChargingController
 from measure.controller.charging.errors import ChargingControllerError
 from measure.execution import ChargingOperatingPoint, ImmediateInteraction, RunInteraction
@@ -24,11 +24,8 @@ class ChargingRunner(MeasurementRunner[ChargingMeasurementRequest]):
         parameters: MeasurementParameters,
         controller: ChargingController,
         interaction: RunInteraction | None = None,
-        battery_level_attribute: str | None = ATTR_BATTERY_LEVEL,
     ) -> None:
-        self.battery_level_entity: str | None = None
         self.config = parameters
-        self.battery_level_attribute = battery_level_attribute
         self.measure_util = measure_util
         self.controller = controller
         self.charging_device_type: ChargingDeviceType | None = None
@@ -144,8 +141,8 @@ class ChargingRunner(MeasurementRunner[ChargingMeasurementRequest]):
         calculation_enabled_condition = "{{ is_state('[[entity]]', 'docked') }}"
 
         linear_config: dict[str, object] = {"calibrate": calibrate_list}
-        if self.battery_level_attribute is not None:
-            linear_config["attribute"] = self.battery_level_attribute
+        if self.controller.battery_level_attribute is not None:
+            linear_config["attribute"] = self.controller.battery_level_attribute
 
         return {
             "device_type": self.charging_device_type.value,

--- a/utils/measure/tests/controller/charging/test_hass.py
+++ b/utils/measure/tests/controller/charging/test_hass.py
@@ -1,94 +1,132 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from homeassistant_api import State
 from homeassistant_api.errors import HomeassistantAPIError
-from measure.controller.charging.const import ATTR_BATTERY_LEVEL, BatteryLevelSourceType
+from measure.controller.charging.const import ATTR_BATTERY_LEVEL
 from measure.controller.charging.errors import BatteryLevelRetrievalError
 from measure.controller.charging.hass import HassChargingController
 from measure.controller.errors import ApiConnectionError
-from measure.home_assistant import HomeAssistantManager
+from measure.home_assistant import HomeAssistantEntityData, HomeAssistantManager
 import pytest
 
 
-def test_get_battery_level_attribute() -> None:
-    """Test retrieving battery level from an attribute."""
-    mocked_state = State(
-        entity_id="vacuum.test",
-        state="docked",
-        attributes={ATTR_BATTERY_LEVEL: 75},
+def _entity(entity_id: str, state: str, **attributes: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        entity_id=entity_id,
+        state=SimpleNamespace(state=state, attributes=attributes),
     )
 
+
+def _no_registry_data() -> HomeAssistantEntityData:
+    """Entity data without a discoverable battery sensor."""
+    return HomeAssistantEntityData(entities={}, entity_registry=[], device_registry=[])
+
+
+def _battery_sensor_data(battery_state: str = "80") -> HomeAssistantEntityData:
+    """Entity data where the charging device has a separate battery sensor on the same device."""
+    return HomeAssistantEntityData(
+        entities={
+            "vacuum": SimpleNamespace(
+                entities={"robot": _entity("vacuum.test", "docked", friendly_name="Robot")},
+            ),
+            "sensor": SimpleNamespace(
+                entities={
+                    "battery": _entity(
+                        "sensor.test_battery_level",
+                        battery_state,
+                        friendly_name="Battery",
+                        device_class="battery",
+                        unit_of_measurement="%",
+                    ),
+                },
+            ),
+        },
+        entity_registry=[
+            SimpleNamespace(entity_id="vacuum.test", device_id="vacuum-device"),
+            SimpleNamespace(entity_id="sensor.test_battery_level", device_id="vacuum-device"),
+        ],
+        device_registry=[{"id": "vacuum-device", "model": "Test Vacuum"}],
+    )
+
+
+def test_get_battery_level_from_sensor() -> None:
+    """Battery level is read from a separate battery sensor on the same device."""
     client = _mock_client()
-    client.get_entity.return_value = MagicMock(state=mocked_state)
-    hass_controller = _get_instance(client=client, battery_level_attribute=ATTR_BATTERY_LEVEL)
-    assert hass_controller.get_battery_level() == 75
-
-
-def test_get_battery_level_entity() -> None:
-    """Test retrieving battery level from a separate entity."""
-    mocked_entity = MagicMock()
-    mocked_entity.state = State(
-        entity_id="sensor.vacuum_battery",
-        state="80",
-        attributes={},
+    client.get_entity_data.return_value = _battery_sensor_data(battery_state="80")
+    client.get_entity.return_value = MagicMock(
+        state=State(entity_id="sensor.test_battery_level", state="80", attributes={}),
     )
+    assert _get_instance(client=client).get_battery_level() == 80
+    client.get_entity.assert_called_once_with(entity_id="sensor.test_battery_level")
 
+
+def test_get_battery_level_discovers_sensor_only_once() -> None:
     client = _mock_client()
-    client.get_entity.return_value = mocked_entity
-    hass_controller = _get_instance(
-        client=client,
-        battery_level_source_type=BatteryLevelSourceType.ENTITY,
-        battery_level_entity_id="sensor.vacuum_battery",
+    client.get_entity_data.return_value = _battery_sensor_data()
+    client.get_entity.return_value = MagicMock(
+        state=State(entity_id="sensor.test_battery_level", state="80", attributes={}),
     )
-    assert hass_controller.get_battery_level() == 80
+    controller = _get_instance(client=client)
+
+    assert controller.get_battery_level() == 80
+    assert controller.get_battery_level() == 80
+    client.get_entity_data.assert_called_once_with()
+    assert controller.battery_level_attribute is None
 
 
-def test_get_battery_level_attribute_error() -> None:
-    """Test error when attribute is missing."""
-    mocked_state = State(
-        entity_id="vacuum.test",
-        state="docked",
-        attributes={},
-    )
-
+def test_cached_battery_sensor_failure_does_not_switch_to_attribute() -> None:
     client = _mock_client()
-    client.get_entity.return_value = MagicMock(state=mocked_state)
-    hass_controller = _get_instance(client=client, battery_level_attribute=ATTR_BATTERY_LEVEL)
+    client.get_entity_data.return_value = _battery_sensor_data()
+    client.get_entity.side_effect = [
+        MagicMock(state=State(entity_id="sensor.test_battery_level", state="80", attributes={})),
+        MagicMock(state=State(entity_id="sensor.test_battery_level", state="unknown", attributes={})),
+    ]
+    controller = _get_instance(client=client)
+
+    assert controller.get_battery_level() == 80
     with pytest.raises(BatteryLevelRetrievalError):
-        hass_controller.get_battery_level()
+        controller.get_battery_level()
+
+    client.get_entity_data.assert_called_once_with()
+    assert [call.kwargs["entity_id"] for call in client.get_entity.call_args_list] == [
+        "sensor.test_battery_level",
+        "sensor.test_battery_level",
+    ]
 
 
-def test_get_battery_level_entity_error() -> None:
-    """Test error when entity is not found."""
+def test_get_battery_level_falls_back_to_attribute() -> None:
+    """Without a battery sensor, the battery_level attribute of the main entity is used."""
     client = _mock_client()
-    client.get_entity.return_value = None
-    hass_controller = _get_instance(
-        client=client,
-        battery_level_source_type=BatteryLevelSourceType.ENTITY,
-        battery_level_entity_id="sensor.vacuum_battery",
+    client.get_entity_data.return_value = _no_registry_data()
+    client.get_entity.return_value = MagicMock(
+        state=State(entity_id="vacuum.test", state="docked", attributes={ATTR_BATTERY_LEVEL: 75}),
+    )
+    controller = _get_instance(client=client)
+    assert controller.get_battery_level() == 75
+    assert controller.battery_level_attribute == ATTR_BATTERY_LEVEL
+
+
+def test_get_battery_level_no_sensor_no_attribute_error() -> None:
+    """Error when neither a battery sensor nor the attribute is available."""
+    client = _mock_client()
+    client.get_entity_data.return_value = _no_registry_data()
+    client.get_entity.return_value = MagicMock(
+        state=State(entity_id="vacuum.test", state="docked", attributes={}),
     )
     with pytest.raises(BatteryLevelRetrievalError):
-        hass_controller.get_battery_level()
+        _get_instance(client=client).get_battery_level()
 
 
-def test_get_battery_level_entity_invalid_state() -> None:
-    """Test error when entity state cannot be converted to int."""
-    mocked_entity = MagicMock()
-    mocked_entity.state = State(
-        entity_id="sensor.vacuum_battery",
-        state="unknown",
-        attributes={},
-    )
-
+def test_get_battery_level_sensor_invalid_state() -> None:
+    """Error when the discovered battery sensor state cannot be converted to int."""
     client = _mock_client()
-    client.get_entity.return_value = mocked_entity
-    hass_controller = _get_instance(
-        client=client,
-        battery_level_source_type=BatteryLevelSourceType.ENTITY,
-        battery_level_entity_id="sensor.vacuum_battery",
+    client.get_entity_data.return_value = _battery_sensor_data(battery_state="80")
+    client.get_entity.return_value = MagicMock(
+        state=State(entity_id="sensor.test_battery_level", state="unknown", attributes={}),
     )
     with pytest.raises(BatteryLevelRetrievalError):
-        hass_controller.get_battery_level()
+        _get_instance(client=client).get_battery_level()
 
 
 def test_is_charging() -> None:
@@ -152,24 +190,16 @@ def test_connection_validation() -> None:
         HassChargingController(client)
 
 
-def _get_instance(
-    *,
-    client: MagicMock | None = None,
-    battery_level_source_type: BatteryLevelSourceType = BatteryLevelSourceType.ATTRIBUTE,
-    battery_level_attribute: str | None = None,
-    battery_level_entity_id: str | None = None,
-) -> HassChargingController:
+def _get_instance(*, client: MagicMock | None = None) -> HassChargingController:
     """Get a mocked instance of HassChargingController."""
     return HassChargingController(
         client or _mock_client(),
         entity_id="vacuum.test",
-        battery_level_source_type=battery_level_source_type,
-        battery_level_attribute=battery_level_attribute,
-        battery_level_entity_id=battery_level_entity_id,
     )
 
 
 def _mock_client() -> MagicMock:
     client = MagicMock(spec=HomeAssistantManager)
     client.get_config.return_value = {}
+    client.get_entity_data.return_value = _no_registry_data()
     return client

--- a/utils/measure/tests/runner/test_charging.py
+++ b/utils/measure/tests/runner/test_charging.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, call
 
-from measure.controller.charging.const import ChargingDeviceType
+from measure.controller.charging.const import ATTR_BATTERY_LEVEL, ChargingDeviceType
 from measure.controller.charging.controller import ChargingController
 from measure.controller.charging.spec import DummyChargingControllerSpec
 from measure.execution import RunInteraction
@@ -14,6 +14,7 @@ from measure.util.measure_util import MeasurementResult, MeasureUtil
 def test_run_reports_battery_and_charging_operating_points() -> None:
     controller = MagicMock(spec=ChargingController)
     controller.get_battery_level.side_effect = [99, 99, 100]
+    controller.battery_level_attribute = ATTR_BATTERY_LEVEL
     controller.is_charging.return_value = True
     measure_util = MagicMock(spec=MeasureUtil)
     measure_util.take_measurement.return_value = MeasurementResult(power=10.5, voltages=[])
@@ -41,3 +42,28 @@ def test_run_reports_battery_and_charging_operating_points() -> None:
         {"type": "charging", "battery_level": 99, "charging": True},
         {"type": "charging", "battery_level": 100, "charging": True},
     ]
+
+
+def test_generated_profile_uses_discovered_battery_sensor_state() -> None:
+    controller = MagicMock(spec=ChargingController)
+    controller.battery_level_attribute = None
+    runner = ChargingRunner(MagicMock(spec=MeasureUtil), MeasurementParameters(), controller)
+    runner.charging_device_type = ChargingDeviceType.VACUUM_ROBOT
+
+    model_data = runner._build_model_json_data({50: [10.0]})  # noqa: SLF001
+
+    assert model_data["linear_config"] == {"calibrate": ["50 -> 10.0"]}
+
+
+def test_generated_profile_keeps_battery_level_attribute_fallback() -> None:
+    controller = MagicMock(spec=ChargingController)
+    controller.battery_level_attribute = ATTR_BATTERY_LEVEL
+    runner = ChargingRunner(MagicMock(spec=MeasureUtil), MeasurementParameters(), controller)
+    runner.charging_device_type = ChargingDeviceType.VACUUM_ROBOT
+
+    model_data = runner._build_model_json_data({50: [10.0]})  # noqa: SLF001
+
+    assert model_data["linear_config"] == {
+        "attribute": ATTR_BATTERY_LEVEL,
+        "calibrate": ["50 -> 10.0"],
+    }

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -50,12 +50,15 @@ class FakeClient:
             SimpleNamespace(entity_id="sensor.test_power", device_id="meter-device"),
             SimpleNamespace(entity_id="sensor.test_voltage", device_id="meter-device"),
             SimpleNamespace(entity_id="light.test", device_id="light-device"),
+            SimpleNamespace(entity_id="vacuum.test", device_id="vacuum-device"),
+            SimpleNamespace(entity_id="sensor.vacuum_battery", device_id="vacuum-device"),
         ]
 
     def get_device_registry(self) -> list[dict[str, object]]:
         return [
             {"id": "meter-device", "model_id": "PM-001", "model": "Power Meter"},
             {"id": "light-device", "model_id": None, "model": "Hue White Ambiance"},
+            {"id": "vacuum-device", "model_id": None, "model": "Test Vacuum"},
         ]
 
     def get_entities(self) -> dict[str, SimpleNamespace]:
@@ -103,6 +106,13 @@ class FakeClient:
                         friendly_name="Test voltage",
                         device_class="voltage",
                         unit_of_measurement="V",
+                    ),
+                    "vacuum_battery": entity(
+                        "sensor.vacuum_battery",
+                        "80",
+                        friendly_name="Vacuum battery",
+                        device_class="battery",
+                        unit_of_measurement="%",
                     ),
                     "temperature": entity("sensor.temperature", "20", unit_of_measurement="°C"),
                     "unknown_power": entity(
@@ -347,6 +357,22 @@ def test_dummy_load_preflight_requires_voltage_and_includes_calibration_time(tmp
     response = test_client.post("/api/preflight", json=request)
     assert response.status_code == 422
     assert "voltage sensor is required" in response.json()["message"]
+
+
+def test_charging_preflight_returns_discovered_battery_sensor(tmp_path: Path) -> None:
+    response = client(tmp_path).post(
+        "/api/preflight",
+        json={
+            "measure_type": "charging",
+            "power_meter": {"type": "hass", "entity_id": "sensor.test_power"},
+            "controller": {"type": "hass", "entity_id": "vacuum.test"},
+            "charging_device_type": "vacuum_robot",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["battery_level_entity_id"] == "sensor.vacuum_battery"
+    assert response.json()["battery_level_attribute"] is None
 
 
 def test_shelly_dummy_load_preflight_builds_and_probes_the_meter_once(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_cli_questions.py
+++ b/utils/measure/tests/test_cli_questions.py
@@ -7,14 +7,7 @@ import inquirer
 from measure.cli.main import Measure
 from measure.cli.measurements import CLI_QUESTION_BUILDERS, measurement_questions
 from measure.const import QUESTION_DUMMY_LOAD, QUESTION_ENTITY_ID, QUESTION_MODEL_ID, MeasureType
-from measure.controller.charging.const import (
-    QUESTION_BATTERY_LEVEL_ATTRIBUTE,
-    QUESTION_BATTERY_LEVEL_ENTITY,
-    QUESTION_BATTERY_LEVEL_SOURCE_TYPE,
-    BatteryLevelSourceType,
-    ChargingControllerType,
-    ChargingDeviceType,
-)
+from measure.controller.charging.const import ChargingControllerType, ChargingDeviceType
 from measure.controller.fan.const import FanControllerType
 from measure.controller.light.const import LightControllerType, LutMode
 from measure.controller.media.const import MediaControllerType
@@ -218,7 +211,7 @@ def test_hass_controller_questions_list_domain_entities(
     assert question.choices == [entity_id]
 
 
-def test_hass_charging_questions_use_selected_device_and_battery_entities(
+def test_hass_charging_questions_use_selected_device(
     mock_config_factory: MockConfigFactory,
 ) -> None:
     environment = mock_config_factory({"selected_charging_controller": ChargingControllerType.HASS})
@@ -228,25 +221,12 @@ def test_hass_charging_questions_use_selected_device_and_battery_entities(
             EntityDomain.VACUUM,
             attributes=["battery_level", "status"],
         ),
-        _entity("sensor.vacuum_battery", EntityDomain.SENSOR, state="80"),
     )
     questions = measurement_questions(MeasureType.CHARGING, environment, entity_catalog)
 
     entity_question = next(question for question in questions if question.name == QUESTION_ENTITY_ID)
     entity_question.answers = {QUESTION_CHARGING_DEVICE_TYPE: ChargingDeviceType.VACUUM_ROBOT}
     assert entity_question.choices == ["vacuum.downstairs"]
-
-    attribute_question = next(question for question in questions if question.name == QUESTION_BATTERY_LEVEL_ATTRIBUTE)
-    attribute_question.answers = {
-        QUESTION_ENTITY_ID: "vacuum.downstairs",
-        QUESTION_BATTERY_LEVEL_SOURCE_TYPE: BatteryLevelSourceType.ATTRIBUTE,
-    }
-    assert attribute_question.choices == ["battery_level", "status"]
-    assert attribute_question.ignore is True
-
-    battery_entity_question = next(question for question in questions if question.name == QUESTION_BATTERY_LEVEL_ENTITY)
-    battery_entity_question.answers = {QUESTION_BATTERY_LEVEL_SOURCE_TYPE: BatteryLevelSourceType.ENTITY}
-    assert battery_entity_question.choices == ["sensor.vacuum_battery"]
 
 
 def test_hue_target_is_entered_directly(mock_config_factory: MockConfigFactory) -> None:

--- a/utils/measure/tests/test_preflight.py
+++ b/utils/measure/tests/test_preflight.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from measure.controller.charging.const import BatteryLevelSourceType
 from measure.controller.charging.spec import HassChargingControllerSpec
 from measure.controller.fan.spec import HassFanControllerSpec
 from measure.controller.light.const import LutMode
@@ -32,6 +31,7 @@ class Entity(EntityRecord):
     max_mired: int | None = None
     state: str = "available"
     attribute_names: list[str] = field(default_factory=list)
+    device_id: str | None = None
 
 
 def preflight(
@@ -235,45 +235,51 @@ def test_preflight_rejects_charging_type_entity_domain_mismatch() -> None:
         checker.validate(request)
 
 
-def test_preflight_rejects_missing_charging_battery_attribute() -> None:
-    request = ChargingMeasurementRequest(
+def _charging_request() -> ChargingMeasurementRequest:
+    return ChargingMeasurementRequest(
         power_meter=HassPowerMeterSpec(entity_id="sensor.power"),
-        controller=HassChargingControllerSpec(entity_id="vacuum.test", battery_level_attribute="charge_percent"),
+        controller=HassChargingControllerSpec(entity_id="vacuum.test"),
         charging_device_type="vacuum_robot",
     )
 
-    with pytest.raises(PreflightError, match=r"charge_percent.*not available"):
-        preflight(base_entities()).validate(request)
+
+def test_preflight_rejects_missing_charging_battery_source() -> None:
+    """Neither a battery sensor on the device nor the battery_level attribute is available."""
+    entities = base_entities() | {("vacuum", None): [Entity("vacuum.test", attribute_names=[])]}
+
+    with pytest.raises(PreflightError, match=r"battery_level is not available"):
+        preflight(entities).validate(_charging_request())
 
 
-@pytest.mark.parametrize(
-    ("battery_entity", "entities", "message"),
-    [
-        ("sensor.missing", base_entities(), "battery level sensor is unavailable"),
-        (
-            "sensor.battery",
-            base_entities() | {("sensor", None): [Entity("sensor.battery", state="unknown")]},
-            "numeric percentage",
-        ),
-    ],
-)
-def test_preflight_rejects_invalid_charging_battery_sensor(
-    battery_entity: str,
-    entities: dict[tuple[str | None, str | None], list[Entity]],
-    message: str,
-) -> None:
-    request = ChargingMeasurementRequest(
-        power_meter=HassPowerMeterSpec(entity_id="sensor.power"),
-        controller=HassChargingControllerSpec(
-            entity_id="vacuum.test",
-            battery_level_source_type=BatteryLevelSourceType.ENTITY,
-            battery_level_entity_id=battery_entity,
-        ),
-        charging_device_type="vacuum_robot",
-    )
+def test_preflight_accepts_charging_with_related_battery_sensor() -> None:
+    """A battery sensor on the same device is used even without the battery_level attribute."""
+    entities = base_entities() | {
+        ("vacuum", None): [Entity("vacuum.test", attribute_names=[], device_id="vacuum-device")],
+        (None, "battery"): [Entity("sensor.vacuum_battery", state="80", device_id="vacuum-device")],
+    }
 
-    with pytest.raises(PreflightError, match=message):
-        preflight(entities).validate(request)
+    result = preflight(entities).validate(_charging_request())
+
+    assert result.warnings == ()
+    assert result.battery_level_entity_id == "sensor.vacuum_battery"
+    assert result.battery_level_attribute is None
+
+
+def test_preflight_reports_battery_level_attribute_fallback() -> None:
+    result = preflight(base_entities()).validate(_charging_request())
+
+    assert result.battery_level_entity_id is None
+    assert result.battery_level_attribute == "battery_level"
+
+
+def test_preflight_rejects_non_numeric_related_battery_sensor() -> None:
+    entities = base_entities() | {
+        ("vacuum", None): [Entity("vacuum.test", attribute_names=[], device_id="vacuum-device")],
+        (None, "battery"): [Entity("sensor.vacuum_battery", state="unknown", device_id="vacuum-device")],
+    }
+
+    with pytest.raises(PreflightError, match="numeric percentage"):
+        preflight(entities).validate(_charging_request())
 
 
 def test_light_preflight_accepts_dummy_controller_without_entity_checks() -> None:

--- a/utils/measure/tests/test_request.py
+++ b/utils/measure/tests/test_request.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from measure.cli.request_adapter import request_from_answers
 from measure.const import PARAMETER_LIMITS, QUESTION_ENTITY_ID, QUESTION_MEASURE_DEVICE, MeasureType
-from measure.controller.charging.const import BatteryLevelSourceType
-from measure.controller.charging.spec import HassChargingControllerSpec
 from measure.controller.light.const import LightControllerType, LutMode
 from measure.powermeter.const import PowerMeterType
 from measure.powermeter.spec import DummyPowerMeterSpec
@@ -134,14 +132,6 @@ def test_request_rejects_dummy_load_with_synthetic_power_meter() -> None:
     dummy_load = DummyLoadCalibrationRequest(description="test load")
     with pytest.raises(ValidationError, match="synthetic"):
         AverageMeasurementRequest(power_meter=power_meter, dummy_load=dummy_load)
-
-
-def test_charging_controller_requires_battery_sensor_for_entity_source() -> None:
-    with pytest.raises(ValidationError, match="battery_level_entity_id"):
-        HassChargingControllerSpec(
-            entity_id="vacuum.test",
-            battery_level_source_type=BatteryLevelSourceType.ENTITY,
-        )
 
 
 def test_cli_request_contains_only_resolved_measurement_input(mock_config_factory: MockConfigFactory) -> None:


### PR DESCRIPTION
## Summary

- remove manual battery source selection from charging measurements
- auto-discover a battery sensor on the same Home Assistant device, with the existing `battery_level` attribute as fallback
- show the resolved battery source in the preflight review
- keep generated profiles aligned with the source used during measurement

## Root cause

Charging measurements required users to choose how battery level was exposed. The initial refactor moved that choice to automatic discovery, but did not propagate the resolved source to generated profiles or the preflight UI, and repeated full entity discovery for every battery sample.

## Impact

Vacuum and lawn mower measurements now resolve their battery source automatically and keep that source stable for the run. Sensor-based profiles omit the attribute override so Powercalc can use the related battery entity, while attribute-based integrations retain the compatibility fallback.

## Validation

- `uv run pytest` in `utils/measure`: 415 passed
- frontend Vitest suite: 98 passed
- frontend TypeScript typecheck passed
- Ruff passed
- focused strict mypy passed
- repository pre-commit hooks passed
