### PR TITLE
Fix Dyson TP07 composite conditions

### DIFF
--- a/profile_library/dyson/TP07/model.json
+++ b/profile_library/dyson/TP07/model.json
@@ -12,13 +12,17 @@
           {
             "attribute": "oscillating",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": true
           },
           {
             "attribute": "direction",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": "reverse"
           }
         ]
@@ -55,13 +59,17 @@
           {
             "attribute": "oscillating",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": true
           },
           {
             "attribute": "direction",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": "forward"
           }
         ]
@@ -98,13 +106,17 @@
           {
             "attribute": "oscillating",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": false
           },
           {
             "attribute": "direction",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": "reverse"
           }
         ]
@@ -141,13 +153,17 @@
           {
             "attribute": "oscillating",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": false
           },
           {
             "attribute": "direction",
             "condition": "state",
-            "entity_id": "[[entity]]",
+            "entity_id": [
+              "[[entity]]"
+            ],
             "state": "forward"
           }
         ]


### PR DESCRIPTION
## What changed

- Encode each TP07 composite condition target as a one-item entity list.

## Why

The profile used scalar `entity_id` placeholders inside nested `and` conditions. Profiles loaded directly from the library do not pass through the same schema normalization as user configuration. With current Home Assistant condition handling, the scalar entity ID was iterated character by character, so every branch raised a condition error and the power sensor became unavailable whenever the fan was on.

Using the accepted list form preserves the resolved source entity as one target and restores the expected calibrated power values.

This fixes the profile added in #4358.

## Validation

- Full test suite: `1037 passed`
- Ruff: passed
- `model_schema.json`: passed
- Manual runtime matrix:
  - oscillating + reverse at 100%: 28.48 W
  - oscillating + forward at 100%: 28.13 W
  - stationary + reverse at 100%: 27.37 W
  - stationary + forward at 100%: 27.36 W
  - standby: 1.13 W
