### PR TITLE
add Zigbee Switch 1 Gang No Neutral

### DIFF
--- a/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
@@ -2,7 +2,7 @@
   "name": "Zigbee Switch 1 Gang No Neutral",
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
-  "measure_device": "Custom Measurement",
+  "measure_device": "Shelly Plug S",
   "measure_method": "manual",
   "measure_description": "No neutral line version. Switch self-consumption: 0.1W standby, 0.3W operating. Total load depends on the connected lamp and must be configured separately.",
   "created_at": "2026-07-28T15:06:00Z",

--- a/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
@@ -7,9 +7,7 @@
   "measure_description": "No neutral line version. Switch self-consumption: 0.1W standby, 0.3W operating. Total load depends on the connected lamp and must be configured separately.",
   "created_at": "2026-07-28T15:06:00Z",
   "standby_power": 0.1,
-  "fixed_config": {
-    "power": 0.3
-  },
+  "standby_power_on": 0.3,
   "author_info": {
     "name": "Maxik933",
     "github": "Maxik933"

--- a/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
@@ -2,7 +2,7 @@
   "name": "Zigbee Switch 1 Gang No Neutral",
   "device_type": "smart_switch",
   "calculation_strategy": "fixed",
-  "measure_device": "Shelly Plug S",
+  "measure_device": "Shelly Plug S Gen3",
   "measure_method": "manual",
   "measure_description": "No neutral line version. Switch self-consumption: 0.1W standby, 0.3W operating. Total load depends on the connected lamp and must be configured separately.",
   "created_at": "2026-07-28T15:06:00Z",

--- a/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
+++ b/profile_library/bseed/zigbee_switch_1_gang_no_neutral/model.json
@@ -1,0 +1,17 @@
+{
+  "name": "Zigbee Switch 1 Gang No Neutral",
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "measure_device": "Custom Measurement",
+  "measure_method": "manual",
+  "measure_description": "No neutral line version. Switch self-consumption: 0.1W standby, 0.3W operating. Total load depends on the connected lamp and must be configured separately.",
+  "created_at": "2026-07-28T15:06:00Z",
+  "standby_power": 0.1,
+  "fixed_config": {
+    "power": 0.3
+  },
+  "author_info": {
+    "name": "Maxik933",
+    "github": "Maxik933"
+  }
+}


### PR DESCRIPTION
## Device information
Zigbee Switch 1 Gang No Neutral (Smart Switch mit manuellem Fix-Wert).

## Home Assistant Device information
- Name: Zigbee Switch 1 Gang No Neutral
- Device Type: smart_switch
- Calculation Strategy: fixed

## Checklist
- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
No neutral line version. Switch self-consumption: 0.1W standby, 0.3W operating. Total load depends on the connected lamp and must be configured separately.