### PR TITLE
Fix STARKVIND auto-mode power calculation by mapping fan_speed

### DIFF
--- a/profile_library/ikea/E2007/model.json
+++ b/profile_library/ikea/E2007/model.json
@@ -1,33 +1,33 @@
 {
   "aliases": [
+    "STARKVIND air purifier",
     "STARKVIND Air purifier table"
   ],
   "calculation_strategy": "linear",
   "created_at": "2025-04-18T12:32:08Z",
   "device_type": "fan",
   "linear_config": {
-    "attribute": "percentage",
+    "attribute": "fan_speed",
     "calibrate": [
-      "1 -> 1.6",
-      "10 -> 1.6",
-      "20 -> 2.2",
-      "30 -> 3.6",
-      "40 -> 5.8",
-      "50 -> 8.9",
-      "60 -> 13",
-      "70 -> 18.3",
-      "80 -> 21.4",
-      "90 -> 24.5",
-      "100 -> 24.8"
+      "0 -> 0.27",
+      "1 -> 1.7",
+      "2 -> 2.26",
+      "3 -> 3.58",
+      "4 -> 5.55",
+      "5 -> 8.5",
+      "6 -> 12.4",
+      "7 -> 17.8",
+      "8 -> 20.65",
+      "9 -> 24.04"
     ]
   },
-  "measure_description": "Manually measured",
-  "measure_device": "GreenWave GWPN1",
+  "measure_description": "Measured via Shelly Plug S",
+  "measure_device": "Shelly Plug S",
   "measure_method": "manual",
-  "name": "STARKVIND air purifier table",
-  "standby_power": 0.2,
+  "name": "STARKVIND air purifier (E2007)",
+  "standby_power": 0.27,
   "author_info": {
-    "name": "Marius",
-    "github": "Mariusthvdb"
+    "name": "Maxik933",
+    "github": "Maxik933"
   }
 }


### PR DESCRIPTION
## Device information
* **Device:** IKEA STARKVIND Air Purifier (E2007)
* **Measurement Device:** Shelly Plug S (Manual measurement)

## Home Assistant Device information
* **Manufacturer:** IKEA
* **Model:** STARKVIND air purifier (E2007)

## Checklist
- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.

## Additional info
* **Changes:** Adjusted the calibration to use the native fan attribute (`fan_speed`) for discrete steps from 0 to 9.
* **Reason:** When the fan runs in auto mode, no percentage scale is available, causing the power sensor to show as unavailable. By looking at the `fan_speed`, it is always correctly displayed which level the air purifier is currently on, regardless of whether it is operated manually or in auto mode.
* **Calculation Strategy:** linear (`fan_speed` attribute, steps 0-9)
* **Standby Power:** 0.27 W