### PR TITLE
Fix composite strategy validation and normalization issues

### DIFF
--- a/custom_components/powercalc/strategy/composite.py
+++ b/custom_components/powercalc/strategy/composite.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 import logging
 from typing import Any
 
-from homeassistant.const import CONF_ATTRIBUTE, CONF_CONDITION, CONF_ENTITY_ID, STATE_OFF
+from homeassistant.const import CONF_ATTRIBUTE, CONF_CONDITION, CONF_CONDITIONS, CONF_ENTITY_ID, STATE_OFF
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ConditionError
 from homeassistant.helpers.condition import ConditionCheckerType
@@ -41,14 +41,52 @@ class CompositeMode(StrEnum):
     SUM_ALL = "sum_all"
 
 
+class ConditionType(StrEnum):
+    """Condition types supported by the composite strategy.
+
+    Home Assistant has no constants for these, it uses string literals itself.
+    """
+
+    AND = "and"
+    DEVICE = "device"
+    NOT = "not"
+    NUMERIC_STATE = "numeric_state"
+    OR = "or"
+    STATE = "state"
+    TEMPLATE = "template"
+
+
+COMPOUND_CONDITIONS = (ConditionType.AND, ConditionType.OR, ConditionType.NOT)
+ENTITY_CONDITIONS = (ConditionType.STATE, ConditionType.NUMERIC_STATE)
+
 DEFAULT_MODE = CompositeMode.STOP_AT_FIRST
 
 
 def make_entity_id_optional(schema: vol.Schema) -> vol.Schema:
     """Make entity_id optional in schema."""
-    schema = schema.schema
-    schema[vol.Optional(CONF_ENTITY_ID)] = schema.pop(vol.Required(CONF_ENTITY_ID))  # type: ignore[index, attr-defined]
-    return vol.Schema(schema)
+    # Copy, the schemas we get passed here are module level globals of Home Assistant itself
+    schema_dict = dict(schema.schema)
+    schema_dict[vol.Optional(CONF_ENTITY_ID)] = schema_dict.pop(vol.Required(CONF_ENTITY_ID))
+    return vol.Schema(schema_dict)
+
+
+def get_compound_schema(condition_type: ConditionType) -> vol.Schema:
+    """Return the schema for and/or/not conditions.
+
+    Home Assistant's own compound schemas recurse into `cv.CONDITION_SCHEMA`, which requires entity_id.
+    We recurse into our own schema instead, so entity_id stays optional at any nesting level
+    and can be defaulted to the source entity.
+    """
+    return vol.Schema(
+        {
+            **cv.CONDITION_BASE_SCHEMA,
+            vol.Required(CONF_CONDITION): condition_type.value,
+            vol.Required(CONF_CONDITIONS): vol.All(
+                cv.ensure_list,
+                [lambda value: CONDITION_SCHEMA(value)],
+            ),
+        },
+    )
 
 
 def get_numeric_state_schema() -> vol.Schema:
@@ -86,13 +124,13 @@ CONDITION_SCHEMA: vol.Schema = vol.Schema(
             cv.key_value_schemas(
                 CONF_CONDITION,
                 {
-                    "and": cv.AND_CONDITION_SCHEMA,
-                    "device": cv.DEVICE_CONDITION_SCHEMA,
-                    "not": cv.NOT_CONDITION_SCHEMA,
-                    "numeric_state": get_numeric_state_schema(),
-                    "or": cv.OR_CONDITION_SCHEMA,
-                    "state": get_state_schema,
-                    "template": cv.TEMPLATE_CONDITION_SCHEMA,
+                    ConditionType.AND: get_compound_schema(ConditionType.AND),
+                    ConditionType.DEVICE: cv.DEVICE_CONDITION_SCHEMA,
+                    ConditionType.NOT: get_compound_schema(ConditionType.NOT),
+                    ConditionType.NUMERIC_STATE: get_numeric_state_schema(),
+                    ConditionType.OR: get_compound_schema(ConditionType.OR),
+                    ConditionType.STATE: get_state_schema,
+                    ConditionType.TEMPLATE: cv.TEMPLATE_CONDITION_SCHEMA,
                 },
             ),
         ),

