### PR TITLE
Handle repeated zero readings in the measure app

### DIFF
--- a/utils/measure/frontend/src/app-controller.test.ts
+++ b/utils/measure/frontend/src/app-controller.test.ts
@@ -450,6 +450,10 @@ describe("measure app controller", () => {
 
     onEvent?.({ sequence: 1, type: "sample", data: { power: 12.5 }, snapshot: { state: "running" } });
     expect(appState.samples).toEqual([12.5]);
+
+    const warning = "Discarding measurement: 0 watt was read from the power meter";
+    onEvent?.({ sequence: 2, type: "warning", data: { message: warning }, snapshot: { state: "running", warnings: [warning] } });
+    expect(appState.logs).toEqual([warning]);
   });
 
   it("reloads effective capabilities after saving measurement defaults", async () => {

--- a/utils/measure/frontend/src/app-controller.ts
+++ b/utils/measure/frontend/src/app-controller.ts
@@ -619,7 +619,7 @@ export class MeasureAppController {
   }
 
   private consumeEvent(event: SessionEvent): void {
-    if ((event.type === "log" || event.type === "checkpoint") && event.data.message) {
+    if ((event.type === "log" || event.type === "warning" || event.type === "checkpoint") && event.data.message) {
       this.state.logs = [...this.state.logs.slice(-39), event.data.message];
     }
     if (event.type === "sample" && typeof event.data.power === "number") {

--- a/utils/measure/frontend/src/components/result-view.ts
+++ b/utils/measure/frontend/src/components/result-view.ts
@@ -4,6 +4,7 @@ import { sharedStyles } from "../styles";
 import "./result-plot";
 
 const CONTRIBUTION_GUIDE_URL = "https://docs.powercalc.nl/contributing/measure/output/";
+const TROUBLESHOOTING_URL = "https://docs.powercalc.nl/contributing/measure/troubleshooting/";
 const PROFILE_LIBRARY_PATH = "profile_library/<manufacturer>/<model>/";
 
 // Contribution methods. Add a new entry here (e.g. "local") to expose another way to
@@ -123,6 +124,7 @@ export class ResultView extends LitElement {
   render() {
     const state = this.snapshot.state;
     const error = typeof this.snapshot.error === "string" ? this.snapshot.error : this.snapshot.error?.message;
+    const showArtifacts = state !== "failed";
     return html`
       <section class="panel" aria-labelledby="result-title">
         <p class="eyebrow">04 / Result</p>
@@ -130,11 +132,11 @@ export class ResultView extends LitElement {
           <div class="status-mark ${state}" aria-hidden="true">${this.statusMark(state)}</div>
           <div><h2 id="result-title">${this.resultTitle(state)}</h2><p class="muted">${this.description(state)}</p></div>
         </div>
-        ${error ? html`<p class="notice error" role="alert">${error}</p>` : nothing}
-        ${this.renderSummary()}
-        ${this.renderPlots()}
-        ${this.renderFiles()}
-        ${this.renderContributionSection(state)}
+        ${error ? html`<p class="notice error" role="alert">${this.renderError(error)}</p>` : nothing}
+        ${showArtifacts ? this.renderSummary() : nothing}
+        ${showArtifacts ? this.renderPlots() : nothing}
+        ${showArtifacts ? this.renderFiles() : nothing}
+        ${showArtifacts ? this.renderContributionSection(state) : nothing}
         ${this.errorMessage ? html`<p class="notice error" role="alert">${this.errorMessage}</p>` : nothing}
         <div class="diagnostics-download">
           <span>Session snapshot and logs for issue reporting.</span>
@@ -146,6 +148,12 @@ export class ResultView extends LitElement {
         </div>
       </section>
     `;
+  }
+
+  private renderError(error: string) {
+    if (!error.includes(TROUBLESHOOTING_URL)) return error;
+    const [before, after] = error.split(TROUBLESHOOTING_URL, 2);
+    return html`${before}<a href=${TROUBLESHOOTING_URL} target="_blank" rel="noopener noreferrer">Troubleshooting guide</a>${after}`;
   }
 
   private renderFiles() {
@@ -425,6 +433,7 @@ ${preview.pr_body}</pre>
   private description(state: SessionSnapshot["state"]): string {
     if (state === "completed") return this.summaryEntries().length ? "Here is the measured result." : "The complete output is ready to inspect or download.";
     if (state === "resumable") return "Compatible output was found. Continue from the last complete variation.";
+    if (state === "failed") return "Review the guidance below, correct the problem, and start a new measurement.";
     return "Any complete output rows have been kept safely.";
   }
 

--- a/utils/measure/frontend/src/components/running-view.ts
+++ b/utils/measure/frontend/src/components/running-view.ts
@@ -75,6 +75,7 @@ export class RunningView extends LitElement {
     .log-head button { min-height: 32px; padding: 0.3rem 0.6rem; }
     .log { flex: 1; overflow: auto; padding: 0.9rem; border: 1px solid var(--line); border-radius: 10px; background: var(--well); font: 0.8rem/1.6 ui-monospace, monospace; color: var(--muted); }
     .log p { margin: 0; }
+    .log p.warning { color: var(--warning); }
     .chart { position: relative; margin-top: 1.4rem; }
     .chart-head { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; }
     .chart-head span { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; }
@@ -134,7 +135,7 @@ export class RunningView extends LitElement {
           </div>
           ${preparing ? this.renderPreparation() : this.renderMeasurement(openEnded, progress)}
         </div>
-        ${this.snapshot.warnings?.length ? html`<div class="notice" role="status">${this.snapshot.warnings.at(-1)}</div>` : nothing}
+        ${this.renderLatestWarning()}
         ${this.logOpen && this.logs.length ? this.renderLog() : nothing}
         <div class="diagnostics-download">
           <span>Session snapshot and logs for issue reporting.</span>
@@ -172,7 +173,7 @@ export class RunningView extends LitElement {
           </div>
           <button class="primary confirm" type="button" @click=${this.confirm} ?disabled=${this.busy}>${this.busy ? "Starting…" : this.confirmationAction || "Start measurement"}</button>
         </div>
-        ${this.snapshot.warnings?.length ? html`<div class="notice" role="status">${this.snapshot.warnings.at(-1)}</div>` : nothing}
+        ${this.renderLatestWarning()}
         ${this.logOpen && this.logs.length ? this.renderLog() : nothing}
         <div class="diagnostics-download">
           <span>Session snapshot and logs for issue reporting.</span>
@@ -348,7 +349,13 @@ export class RunningView extends LitElement {
   }
 
   private logLine(log: string) {
-    return html`<p>${log}</p>`;
+    const warning = this.snapshot.warnings?.includes(log) ?? false;
+    return html`<p class=${warning ? "warning" : ""}>${log}</p>`;
+  }
+
+  private renderLatestWarning() {
+    const warning = this.snapshot.warnings?.at(-1);
+    return warning ? html`<div class="notice warning" role="alert">${warning}</div>` : nothing;
   }
 
   private toggleLog(): void {

--- a/utils/measure/frontend/src/components/running-view.ts
+++ b/utils/measure/frontend/src/components/running-view.ts
@@ -219,8 +219,9 @@ export class RunningView extends LitElement {
                   <progress max="100" aria-label="Recording"></progress>`;
     }
     const percent = progress.percent ?? (progress.total ? progress.completed / progress.total * 100 : 0);
-    return html`<div class="value" aria-label="${Math.round(percent)} percent complete">${Math.round(percent)}<small>%</small></div>
-                <progress max="100" .value=${percent}>${Math.round(percent)}%</progress>`;
+    const percentLabel = percent > 0 && Math.round(percent) === 0 ? "<1" : String(Math.round(percent));
+    return html`<div class="value" aria-label="${percentLabel} percent complete">${percentLabel}<small>%</small></div>
+                <progress max="100" .value=${percent}>${percentLabel}%</progress>`;
   }
 
   private renderMetrics(openEnded: boolean, progress: SessionProgress) {
@@ -232,6 +233,7 @@ export class RunningView extends LitElement {
       <div class="metrics">
         <div class="metric"><span>Mode</span><strong>${this.snapshot.mode ?? "—"}</strong></div>
         <div class="metric"><span>${progressLabel}</span><strong>${openEnded ? progress.completed : html`${progress.completed} / ${progress.total}`}</strong></div>
+        ${progress.skipped ? html`<div class="metric"><span>Skipped</span><strong>${progress.skipped}</strong></div>` : nothing}
         <div class="metric"><span>Remaining</span><strong>${openEnded ? "Until stopped" : this.remaining(progress.estimated_remaining_seconds)}</strong></div>
       </div>
     `;

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -935,6 +935,22 @@ describe("running view", () => {
     expect(element.shadowRoot.querySelector(".diagnostics-download")?.textContent).toContain("snapshot and logs");
   });
 
+  it("shows sub-one-percent progress and skipped readings", async () => {
+    const element = document.createElement("measure-running-view") as HTMLElement & {
+      snapshot: SessionSnapshot;
+      updateComplete: Promise<boolean>;
+      shadowRoot: ShadowRoot;
+    };
+    element.snapshot = { state: "running", mode: "brightness", progress: { completed: 1, total: 300, skipped: 1 } };
+    document.body.append(element);
+    await element.updateComplete;
+
+    expect(element.shadowRoot.querySelector(".value")?.textContent).toContain("<1%");
+    expect(element.shadowRoot.querySelector("progress")?.value).toBeCloseTo(1 / 300 * 100);
+    expect(element.shadowRoot.textContent).toContain("1 / 300");
+    expect(element.shadowRoot.textContent).toContain("Skipped");
+  });
+
   it("draws a live power chart from streamed samples", async () => {
     const element = document.createElement("measure-running-view") as HTMLElement & {
       snapshot: SessionSnapshot; samples: number[]; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -1091,6 +1091,25 @@ describe("running view", () => {
     expect(element.shadowRoot.querySelector(".log-overlay")?.textContent).toContain("Second log");
   });
 
+  it("presents discarded readings as warnings in the page and log panel", async () => {
+    const warning = "Discarding measurement: 0 watt was read from the power meter";
+    const element = document.createElement("measure-running-view") as HTMLElement & {
+      snapshot: SessionSnapshot; logs: string[]; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
+    };
+    element.snapshot = { state: "running", progress: { completed: 0, total: 2 }, warnings: [warning] };
+    element.logs = [warning];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const notice = element.shadowRoot.querySelector(".notice.warning");
+    expect(notice?.getAttribute("role")).toBe("alert");
+    expect(notice?.textContent).toContain(warning);
+
+    (element.shadowRoot.querySelector(".log-toggle") as HTMLButtonElement).click();
+    await element.updateComplete;
+    expect(element.shadowRoot.querySelector(".log p.warning")?.textContent).toContain(warning);
+  });
+
   it("auto-scrolls the log container when new log lines arrive", async () => {
     const element = document.createElement("measure-running-view") as HTMLElement & {
       snapshot: SessionSnapshot;
@@ -1959,6 +1978,36 @@ describe("result view", () => {
     expect(diagnostics.textContent).toBe("Download diagnostics");
     expect(diagnostics.href).toBe(element.diagnosticsUrl);
     expect(element.shadowRoot.querySelector(".diagnostics-download")?.textContent).toContain("snapshot and logs");
+  });
+
+  it("keeps failed results focused on the actionable error", async () => {
+    const element = document.createElement("measure-result-view") as HTMLElement & {
+      snapshot: SessionSnapshot;
+      files: { name: string; size: number; media_type: string }[];
+      plotCollection: { partial: boolean; plots: never[]; warnings: string[] };
+      diagnosticsUrl: string;
+      updateComplete: Promise<boolean>;
+      shadowRoot: ShadowRoot;
+    };
+    element.snapshot = {
+      state: "failed",
+      error: "Use a more sensitive meter. See https://docs.powercalc.nl/contributing/measure/troubleshooting/ for troubleshooting guidance.",
+    };
+    element.files = [{ name: "brightness.csv", size: 10, media_type: "text/csv" }];
+    element.plotCollection = { partial: true, plots: [], warnings: ["Could not plot brightness.csv"] };
+    element.diagnosticsUrl = "http://ha.local/ingress/api/session/current/diagnostics";
+    document.body.append(element);
+    await element.updateComplete;
+
+    expect(element.shadowRoot.querySelector(".notice.error")?.textContent).toContain("Use a more sensitive meter.");
+    const troubleshootingLink = element.shadowRoot.querySelector(".notice.error a") as HTMLAnchorElement;
+    expect(troubleshootingLink.textContent).toBe("Troubleshooting guide");
+    expect(troubleshootingLink.href).toBe("https://docs.powercalc.nl/contributing/measure/troubleshooting/");
+    expect(element.shadowRoot.textContent).toContain("correct the problem");
+    expect(element.shadowRoot.textContent).not.toContain("Could not plot");
+    expect(element.shadowRoot.textContent).not.toContain("Generated files");
+    expect(element.shadowRoot.textContent).not.toContain("Download all");
+    expect(element.shadowRoot.querySelector(".diagnostics-download a")).toBeTruthy();
   });
 
   it("shows a download-all action for generated files", async () => {

--- a/utils/measure/frontend/src/styles.ts
+++ b/utils/measure/frontend/src/styles.ts
@@ -65,6 +65,8 @@ export const sharedStyles = css`
   .muted { color: var(--muted); }
   .error { color: var(--danger); }
   .notice { padding: 0.8rem 1rem; border-left: 3px solid var(--signal); background: color-mix(in srgb, var(--signal) 8%, transparent); }
+  .notice.warning { border-left-color: var(--warning); background: color-mix(in srgb, var(--warning) 10%, transparent); color: var(--warning); }
+  .notice.error { border-left-color: var(--danger); background: color-mix(in srgb, var(--danger) 9%, transparent); }
   .diagnostics-download { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 0.35rem 1rem; margin-top: 1.25rem; color: var(--muted); font-size: 0.78rem; }
   .diagnostics-download a { color: var(--signal-strong); font-weight: 700; white-space: nowrap; }
   .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }

--- a/utils/measure/frontend/src/types.ts
+++ b/utils/measure/frontend/src/types.ts
@@ -213,6 +213,7 @@ export interface PreflightResponse {
 export interface SessionProgress {
   completed: number;
   total: number;
+  skipped?: number;
   percent?: number;
   estimated_remaining_seconds?: number | null;
 }
@@ -270,6 +271,7 @@ export interface SessionEventData {
   power?: number;
   completed?: number;
   total?: number;
+  skipped?: number;
   mode?: string;
   estimated_remaining?: string;
   state?: SessionState;

--- a/utils/measure/measure/cli/interaction.py
+++ b/utils/measure/measure/cli/interaction.py
@@ -24,7 +24,15 @@ class ConsoleInteraction(RunInteraction):
     def phase(self, message: str) -> None:
         return
 
-    def progress(self, completed: int, total: int, *, phase: str, remaining_seconds: float | None = None) -> None:
+    def progress(
+        self,
+        completed: int,
+        total: int,
+        *,
+        phase: str,
+        remaining_seconds: float | None = None,
+        skipped: int = 0,
+    ) -> None:
         return
 
     def wait(self, seconds: float) -> None:

--- a/utils/measure/measure/execution.py
+++ b/utils/measure/measure/execution.py
@@ -64,7 +64,15 @@ class RunInteraction(Protocol):
     def phase(self, message: str) -> None:
         """Report the current activity when numeric progress is unavailable."""
 
-    def progress(self, completed: int, total: int, *, phase: str, remaining_seconds: float | None = None) -> None:
+    def progress(
+        self,
+        completed: int,
+        total: int,
+        *,
+        phase: str,
+        remaining_seconds: float | None = None,
+        skipped: int = 0,
+    ) -> None:
         """Report measurement progress. ``total`` of 0 means the run is open-ended."""
 
     def wait(self, seconds: float) -> None:
@@ -96,7 +104,15 @@ class ImmediateInteraction(RunInteraction):
     def phase(self, message: str) -> None:
         return
 
-    def progress(self, completed: int, total: int, *, phase: str, remaining_seconds: float | None = None) -> None:
+    def progress(
+        self,
+        completed: int,
+        total: int,
+        *,
+        phase: str,
+        remaining_seconds: float | None = None,
+        skipped: int = 0,
+    ) -> None:
         return
 
     def wait(self, seconds: float) -> None:

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -771,6 +771,7 @@ def _snapshot_response(context: AppContext, snapshot: SessionSnapshot) -> dict[s
         "progress": {
             "completed": snapshot.completed,
             "total": snapshot.total,
+            "skipped": snapshot.skipped,
             "percent": snapshot.progress,
             "estimated_remaining_seconds": _duration_seconds(snapshot.estimated_remaining),
         },

--- a/utils/measure/measure/ha_app/coordinator.py
+++ b/utils/measure/measure/ha_app/coordinator.py
@@ -237,6 +237,7 @@ class MeasurementCoordinator:
                     updated_at=event.created_at,
                     completed=int(event.data["completed"]),
                     total=int(event.data["total"]),
+                    skipped=int(event.data.get("skipped", 0)),
                     phase=str(event.data["mode"]),
                     mode=str(event.data["mode"]),
                     estimated_remaining=str(event.data["estimated_remaining"]),

--- a/utils/measure/measure/ha_app/interaction.py
+++ b/utils/measure/measure/ha_app/interaction.py
@@ -24,9 +24,23 @@ class SessionInteraction(RunInteraction):
     def phase(self, message: str) -> None:
         self.control.phase(message)
 
-    def progress(self, completed: int, total: int, *, phase: str, remaining_seconds: float | None = None) -> None:
+    def progress(
+        self,
+        completed: int,
+        total: int,
+        *,
+        phase: str,
+        remaining_seconds: float | None = None,
+        skipped: int = 0,
+    ) -> None:
         remaining = "" if remaining_seconds is None else f"{int(remaining_seconds)}s"
-        self.control.progress(completed=completed, total=total, mode=phase, estimated_remaining=remaining)
+        self.control.progress(
+            completed=completed,
+            total=total,
+            mode=phase,
+            estimated_remaining=remaining,
+            skipped=skipped,
+        )
 
     def wait(self, seconds: float) -> None:
         self.control.wait(seconds)

--- a/utils/measure/measure/ha_app/session.py
+++ b/utils/measure/measure/ha_app/session.py
@@ -67,6 +67,7 @@ class SessionSnapshot:
     updated_at: str
     completed: int = 0
     total: int = 0
+    skipped: int = 0
     phase: str | None = None
     confirmation_message: str | None = None
     mode: str | None = None
@@ -158,12 +159,13 @@ class SessionControl:
             listener(event)
         return event
 
-    def progress(self, *, completed: int, total: int, mode: str, estimated_remaining: str) -> None:
+    def progress(self, *, completed: int, total: int, mode: str, estimated_remaining: str, skipped: int = 0) -> None:
         self.emit(
             SessionEventType.PROGRESS,
             {
                 "completed": completed,
                 "total": total,
+                "skipped": skipped,
                 "mode": mode,
                 "estimated_remaining": estimated_remaining,
             },

--- a/utils/measure/measure/ha_app/storage.py
+++ b/utils/measure/measure/ha_app/storage.py
@@ -155,6 +155,7 @@ class SessionStorage:
                 updated_at=str(state["updated_at"]),
                 completed=int(state.get("completed", 0)),
                 total=int(state.get("total", 0)),
+                skipped=int(state.get("skipped", 0)),
                 phase=state.get("phase"),
                 confirmation_message=state.get("confirmation_message"),
                 mode=state.get("mode"),

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -39,7 +39,12 @@ from measure.tuning import MeasurementParameters
 from measure.util.measure_util import AverageMeasurementConvergence, MeasurementResult, MeasureUtil
 
 CSV_WRITE_BUFFER = 50
-MAX_ALLOWED_0_READINGS = 50
+MAX_CONSECUTIVE_ZERO_READINGS = 5
+ZERO_READING_ABORT_MESSAGE = (
+    "Aborting measurement session after repeated 0 W readings. The power meter may not resolve this low load. "
+    "Verify the device is on and connected, raise the minimum brightness, measure multiple identical lights together, "
+    "add a resistive dummy load, or use a more sensitive meter."
+)
 
 _LOGGER = logging.getLogger("measure")
 
@@ -61,6 +66,7 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
         self.lut_modes: set[LutMode] | None = None
         self.num_lights: int = 1
         self.num_0_readings: int = 0
+        self.skipped_zero_readings: int = 0
         self.light_info: LightInfo | None = None
         self.plan: LightMeasurementPlan | None = None
         self.active_plan: LightMeasurementPlan | None = None
@@ -201,54 +207,40 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
             self.interaction.phase(f"Stabilizing light before the first reading ({self.config.sleep_initial} s)")
             self._wait(self.config.sleep_initial)
 
-            self.interaction.progress(
-                completed=len(all_variations) - len(remaining_variations),
-                total=len(all_variations),
-                phase=mode.value,
-                remaining_seconds=self.calculate_time_left_seconds(mode, all_variations, remaining_variations),
-            )
+            self._report_progress(mode, all_variations, remaining_variations)
             previous_variation = None
             for count, variation in enumerate(measurement_info.variations):
-                self._log_progress(mode, count, variation, all_variations, remaining_variations)
-                _LOGGER.info("Changing light to: %s", variation)
-                self._checkpoint()
-                variation_start_time = time.time()
-                self._change_light_with_retry(mode, variation)
-                self.wait(variation, previous_variation)
-
-                previous_variation = variation
-
-                try:
+                while True:
+                    self._log_progress(mode, count, variation, all_variations, remaining_variations)
+                    _LOGGER.info("Changing light to: %s", variation)
                     self._checkpoint()
-                    measurement_result = self.take_power_measurement(mode, variation_start_time)
-                except OutdatedMeasurementError:
-                    measurement_result = self.nudge_and_remeasure(mode, variation)
-                except ZeroReadingError as error:
-                    self.num_0_readings += 1
-                    _LOGGER.warning("Discarding measurement: %s", error)
-                    if self.num_0_readings > MAX_ALLOWED_0_READINGS:
-                        raise RunnerError(
-                            "Aborting measurement session. Received too many 0 readings",
-                        ) from error
-                    continue
-                except PowerMeterError as error:
-                    raise RunnerError(f"Aborting measurement session: {error}") from error
-                _LOGGER.info("Measured power: %.2f", measurement_result.power)
-                self._checkpoint()
-                csv_writer.write_measurement(variation, measurement_result.power)
-                voltages.extend(measurement_result.voltages)
-                remaining_variations.remove(variation)
-                self.interaction.progress(
-                    completed=len(all_variations) - len(remaining_variations),
-                    total=len(all_variations),
-                    phase=mode.value,
-                    remaining_seconds=self.calculate_time_left_seconds(
-                        mode,
-                        all_variations,
-                        remaining_variations,
-                        variation,
-                    ),
-                )
+                    variation_start_time = time.time()
+                    self._change_light_with_retry(mode, variation)
+                    self.wait(variation, previous_variation)
+
+                    previous_variation = variation
+
+                    try:
+                        self._checkpoint()
+                        measurement_result = self.take_power_measurement(mode, variation_start_time)
+                    except OutdatedMeasurementError:
+                        measurement_result = self.nudge_and_remeasure(mode, variation)
+                    except ZeroReadingError as error:
+                        self._record_zero_reading()
+                        self._report_progress(mode, all_variations, remaining_variations, variation)
+                        _LOGGER.warning("Discarding measurement: %s", error)
+                        self._raise_for_repeated_zero_readings(error)
+                        continue
+                    except PowerMeterError as error:
+                        raise RunnerError(f"Aborting measurement session: {error}") from error
+                    self.num_0_readings = 0
+                    _LOGGER.info("Measured power: %.2f", measurement_result.power)
+                    self._checkpoint()
+                    csv_writer.write_measurement(variation, measurement_result.power)
+                    voltages.extend(measurement_result.voltages)
+                    remaining_variations.remove(variation)
+                    self._report_progress(mode, all_variations, remaining_variations, variation)
+                    break
 
             _LOGGER.info(
                 "Hooray! measurements finished. Exported CSV file %s",
@@ -280,6 +272,35 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
         time_left = self.calculate_time_left(mode, all_variations, remaining_variations, variation)
         progress_percentage = ((len(all_variations) - len(remaining_variations)) / len(all_variations)) * 100
         _LOGGER.info("Progress: %d%%, Estimated time left: %s", progress_percentage, time_left)
+
+    def _report_progress(
+        self,
+        mode: LutMode,
+        all_variations: list[Variation],
+        remaining_variations: list[Variation],
+        current_variation: Variation | None = None,
+    ) -> None:
+        completed_variations = len(all_variations) - len(remaining_variations)
+        self.interaction.progress(
+            completed=completed_variations,
+            total=len(all_variations),
+            phase=mode.value,
+            remaining_seconds=self.calculate_time_left_seconds(
+                mode,
+                all_variations,
+                remaining_variations,
+                current_variation,
+            ),
+            skipped=self.skipped_zero_readings,
+        )
+
+    def _record_zero_reading(self) -> None:
+        self.num_0_readings += 1
+        self.skipped_zero_readings += 1
+
+    def _raise_for_repeated_zero_readings(self, error: ZeroReadingError) -> None:
+        if self.num_0_readings >= MAX_CONSECUTIVE_ZERO_READINGS:
+            raise RunnerError(ZERO_READING_ABORT_MESSAGE) from error
 
     def _change_light_with_retry(self, mode: LutMode, variation: Variation) -> None:
         for _ in range(5):
@@ -440,16 +461,15 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
                 self.interaction.operating_point(self._operating_point(mode, variation))
                 # Wait a longer amount of time for the PM to settle
                 self._wait(self.config.sleep_time_nudge)
-                return self.take_power_measurement(mode, variation_start_time)
+                result = self.take_power_measurement(mode, variation_start_time)
+                self.num_0_readings = 0
+                return result
             except OutdatedMeasurementError:
                 continue
             except ZeroReadingError as error:
-                self.num_0_readings += 1
+                self._record_zero_reading()
                 _LOGGER.warning("Discarding measurement: %s", error)
-                if self.num_0_readings > MAX_ALLOWED_0_READINGS:
-                    raise RunnerError(
-                        "Aborting measurement session. Received too many 0 readings",
-                    ) from error
+                self._raise_for_repeated_zero_readings(error)
                 continue
         raise OutdatedMeasurementError(
             f"Power measurement is outdated. Aborting after {self.config.max_nudges} nudge attempts",

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -43,7 +43,8 @@ MAX_CONSECUTIVE_ZERO_READINGS = 5
 ZERO_READING_ABORT_MESSAGE = (
     "Aborting measurement session after repeated 0 W readings. The power meter may not resolve this low load. "
     "Verify the device is on and connected, measure multiple identical lights together, "
-    "add a resistive dummy load, or use a more sensitive meter."
+    "add a resistive dummy load, or use a more sensitive meter. "
+    "See https://docs.powercalc.nl/contributing/measure/troubleshooting/ for troubleshooting guidance."
 )
 
 _LOGGER = logging.getLogger("measure")

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -42,7 +42,7 @@ CSV_WRITE_BUFFER = 50
 MAX_CONSECUTIVE_ZERO_READINGS = 5
 ZERO_READING_ABORT_MESSAGE = (
     "Aborting measurement session after repeated 0 W readings. The power meter may not resolve this low load. "
-    "Verify the device is on and connected, raise the minimum brightness, measure multiple identical lights together, "
+    "Verify the device is on and connected, measure multiple identical lights together, "
     "add a resistive dummy load, or use a more sensitive meter."
 )
 

--- a/utils/measure/tests/runner/test_light.py
+++ b/utils/measure/tests/runner/test_light.py
@@ -1,5 +1,5 @@
 import csv
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import os.path
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -9,11 +9,13 @@ from measure.controller.light.const import LutMode
 from measure.controller.light.dummy import DummyLightController
 from measure.controller.light.spec import DummyLightControllerSpec
 from measure.execution import RunInteraction
+from measure.powermeter.errors import ZeroReadingError
 from measure.powermeter.spec import DummyPowerMeterSpec
 from measure.request import LightMeasurementRequest
 from measure.runner.const import QUESTION_MODE
-from measure.runner.light import EffectVariation, LightRunner
-from measure.runner.light_plan import build_light_plan
+from measure.runner.errors import RunnerError
+from measure.runner.light import EffectVariation, LightRunner, MeasurementRunInput
+from measure.runner.light_plan import LightMeasurementPlan, LightModePlan, Variation, build_light_plan
 from measure.tuning import MeasurementParameters
 from measure.util.measure_util import AverageMeasurementConvergence, MeasurementResult, MeasureUtil
 import pytest
@@ -28,6 +30,51 @@ def _parameters() -> MeasurementParameters:
         hs_hue_steps=2731,
         hs_sat_steps=32,
     )
+
+
+def _zero_sleep_parameters() -> MeasurementParameters:
+    return replace(
+        _parameters(),
+        sleep_initial=0,
+        sleep_time=0,
+        sleep_time_ct=0,
+        sleep_time_hue=0,
+        sleep_time_sat=0,
+        sleep_time_effect_change=0,
+    )
+
+
+@dataclass
+class _BrightnessRun:
+    runner: LightRunner
+    measurement_info: MeasurementRunInput
+    all_variations: list[Variation]
+    remaining_variations: list[Variation]
+    measure_util: MagicMock
+
+    def execute(self) -> None:
+        self.runner.run_mode(self.measurement_info, self.all_variations, self.remaining_variations)
+
+
+def _brightness_run(tmp_path: Path, variations: list[Variation]) -> _BrightnessRun:
+    measure_util_mock = MagicMock(MeasureUtil)
+    interaction = MagicMock(spec=RunInteraction)
+    runner = LightRunner(measure_util_mock, _zero_sleep_parameters(), DummyLightController(), interaction)
+    runner.gzip = False
+    runner.light_info = runner.light_controller.get_light_info()
+    runner.active_plan = LightMeasurementPlan(
+        modes=[LightModePlan(mode=LutMode.BRIGHTNESS, variations=variations)],
+        effects=[],
+    )
+    all_variations = variations.copy()
+    remaining_variations = variations.copy()
+    measurement_info = MeasurementRunInput(
+        mode=LutMode.BRIGHTNESS,
+        csv_file=str(tmp_path / "brightness.csv"),
+        variations=variations.copy(),
+        is_resuming=False,
+    )
+    return _BrightnessRun(runner, measurement_info, all_variations, remaining_variations, measure_util_mock)
 
 
 @pytest.mark.parametrize(
@@ -111,6 +158,66 @@ def test_run(export_path: str) -> None:
     points = [call.args[0] for call in interaction.operating_point.call_args_list]
     assert points[0] == {"type": "light", "on": True, "brightness": 1}
     assert points[-1] == {"type": "light", "on": True, "brightness": 255}
+
+
+def test_zero_reading_retries_current_variation_and_reports_skipped_progress(tmp_path: Path) -> None:
+    variations = [Variation(1), Variation(2)]
+    run = _brightness_run(tmp_path, variations)
+    run.measure_util.take_measurement.side_effect = [
+        ZeroReadingError("0 watt was read from the power meter"),
+        MeasurementResult(power=1, voltages=[]),
+        MeasurementResult(power=2, voltages=[]),
+    ]
+
+    run.execute()
+
+    with open(run.measurement_info.csv_file, newline="") as csv_file:
+        rows = list(csv.reader(csv_file))
+    assert rows == [["bri", "watt"], ["1", "1.0"], ["2", "2.0"]]
+    skipped_progress = run.runner.interaction.progress.call_args_list[1]
+    assert skipped_progress.kwargs["completed"] == 0
+    assert skipped_progress.kwargs["total"] == 2
+    assert skipped_progress.kwargs["skipped"] == 1
+    assert run.runner.interaction.progress.call_args_list[-1].kwargs["completed"] == 2
+    assert run.runner.interaction.progress.call_args_list[-1].kwargs["total"] == 2
+
+
+def test_zero_reading_counter_resets_after_valid_measurement(tmp_path: Path) -> None:
+    variations = [Variation(1), Variation(2)]
+    run = _brightness_run(tmp_path, variations)
+    run.measure_util.take_measurement.side_effect = [
+        ZeroReadingError("first low reading"),
+        MeasurementResult(power=1, voltages=[]),
+        ZeroReadingError("second low reading"),
+        ZeroReadingError("third low reading"),
+        ZeroReadingError("fourth low reading"),
+        ZeroReadingError("fifth low reading"),
+        MeasurementResult(power=2, voltages=[]),
+    ]
+
+    run.execute()
+
+    with open(run.measurement_info.csv_file, newline="") as csv_file:
+        rows = list(csv.reader(csv_file))
+    assert rows[-2:] == [["1", "1.0"], ["2", "2.0"]]
+
+
+def test_repeated_zero_readings_fail_fast_with_actionable_error(tmp_path: Path) -> None:
+    variations = [Variation(1), Variation(2)]
+    run = _brightness_run(tmp_path, variations)
+    run.measure_util.take_measurement.side_effect = ZeroReadingError("0 watt was read from the power meter")
+
+    with pytest.raises(RunnerError) as error:
+        run.execute()
+
+    message = str(error.value)
+    assert "repeated 0 W readings" in message
+    assert "power meter may not resolve this low load" in message
+    assert "raise the minimum brightness" in message
+    assert "multiple identical lights" in message
+    assert "resistive dummy load" in message
+    assert run.measure_util.take_measurement.call_count == 5
+    assert run.runner.interaction.progress.call_args_list[-1].kwargs["skipped"] == 5
 
 
 def test_cleanup_turns_off_light() -> None:

--- a/utils/measure/tests/runner/test_light.py
+++ b/utils/measure/tests/runner/test_light.py
@@ -213,9 +213,9 @@ def test_repeated_zero_readings_fail_fast_with_actionable_error(tmp_path: Path) 
     message = str(error.value)
     assert "repeated 0 W readings" in message
     assert "power meter may not resolve this low load" in message
-    assert "raise the minimum brightness" in message
     assert "multiple identical lights" in message
     assert "resistive dummy load" in message
+    assert "https://docs.powercalc.nl/contributing/measure/troubleshooting/" in message
     assert run.measure_util.take_measurement.call_count == 5
     assert run.runner.interaction.progress.call_args_list[-1].kwargs["skipped"] == 5
 

--- a/utils/measure/tests/test_session.py
+++ b/utils/measure/tests/test_session.py
@@ -29,6 +29,18 @@ def test_events_are_sequenced_and_delivered() -> None:
     assert events[0].type == SessionEventType.PHASE
     assert events[0].data == {"message": "Preparing measurement devices"}
     assert events[1].data["completed"] == 1
+    assert events[1].data["skipped"] == 0
+
+
+def test_progress_event_includes_skipped_readings() -> None:
+    control = SessionControl()
+    events = []
+    control.subscribe(events.append)
+
+    control.progress(completed=2, total=12, mode="brightness", estimated_remaining="10s", skipped=1)
+
+    assert events[0].type == SessionEventType.PROGRESS
+    assert events[0].data["skipped"] == 1
 
 
 def test_sample_emits_rounded_power_reading() -> None:


### PR DESCRIPTION
## Summary

- retry the current variation when a power meter reports zero, preserving contiguous resume data
- abort after five consecutive zero readings with practical low-load troubleshooting guidance. Previously it would only error after 51 retries, which could take up to 10 minutes to reach.
- expose skipped readings in session progress and show positive sub-1% progress accurately

## Validation

- 103 targeted Python tests
- Ruff and strict mypy
- 119 frontend tests and frontend typecheck
- staged diff validation

Addresses bramstroker/homeassistant-powercalc#4396