### PR TITLE
Add Bseed Smart Zigbee Switch profile

### DIFF
--- a/profile_library/bseed/zigbee_switch_1_gang/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang/model.json
@@ -1,0 +1,5 @@
+{
+  "name": "BSEED Smart Zigbee Switch 1-Gang",
+  "power": 0.89,
+  "power_off": 0.59
+}

--- a/profile_library/bseed/zigbee_switch_1_gang/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang/model.json
@@ -2,7 +2,7 @@
   "name": "Zigbee Switch 1 Gang",
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
-  "measure_device": "Shelly Gen 3",
+  "measure_device": "Shelly Plug S",
   "measure_method": "script",
   "measure_description": "Measured via Powercalc Measure Tool",
   "created_at": "2026-07-27T15:17:25Z",

--- a/profile_library/bseed/zigbee_switch_1_gang/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang/model.json
@@ -1,5 +1,0 @@
-{
-  "name": "BSEED Smart Zigbee Switch 1-Gang",
-  "power": 0.89,
-  "power_off": 0.59
-}

--- a/profile_library/bseed/zigbee_switch_1_gang/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang/model.json
@@ -1,0 +1,17 @@
+{
+  "name": "Zigbee Switch 1 Gang",
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "measure_device": "Shelly Gen 3",
+  "measure_method": "script",
+  "measure_description": "Measured via Powercalc Measure Tool",
+  "created_at": "2026-07-27T15:17:25Z",
+  "standby_power": 0.59,
+  "fixed_config": {
+    "power": 0.89
+  },
+  "author_info": {
+    "name": "Maxik933",
+    "github": "Maxik933"
+  }
+}


### PR DESCRIPTION
## Device information
BSEED Smart Zigbee Switch 1-Gang

## Home Assistant Device information
- Manufacturer: BSEED
- Model: Smart Zigbee Switch 1-Gang

## Checklist
- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
Measured via Powercalc Measure Tool: Standby power is 0.59 W, active power is 0.89 W.