--- a/custom_components/powercalc/strategy/factory.py
+++ b/custom_components/powercalc/strategy/factory.py
@@ -4,12 +4,13 @@ from collections.abc import Callable
 from decimal import Decimal
 from typing import Any, cast
 
-from homeassistant.const import CONF_CONDITION, CONF_ENTITIES, CONF_ENTITY_ID
+from homeassistant.const import CONF_CONDITION, CONF_CONDITIONS, CONF_ENTITIES, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import condition
 from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType
+import voluptuous as vol
 
 from custom_components.powercalc.common import SourceEntity
 from custom_components.powercalc.const import (
@@ -31,7 +32,14 @@ from custom_components.powercalc.errors import (
 )
 from custom_components.powercalc.power_profile.power_profile import PowerProfile
 
-from .composite import DEFAULT_MODE, CompositeStrategy, SubStrategy
+from .composite import (
+    COMPOUND_CONDITIONS,
+    CONFIG_SCHEMA as COMPOSITE_SCHEMA,
+    DEFAULT_MODE,
+    ENTITY_CONDITIONS,
+    CompositeStrategy,
+    SubStrategy,
+)
 from .fixed import FixedStrategy
 from .linear import LinearStrategy
 from .lut import LutRegistry, LutStrategy
@@ -40,6 +48,24 @@ from .playbook import PlaybookStrategy
 from .selector import detect_calculation_strategy
 from .strategy_interface import PowerCalculationStrategyInterface
 from .wled import WledStrategy
+
+
+def resolve_condition_entity_ids(condition_config: ConfigType, source_entity: SourceEntity) -> ConfigType:
+    """Default entity_id to the source entity for conditions which omit it.
+
+    Recurses into and/or/not, so nested conditions are treated the same as top level ones.
+    Returns a copy, to prevent mutating the profile configuration.
+    """
+    resolved = dict(condition_config)
+    condition_type = resolved.get(CONF_CONDITION)
+    if condition_type in COMPOUND_CONDITIONS:
+        resolved[CONF_CONDITIONS] = [
+            resolve_condition_entity_ids(sub_condition, source_entity)
+            for sub_condition in resolved.get(CONF_CONDITIONS, [])
+        ]
+    elif condition_type in ENTITY_CONDITIONS and CONF_ENTITY_ID not in resolved:
+        resolved[CONF_ENTITY_ID] = [source_entity.entity_id]
+    return resolved
 
 
 class PowerCalculatorStrategyFactory:
@@ -167,7 +193,7 @@ class PowerCalculatorStrategyFactory:
         composite_config: list | dict | None = config.get(CONF_COMPOSITE)
         if composite_config is None:
             if power_profile and power_profile.composite_config:
-                composite_config = power_profile.composite_config
+                composite_config = self._validate_composite_config(power_profile.composite_config)
             else:
                 raise StrategyConfigurationError("No composite configuration supplied")
 
@@ -183,11 +209,8 @@ class PowerCalculatorStrategyFactory:
             condition_instance = None
             condition_config = strategy_config.get(CONF_CONDITION)
             if condition_config:
-                condition_type = condition_config.get(CONF_CONDITION)
-                if condition_type in ["state", "numeric_state"] and CONF_ENTITY_ID not in condition_config:
-                    condition_config[CONF_ENTITY_ID] = [source_entity.entity_id]
-                if condition_type == "state":
-                    condition_config = condition.state_validate_config(self._hass, condition_config)
+                condition_config = resolve_condition_entity_ids(condition_config, source_entity)
+                condition_config = await condition.async_validate_condition_config(self._hass, condition_config)
                 condition_instance = await condition.async_from_config(
                     self._hass,
                     condition_config,
@@ -206,6 +229,19 @@ class PowerCalculatorStrategyFactory:
             raise StrategyConfigurationError("No strategies configured for composite strategy")
         strategies = [await _create_sub_strategy(config) for config in sub_strategies]
         return CompositeStrategy(self._hass, strategies, mode)
+
+    @staticmethod
+    def _validate_composite_config(composite_config: list | dict) -> list | dict:
+        """Validate the composite configuration of a library profile.
+
+        Configuration from YAML and the config flow is already validated by the sensor schema.
+        Library profiles are raw JSON, so validate them here as well to get the same normalization,
+        for example entity_id to a list and value_template to a Template instance.
+        """
+        try:
+            return cast(list | dict, COMPOSITE_SCHEMA(composite_config))
+        except vol.Invalid as err:
+            raise StrategyConfigurationError(f"Invalid composite configuration in profile: {err}") from err
 
     def _create_multi_switch(self, config: ConfigType, power_profile: PowerProfile | None) -> MultiSwitchStrategy:
         """Create instance of multi switch strategy."""

--- a/tests/power_profile/user_scenarios/test_dyson_tp07.py
+++ b/tests/power_profile/user_scenarios/test_dyson_tp07.py
@@ -1,0 +1,44 @@
+from homeassistant.components.fan import ATTR_PERCENTAGE
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
+
+from tests.common import assert_entity_state, run_powercalc_setup, set_states
+
+
+async def test_dyson_tp07(
+    hass: HomeAssistant,
+) -> None:
+    """
+    The profile uses nested `and` conditions with a scalar entity_id.
+
+    See https://github.com/bramstroker/homeassistant-powercalc/pull/4378
+    """
+    fan_entity = "fan.test"
+    power_entity = "sensor.test_power"
+    await run_powercalc_setup(hass, {"entity_id": fan_entity, "manufacturer": "dyson", "model": "TP07"})
+
+    assert hass.states.get(power_entity)
+
+    await set_states(
+        hass,
+        [(fan_entity, STATE_ON, {ATTR_PERCENTAGE: 100, "oscillating": True, "direction": "reverse"})],
+    )
+    assert_entity_state(hass, power_entity, "28.48")
+
+    await set_states(
+        hass,
+        [(fan_entity, STATE_ON, {ATTR_PERCENTAGE: 100, "oscillating": True, "direction": "forward"})],
+    )
+    assert_entity_state(hass, power_entity, "28.13")
+
+    await set_states(
+        hass,
+        [(fan_entity, STATE_ON, {ATTR_PERCENTAGE: 100, "oscillating": False, "direction": "reverse"})],
+    )
+    assert_entity_state(hass, power_entity, "27.37")
+
+    await set_states(
+        hass,
+        [(fan_entity, STATE_ON, {ATTR_PERCENTAGE: 100, "oscillating": False, "direction": "forward"})],
+    )
+    assert_entity_state(hass, power_entity, "27.36")

--- a/tests/strategy/test_composite.py
+++ b/tests/strategy/test_composite.py
@@ -370,6 +370,75 @@ async def test_composite_strategy_from_library_profile(hass: HomeAssistant) -> N
     assert_entity_state(hass, "sensor.test_power", "0.82")
 
 
+async def test_nested_conditions_from_library_profile(hass: HomeAssistant) -> None:
+    """Nested conditions in a library profile must be normalized the same way YAML configuration is.
+
+    A scalar entity_id was iterated character by character, making every condition raise,
+    and a nested condition omitting entity_id did not default to the source entity.
+    See https://github.com/bramstroker/homeassistant-powercalc/issues/4378
+    """
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_ENTITY_ID: "fan.test",
+            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("composite_nested"),
+        },
+    )
+
+    await set_states(hass, [("fan.test", STATE_ON, {"oscillating": True, "direction": "reverse"})])
+    assert_entity_state(hass, "sensor.test_power", "20.00")
+
+    await set_states(hass, [("fan.test", STATE_ON, {"oscillating": True, "direction": "forward"})])
+    assert_entity_state(hass, "sensor.test_power", "15.00")
+
+    await set_states(hass, [("fan.test", STATE_ON, {"oscillating": False, "direction": "forward"})])
+    assert_entity_state(hass, "sensor.test_power", "5.00")
+
+
+async def test_nested_condition_omit_entity_id(hass: HomeAssistant) -> None:
+    await set_states(hass, [("media_player.test", STATE_PAUSED, {"source": "HDMI1"})])
+    sensor_config = {
+        CONF_ENTITY_ID: "media_player.test",
+        CONF_COMPOSITE: [
+            {
+                CONF_CONDITION: {
+                    "condition": "and",
+                    "conditions": [
+                        {"condition": "state", "state": STATE_PLAYING},
+                        {"condition": "state", "attribute": "source", "state": "HDMI1"},
+                    ],
+                },
+                CONF_FIXED: {CONF_POWER: 20},
+            },
+            {
+                CONF_FIXED: {CONF_POWER: 2},
+            },
+        ],
+    }
+
+    await run_powercalc_setup(hass, sensor_config, {})
+
+    assert_entity_state(hass, "sensor.test_power", "2.00")
+
+    await set_states(hass, [("media_player.test", STATE_PLAYING, {"source": "HDMI1"})])
+    assert_entity_state(hass, "sensor.test_power", "20.00")
+
+    await set_states(hass, [("media_player.test", STATE_PLAYING, {"source": "HDMI2"})])
+    assert_entity_state(hass, "sensor.test_power", "2.00")
+
+
+async def test_invalid_composite_config_in_profile(hass: HomeAssistant) -> None:
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_ENTITY_ID: "light.test",
+            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("composite_invalid"),
+        },
+    )
+
+    assert not hass.states.get("sensor.test_power")
+
+
 async def test_composite_mode_sum(hass: HomeAssistant) -> None:
     await set_states(hass, [("sensor.test", 50)])
     sensor_config = {

--- a/tests/testing_config/powercalc/profiles/test/composite_invalid/model.json
+++ b/tests/testing_config/powercalc/profiles/test/composite_invalid/model.json
@@ -1,0 +1,24 @@
+{
+  "calculation_strategy": "composite",
+  "composite_config": [
+    {
+      "condition": {
+        "condition": "and",
+        "conditions": [
+          {
+            "condition": "state",
+            "entity_id": "not a valid entity id",
+            "state": "on"
+          }
+        ]
+      },
+      "fixed": {
+        "power": 10
+      }
+    }
+  ],
+  "device_type": "light",
+  "measure_device": "Test light",
+  "measure_method": "manual",
+  "name": "Test light"
+}

--- a/tests/testing_config/powercalc/profiles/test/composite_nested/model.json
+++ b/tests/testing_config/powercalc/profiles/test/composite_nested/model.json
@@ -1,0 +1,56 @@
+{
+  "calculation_strategy": "composite",
+  "composite_config": [
+    {
+      "condition": {
+        "condition": "and",
+        "conditions": [
+          {
+            "attribute": "oscillating",
+            "condition": "state",
+            "entity_id": "fan.test",
+            "state": true
+          },
+          {
+            "condition": "state",
+            "attribute": "direction",
+            "state": "reverse"
+          }
+        ]
+      },
+      "fixed": {
+        "power": 20
+      }
+    },
+    {
+      "condition": {
+        "condition": "and",
+        "conditions": [
+          {
+            "attribute": "oscillating",
+            "condition": "state",
+            "entity_id": "fan.test",
+            "state": true
+          },
+          {
+            "condition": "state",
+            "attribute": "direction",
+            "state": "forward"
+          }
+        ]
+      },
+      "fixed": {
+        "power": 15
+      }
+    },
+    {
+      "fixed": {
+        "power": 5
+      }
+    }
+  ],
+  "device_type": "fan",
+  "measure_device": "Test fan",
+  "measure_method": "manual",
+  "name": "Test fan"
+}


### PR DESCRIPTION
Composite configuration from library profiles is now validated with the same schema as YAML, so nested conditions get normalized (a scalar entity_id was iterated per character and made every condition raise) and entity_id may be omitted at any nesting level to default to the source entity.

Invalid composite config in a profile now fails at setup instead of silently producing an unavailable sensor.
