### PR TITLE
Add unknown ddfdsfd power profile

### DIFF
--- a/profile_library/unknown/ddfdsfd/model.json
+++ b/profile_library/unknown/ddfdsfd/model.json
@@ -1,0 +1,29 @@
+{
+  "author_info": {
+    "github": "bramski80",
+    "name": "test"
+  },
+  "calculation_enabled_condition": "{{ is_state('[[entity]]', 'playing') }}",
+  "calculation_strategy": "linear",
+  "created_at": "2026-07-24T10:44:33Z",
+  "device_type": "smart_speaker",
+  "linear_config": {
+    "calibrate": [
+      "10 -> 75.46",
+      "100 -> 96.5",
+      "0 -> 30.69"
+    ]
+  },
+  "max_voltage": 233.0,
+  "measure_description": "Measured with utils/measure script",
+  "measure_device": "fgdfgdfdfg",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 1,
+    "SLEEP_TIME": 0,
+    "VERSION": "master"
+  },
+  "min_voltage": 233.0,
+  "name": "fsdffd",
+  "standby_power": 94.06
+}

--- a/profile_library/unknown/manufacturer.json
+++ b/profile_library/unknown/manufacturer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Unknown",
+  "aliases": []
+}


### PR DESCRIPTION
## Device information

- Manufacturer: Unknown
- Model ID: ddfdsfd
- Product name: fsdffd

## Home Assistant Device information

Generated by Powercalc Measure from a completed measurement session.

## Checklist

- [x] I have created a single PR per device.
- [x] For lights, only generated gzipped lookup tables are included.
- [x] I reviewed the generated files and JSON in Powercalc Measure.

## Additional info

fsfsdfds

### Generated files

- `profile_library/unknown/ddfdsfd/model.json`
- `profile_library/unknown/manufacturer.json`

### Duplicate warnings

- None
