### PR TITLE
fix: prevent own group sensors being added to group

### DIFF
--- a/custom_components/powercalc/group_include/include.py
+++ b/custom_components/powercalc/group_include/include.py
@@ -9,9 +9,13 @@ from homeassistant.helpers.entity_registry import RegistryEntry
 
 from custom_components.powercalc.common import create_source_entity
 from custom_components.powercalc.const import (
+    CONF_SENSOR_TYPE,
     DATA_CONFIGURED_ENTITIES,
     DATA_ENTITIES,
     DOMAIN,
+    ENTRY_DATA_ENERGY_ENTITY,
+    ENTRY_DATA_POWER_ENTITY,
+    SensorType,
 )
 from custom_components.powercalc.discovery import get_power_profile_by_source_entity
 from custom_components.powercalc.power_profile.power_profile import SUPPORTED_DOMAINS
@@ -71,7 +75,7 @@ async def find_entities(
             resolved_entities.append(existing)
             continue
 
-        if _should_skip_source_entity(source_entity, include_non_powercalc):
+        if _should_skip_source_entity(hass, source_entity, include_non_powercalc):
             continue
 
         real_sensor = _create_real_sensor(source_entity)
@@ -92,8 +96,33 @@ async def find_entities(
     return FindEntitiesResult(resolved_entities, discoverable_entities)
 
 
-def _should_skip_source_entity(source_entity: RegistryEntry, include_non_powercalc: bool) -> bool:
-    return source_entity.domain == sensor.DOMAIN and source_entity.platform != DOMAIN and not include_non_powercalc
+def _should_skip_persisted_powercalc_entity(hass: HomeAssistant, source_entity: RegistryEntry) -> bool:
+    """Exclude derived Powercalc entities which are not available as runtime objects yet."""
+    if source_entity.platform != DOMAIN or not source_entity.config_entry_id:
+        return False
+
+    config_entry = hass.config_entries.async_get_entry(source_entity.config_entry_id)
+    if config_entry is None:
+        return False
+
+    if config_entry.data.get(CONF_SENSOR_TYPE) == SensorType.GROUP:
+        return True
+
+    main_entity_ids = {
+        config_entry.data.get(ENTRY_DATA_POWER_ENTITY),
+        config_entry.data.get(ENTRY_DATA_ENERGY_ENTITY),
+    }
+    return source_entity.entity_id not in main_entity_ids
+
+
+def _should_skip_source_entity(
+    hass: HomeAssistant,
+    source_entity: RegistryEntry,
+    include_non_powercalc: bool,
+) -> bool:
+    return (
+        source_entity.domain == sensor.DOMAIN and source_entity.platform != DOMAIN and not include_non_powercalc
+    ) or _should_skip_persisted_powercalc_entity(hass, source_entity)
 
 
 def _create_real_sensor(source_entity: RegistryEntry) -> Entity | None:

--- a/custom_components/powercalc/group_include/include.py
+++ b/custom_components/powercalc/group_include/include.py
@@ -57,7 +57,7 @@ async def find_entities(
     resolved_entities: list[Entity] = []
     discoverable_entities: list[str] = []
 
-    source_entities = get_filtered_entity_list(hass, _build_filter(entity_filter))
+    source_entities = get_filtered_entity_list(hass, _build_filter(hass, entity_filter, include_non_powercalc))
 
     if _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: no cover
         _LOGGER.debug("Source entities: %s", [entity.entity_id for entity in source_entities])
@@ -73,9 +73,6 @@ async def find_entities(
         existing = powercalc_entities.get(entity_id)
         if existing:
             resolved_entities.append(existing)
-            continue
-
-        if _should_skip_source_entity(hass, source_entity, include_non_powercalc):
             continue
 
         real_sensor = _create_real_sensor(source_entity)
@@ -96,33 +93,31 @@ async def find_entities(
     return FindEntitiesResult(resolved_entities, discoverable_entities)
 
 
-def _should_skip_persisted_powercalc_entity(hass: HomeAssistant, source_entity: RegistryEntry) -> bool:
-    """Exclude derived Powercalc entities which are not available as runtime objects yet."""
-    if source_entity.platform != DOMAIN or not source_entity.config_entry_id:
-        return False
+def _is_source_entity_eligible(
+    hass: HomeAssistant,
+    source_entity: RegistryEntry,
+    include_non_powercalc: bool,
+) -> bool:
+    """Return whether a registry entity is eligible for Powercalc discovery."""
+    if source_entity.platform != DOMAIN:
+        return include_non_powercalc or source_entity.domain != sensor.DOMAIN
+
+    # YAML-created Powercalc entities have no config entry and are classified by their runtime type later.
+    if source_entity.config_entry_id is None:
+        return True
 
     config_entry = hass.config_entries.async_get_entry(source_entity.config_entry_id)
     if config_entry is None:
         return False
 
     if config_entry.data.get(CONF_SENSOR_TYPE) == SensorType.GROUP:
-        return True
+        return False
 
     main_entity_ids = {
         config_entry.data.get(ENTRY_DATA_POWER_ENTITY),
         config_entry.data.get(ENTRY_DATA_ENERGY_ENTITY),
     }
-    return source_entity.entity_id not in main_entity_ids
-
-
-def _should_skip_source_entity(
-    hass: HomeAssistant,
-    source_entity: RegistryEntry,
-    include_non_powercalc: bool,
-) -> bool:
-    return (
-        source_entity.domain == sensor.DOMAIN and source_entity.platform != DOMAIN and not include_non_powercalc
-    ) or _should_skip_persisted_powercalc_entity(hass, source_entity)
+    return source_entity.entity_id in main_entity_ids
 
 
 def _create_real_sensor(source_entity: RegistryEntry) -> Entity | None:
@@ -149,10 +144,15 @@ async def _is_discoverable_source_entity(hass: HomeAssistant, source_entity: Reg
     )
 
 
-def _build_filter(entity_filter: EntityFilter | None) -> EntityFilter:
+def _build_filter(
+    hass: HomeAssistant,
+    entity_filter: EntityFilter | None,
+    include_non_powercalc: bool,
+) -> EntityFilter:
     base_filter = CompositeFilter(
         [
             DomainFilter(SUPPORTED_DOMAINS),
+            LambdaFilter(lambda entity: _is_source_entity_eligible(hass, entity, include_non_powercalc)),
             LambdaFilter(lambda entity: entity.platform != "utility_meter"),
             LambdaFilter(lambda entity: not str(entity.unique_id).startswith("powercalc_standby_group")),
             LambdaFilter(lambda entity: "tracked_" not in str(entity.unique_id)),

--- a/tests/sensors/group/test_custom.py
+++ b/tests/sensors/group/test_custom.py
@@ -2198,54 +2198,22 @@ async def test_resolve_entity_ids_area_excludes_persisted_powercalc_derived_enti
     mock_registry(
         hass,
         {
-            "sensor.bedside_lamp_power": RegistryEntryWithDefaults(
-                entity_id="sensor.bedside_lamp_power",
-                unique_id="bedside_lamp_power",
+            entity_id: RegistryEntryWithDefaults(
+                entity_id=entity_id,
+                unique_id=entity_id,
                 platform=DOMAIN,
-                config_entry_id=sensor_entry.entry_id,
-                device_class=SensorDeviceClass.POWER,
+                config_entry_id=config_entry_id,
+                device_class=device_class,
                 area_id=area.id,
-            ),
-            "sensor.bedside_lamp_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.bedside_lamp_energy",
-                unique_id="bedside_lamp_energy",
-                platform=DOMAIN,
-                config_entry_id=sensor_entry.entry_id,
-                device_class=SensorDeviceClass.ENERGY,
-                area_id=area.id,
-            ),
-            "sensor.bedside_lamp_energy_daily": RegistryEntryWithDefaults(
-                entity_id="sensor.bedside_lamp_energy_daily",
-                unique_id="bedside_lamp_energy_daily",
-                platform=DOMAIN,
-                config_entry_id=sensor_entry.entry_id,
-                device_class=SensorDeviceClass.ENERGY,
-                area_id=area.id,
-            ),
-            "sensor.bedroom_power": RegistryEntryWithDefaults(
-                entity_id="sensor.bedroom_power",
-                unique_id="bedroom_power",
-                platform=DOMAIN,
-                config_entry_id=group_entry.entry_id,
-                device_class=SensorDeviceClass.POWER,
-                area_id=area.id,
-            ),
-            "sensor.bedroom_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.bedroom_energy",
-                unique_id="bedroom_energy",
-                platform=DOMAIN,
-                config_entry_id=group_entry.entry_id,
-                device_class=SensorDeviceClass.ENERGY,
-                area_id=area.id,
-            ),
-            "sensor.bedroom_energy_daily": RegistryEntryWithDefaults(
-                entity_id="sensor.bedroom_energy_daily",
-                unique_id="bedroom_energy_daily",
-                platform=DOMAIN,
-                config_entry_id=group_entry.entry_id,
-                device_class=SensorDeviceClass.ENERGY,
-                area_id=area.id,
-            ),
+            )
+            for entity_id, config_entry_id, device_class in (
+                ("sensor.bedside_lamp_power", sensor_entry.entry_id, SensorDeviceClass.POWER),
+                ("sensor.bedside_lamp_energy", sensor_entry.entry_id, SensorDeviceClass.ENERGY),
+                ("sensor.bedside_lamp_energy_daily", sensor_entry.entry_id, SensorDeviceClass.ENERGY),
+                ("sensor.bedroom_power", group_entry.entry_id, SensorDeviceClass.POWER),
+                ("sensor.bedroom_energy", group_entry.entry_id, SensorDeviceClass.ENERGY),
+                ("sensor.bedroom_energy_daily", group_entry.entry_id, SensorDeviceClass.ENERGY),
+            )
         },
     )
 

--- a/tests/sensors/group/test_custom.py
+++ b/tests/sensors/group/test_custom.py
@@ -84,6 +84,7 @@ from custom_components.powercalc.const import (
     DOMAIN,
     DUMMY_ENTITY_ID,
     ENTRY_DATA_ENERGY_ENTITY,
+    ENTRY_DATA_POWER_ENTITY,
     SERVICE_CALIBRATE_ENERGY,
     SERVICE_DEBUG_GROUP,
     SERVICE_GET_GROUP_ENTITIES,
@@ -2166,6 +2167,93 @@ async def test_resolve_entity_ids_area(hass: HomeAssistant, area_registry: AreaR
 
     resolved = await resolve_entity_ids_recursively(hass, config_entry, SensorDeviceClass.POWER)
     assert resolved == {"sensor.test_power"}
+
+
+async def test_resolve_entity_ids_area_excludes_persisted_powercalc_derived_entities(
+    hass: HomeAssistant,
+    area_registry: AreaRegistry,
+) -> None:
+    area = area_registry.async_get_or_create("Bedroom")
+
+    sensor_entry = await create_mock_config_entry(
+        hass,
+        {
+            CONF_SENSOR_TYPE: SensorType.VIRTUAL_POWER,
+            ENTRY_DATA_POWER_ENTITY: "sensor.bedside_lamp_power",
+            ENTRY_DATA_ENERGY_ENTITY: "sensor.bedside_lamp_energy",
+        },
+        setup=False,
+    )
+    group_entry = await create_mock_config_entry(
+        hass,
+        {
+            CONF_AREA: area.id,
+            CONF_NAME: "Bedroom",
+            CONF_SENSOR_TYPE: SensorType.GROUP,
+            ENTRY_DATA_ENERGY_ENTITY: "sensor.bedroom_energy",
+        },
+        setup=False,
+    )
+
+    mock_registry(
+        hass,
+        {
+            "sensor.bedside_lamp_power": RegistryEntryWithDefaults(
+                entity_id="sensor.bedside_lamp_power",
+                unique_id="bedside_lamp_power",
+                platform=DOMAIN,
+                config_entry_id=sensor_entry.entry_id,
+                device_class=SensorDeviceClass.POWER,
+                area_id=area.id,
+            ),
+            "sensor.bedside_lamp_energy": RegistryEntryWithDefaults(
+                entity_id="sensor.bedside_lamp_energy",
+                unique_id="bedside_lamp_energy",
+                platform=DOMAIN,
+                config_entry_id=sensor_entry.entry_id,
+                device_class=SensorDeviceClass.ENERGY,
+                area_id=area.id,
+            ),
+            "sensor.bedside_lamp_energy_daily": RegistryEntryWithDefaults(
+                entity_id="sensor.bedside_lamp_energy_daily",
+                unique_id="bedside_lamp_energy_daily",
+                platform=DOMAIN,
+                config_entry_id=sensor_entry.entry_id,
+                device_class=SensorDeviceClass.ENERGY,
+                area_id=area.id,
+            ),
+            "sensor.bedroom_power": RegistryEntryWithDefaults(
+                entity_id="sensor.bedroom_power",
+                unique_id="bedroom_power",
+                platform=DOMAIN,
+                config_entry_id=group_entry.entry_id,
+                device_class=SensorDeviceClass.POWER,
+                area_id=area.id,
+            ),
+            "sensor.bedroom_energy": RegistryEntryWithDefaults(
+                entity_id="sensor.bedroom_energy",
+                unique_id="bedroom_energy",
+                platform=DOMAIN,
+                config_entry_id=group_entry.entry_id,
+                device_class=SensorDeviceClass.ENERGY,
+                area_id=area.id,
+            ),
+            "sensor.bedroom_energy_daily": RegistryEntryWithDefaults(
+                entity_id="sensor.bedroom_energy_daily",
+                unique_id="bedroom_energy_daily",
+                platform=DOMAIN,
+                config_entry_id=group_entry.entry_id,
+                device_class=SensorDeviceClass.ENERGY,
+                area_id=area.id,
+            ),
+        },
+    )
+
+    resolved_power = await resolve_entity_ids_recursively(hass, group_entry, SensorDeviceClass.POWER)
+    assert resolved_power == {"sensor.bedside_lamp_power"}
+
+    resolved_energy = await resolve_entity_ids_recursively(hass, group_entry, SensorDeviceClass.ENERGY)
+    assert resolved_energy == {"sensor.bedside_lamp_energy"}
 
 
 async def test_resolve_entity_ids_skips_tasmota_yesterday_and_today(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Prevent own group sensors to be added to group when using include by area
