### PR TITLE
Fix energy price sensor GUI selector

### DIFF
--- a/custom_components/powercalc/config_flow.py
+++ b/custom_components/powercalc/config_flow.py
@@ -33,6 +33,7 @@ from .common import SourceEntity, create_source_entity
 from .const import (
     CONF_CREATE_COST_SENSOR,
     CONF_CREATE_UTILITY_METERS,
+    CONF_ENERGY_PRICE_SENSOR,
     CONF_MANUFACTURER,
     CONF_MODE,
     CONF_MODEL,
@@ -76,12 +77,12 @@ from .flow_helper.flows.virtual_power import (
 from .flow_helper.profile_preview import async_setup_preview as async_setup_powercalc_preview
 from .flow_helper.schema import (
     COST_DOCS_URI,
-    SCHEMA_COST_PRICING,
     SCHEMA_COST_SENSOR_TOGGLE,
     SCHEMA_ENERGY_SENSOR_TOGGLE,
     SCHEMA_SENSOR_ENERGY_OPTIONS,
     SCHEMA_UTILITY_METER_OPTIONS,
     SCHEMA_UTILITY_METER_TOGGLE,
+    build_cost_pricing_schema,
 )
 from .power_profile.factory import get_power_profile
 from .power_profile.power_profile import SUPPORTED_DOMAINS, DeviceType, DiscoveryBy, PowerProfile
@@ -599,7 +600,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
         """Handle the per sensor energy price override."""
         return await self.async_handle_options_step(
             user_input,
-            SCHEMA_COST_PRICING,
+            build_cost_pricing_schema(self.hass, self.sensor_config.get(CONF_ENERGY_PRICE_SENSOR)),
             Step.COST_OPTIONS,
             form_kwarg={"description_placeholders": {"docs_uri": COST_DOCS_URI}},
         )

--- a/custom_components/powercalc/flow_helper/flows/cost.py
+++ b/custom_components/powercalc/flow_helper/flows/cost.py
@@ -21,28 +21,37 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.flow_helper.common import PowercalcFormStep, Step, flatten_sections
-from custom_components.powercalc.flow_helper.schema import SCHEMA_COST_PRICING, SECTION_COST_PRICING
+from custom_components.powercalc.flow_helper.schema import SECTION_COST_PRICING, build_cost_pricing_schema
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
     from custom_components.powercalc.config_flow import PowercalcConfigFlow, PowercalcOptionsFlow
 
-SCHEMA_COST_OPTIONS = vol.Schema(
-    {
-        vol.Required(CONF_ENERGY_SENSOR_ID): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain="sensor", device_class=SensorDeviceClass.ENERGY),
-        ),
-        vol.Optional(SECTION_COST_PRICING): section(SCHEMA_COST_PRICING, {"collapsed": True}),
-    },
-)
 
-SCHEMA_COST = vol.Schema(
-    {
-        vol.Required(CONF_NAME): selector.TextSelector(),
-        **SCHEMA_COST_OPTIONS.schema,
-    },
-)
+def build_cost_options_schema(hass: HomeAssistant, current_price_entity_id: str | None = None) -> vol.Schema:
+    """Return the schema for the options of a standalone cost sensor."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_ENERGY_SENSOR_ID): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="sensor", device_class=SensorDeviceClass.ENERGY),
+            ),
+            vol.Optional(SECTION_COST_PRICING): section(
+                build_cost_pricing_schema(hass, current_price_entity_id),
+                {"collapsed": True},
+            ),
+        },
+    )
+
+
+def build_cost_schema(hass: HomeAssistant) -> vol.Schema:
+    """Return the schema for creating a standalone cost sensor."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_NAME): selector.TextSelector(),
+            **build_cost_options_schema(hass).schema,
+        },
+    )
 
 
 def is_global_price_configured(hass: HomeAssistant) -> bool:
@@ -68,13 +77,17 @@ class CostConfigFlow:
         """Handle the flow for a standalone cost sensor."""
         self.flow.selected_sensor_type = SensorType.COST
         return await self.flow.handle_form_step(
-            PowercalcFormStep(step=Step.COST, schema=SCHEMA_COST, validate_user_input=self.validate),
+            PowercalcFormStep(
+                step=Step.COST,
+                schema=build_cost_schema(self.flow.hass),
+                validate_user_input=self.validate,
+            ),
             user_input,
         )
 
     def validate(self, user_input: dict[str, Any]) -> dict[str, Any]:
         """Flatten the pricing section and reject the input when no price is available."""
-        user_input = flatten_sections(user_input, SCHEMA_COST)
+        user_input = flatten_sections(user_input, build_cost_schema(self.flow.hass))
         if validate_price_configured(self.flow.hass, user_input):
             raise SchemaFlowError("cost_price_mandatory")
         return user_input
@@ -88,7 +101,7 @@ class CostOptionsFlow:
         """Handle the cost sensor options flow."""
         return await self.flow.async_handle_options_step(
             user_input,
-            SCHEMA_COST_OPTIONS,
+            build_cost_options_schema(self.flow.hass, self.flow.sensor_config.get(CONF_ENERGY_PRICE_SENSOR)),
             Step.COST,
             validate=lambda flat_input: validate_price_configured(self.flow.hass, flat_input),
         )

--- a/custom_components/powercalc/flow_helper/flows/global_configuration.py
+++ b/custom_components/powercalc/flow_helper/flows/global_configuration.py
@@ -55,12 +55,12 @@ from custom_components.powercalc.flow_helper.schema import (
     COST_DOCS_URI,
     SCHEMA_COST_APPLY,
     SCHEMA_ENERGY_OPTIONS,
-    SCHEMA_GLOBAL_COST,
     SCHEMA_GLOBAL_COST_FLAT,
     SCHEMA_UTILITY_METER_OPTIONS,
     SCHEMA_UTILITY_METER_TOGGLE,
     SECTION_COST_NAMING,
     SECTION_COST_PRICING,
+    build_global_cost_schema,
 )
 from custom_components.powercalc.power_profile.power_profile import DeviceType
 from custom_components.powercalc.service.gui_configuration import apply_field_to_config_entries
@@ -325,7 +325,7 @@ class GlobalConfigurationFlow:
 
         form_step = PowercalcFormStep(
             step=Step.GLOBAL_CONFIGURATION_COST,
-            schema=SCHEMA_GLOBAL_COST,
+            schema=build_global_cost_schema(self.flow.hass, self.flow.global_config.get(CONF_ENERGY_PRICE_SENSOR)),
             form_kwarg={
                 "description_placeholders": {
                     "docs_uri": COST_DOCS_URI,

--- a/custom_components/powercalc/flow_helper/schema.py
+++ b/custom_components/powercalc/flow_helper/schema.py
@@ -1,9 +1,15 @@
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.utility_meter.const import CONF_METER_TYPE, METER_TYPES
-from homeassistant.const import UnitOfPower
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfPower
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import selector
-from homeassistant.helpers.selector import NumberSelector, NumberSelectorMode
+from homeassistant.helpers.selector import (
+    EntityWithDeviceFilterSelectorConfig,
+    NumberSelector,
+    NumberSelectorMode,
+)
+from homeassistant.util.unit_conversion import EnergyConverter
 import voluptuous as vol
 
 from custom_components.powercalc.const import (
@@ -61,8 +67,10 @@ SCHEMA_COST_PRICING = vol.Schema(
         vol.Optional(CONF_ENERGY_PRICE): NumberSelector(
             selector.NumberSelectorConfig(mode=NumberSelectorMode.BOX, step="any"),
         ),
+        # Unfiltered fallback. Prefer `build_cost_pricing_schema()` when a `hass` instance is
+        # available, it narrows this picker down to the price sensors actually present.
         vol.Optional(CONF_ENERGY_PRICE_SENSOR): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain="sensor", device_class=SensorDeviceClass.MONETARY),
+            selector.EntitySelectorConfig(domain=SENSOR_DOMAIN),
         ),
         vol.Optional(CONF_ENERGY_PRICE_SURCHARGE): NumberSelector(
             selector.NumberSelectorConfig(mode=NumberSelectorMode.BOX, step="any"),
@@ -80,13 +88,72 @@ SCHEMA_GLOBAL_COST_NAMING = vol.Schema(
     },
 )
 
-# Presented in the GUI as two collapsible sections (pricing and naming).
-SCHEMA_GLOBAL_COST = vol.Schema(
-    {
-        vol.Required(SECTION_COST_PRICING): section(SCHEMA_COST_PRICING),
-        vol.Required(SECTION_COST_NAMING): section(SCHEMA_GLOBAL_COST_NAMING, {"collapsed": True}),
-    },
-)
+
+def is_energy_price_unit(unit: str | None) -> bool:
+    """Check whether a unit of measurement expresses a price per unit of energy.
+
+    Price sensors use `<currency>/<energy unit>`, for example `€/kWh`, `EUR/kWh` or `ct/MWh`.
+    The currency part is free form (currency codes, symbols and cents are all in the wild), so
+    only the energy denominator is validated, mirroring what the cost sensor accepts at runtime.
+    """
+    if not unit or "/" not in unit:
+        return False
+    currency, _, denominator = unit.rpartition("/")
+    return bool(currency.strip()) and denominator.strip() in EnergyConverter.VALID_UNITS
+
+
+def _energy_price_units(hass: HomeAssistant, current_entity_id: str | None) -> list[str] | None:
+    """Collect the price units to filter the energy price sensor picker on.
+
+    Returns None when the picker must not be filtered at all. The Home Assistant frontend
+    matches this filter on the exact unit string and hides entities without a unit, so filtering
+    is only safe when we can be sure it does not hide a sensor the user needs: the units are
+    taken from the sensors actually present rather than from a hardcoded list of currencies, and
+    an already configured price sensor which would not survive the filter disables it entirely.
+    """
+    if current_entity_id:
+        current_state = hass.states.get(current_entity_id)
+        if not current_state or not is_energy_price_unit(current_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+            return None
+
+    units = {
+        unit
+        for state in hass.states.async_all(SENSOR_DOMAIN)
+        if is_energy_price_unit(unit := state.attributes.get(ATTR_UNIT_OF_MEASUREMENT))
+    }
+    return sorted(units) or None
+
+
+def build_cost_pricing_schema(hass: HomeAssistant, current_entity_id: str | None = None) -> vol.Schema:
+    """Return the pricing schema with the energy price sensor picker limited to price sensors.
+
+    `current_entity_id` is the price sensor already configured, if any, so an options flow never
+    hides the current selection.
+    """
+    units = _energy_price_units(hass, current_entity_id)
+    if units is None:
+        return SCHEMA_COST_PRICING
+
+    entity_filter: EntityWithDeviceFilterSelectorConfig = {"domain": SENSOR_DOMAIN, "unit_of_measurement": units}
+    schema: vol.Schema = SCHEMA_COST_PRICING.extend(
+        {
+            vol.Optional(CONF_ENERGY_PRICE_SENSOR): selector.EntitySelector(
+                selector.EntitySelectorConfig(filter=entity_filter),
+            ),
+        },
+    )
+    return schema
+
+
+def build_global_cost_schema(hass: HomeAssistant, current_entity_id: str | None = None) -> vol.Schema:
+    """Return the global cost schema, presented in the GUI as two sections (pricing and naming)."""
+    return vol.Schema(
+        {
+            vol.Required(SECTION_COST_PRICING): section(build_cost_pricing_schema(hass, current_entity_id)),
+            vol.Required(SECTION_COST_NAMING): section(SCHEMA_GLOBAL_COST_NAMING, {"collapsed": True}),
+        },
+    )
+
 
 # Flat variant with all cost keys, used to merge/clear the (un)nested user input.
 SCHEMA_GLOBAL_COST_FLAT = SCHEMA_COST_PRICING.extend(SCHEMA_GLOBAL_COST_NAMING.schema)

--- a/tests/config_flow/test_cost.py
+++ b/tests/config_flow/test_cost.py
@@ -14,6 +14,7 @@ from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_CREATE_COST_SENSOR,
     CONF_ENERGY_PRICE,
+    CONF_ENERGY_PRICE_SENSOR,
     CONF_ENERGY_SENSOR_ID,
     CONF_FIXED,
     CONF_MODE,
@@ -22,7 +23,7 @@ from custom_components.powercalc.const import (
     CalculationStrategy,
     SensorType,
 )
-from custom_components.powercalc.flow_helper.schema import SECTION_COST_PRICING
+from custom_components.powercalc.flow_helper.schema import SECTION_COST_PRICING, build_cost_pricing_schema
 from tests.common import create_mock_config_entry, run_powercalc_setup, set_states
 from tests.config_flow.common import (
     handle_options_flow_update,
@@ -205,3 +206,52 @@ async def test_cost_options_flow(hass: HomeAssistant) -> None:
     )
 
     assert entry.data[CONF_ENERGY_SENSOR_ID] == "sensor.other_energy"
+
+
+def _price_sensor_selector_config(hass: HomeAssistant, current_entity_id: str | None = None) -> dict:
+    """Return the selector config of the energy price sensor field."""
+    schema = build_cost_pricing_schema(hass, current_entity_id)
+    return schema.schema[CONF_ENERGY_PRICE_SENSOR].config  # type: ignore[no-any-return]
+
+
+@pytest.mark.parametrize(
+    "unit",
+    ["€/kWh", "EUR/kWh", "ct/kWh", "EUR/MWh"],
+)
+async def test_energy_price_sensor_selector_filters_on_price_units(hass: HomeAssistant, unit: str) -> None:
+    """The picker lists price sensors by their `<currency>/<energy>` unit.
+
+    Filtering on the `monetary` device class instead listed only cost sensors, since price
+    sensors have no device class at all, see #4422.
+    """
+    await set_states(hass, [("sensor.energy_price", "0.32", {ATTR_UNIT_OF_MEASUREMENT: unit})])
+    await set_states(hass, [("sensor.existing_energy", "10", _KWH)])
+
+    config = _price_sensor_selector_config(hass)
+
+    assert config["filter"] == [{"domain": ["sensor"], ATTR_UNIT_OF_MEASUREMENT: [unit]}]
+    assert "device_class" not in config
+
+
+async def test_energy_price_sensor_selector_is_unfiltered_without_price_sensors(hass: HomeAssistant) -> None:
+    """Without any price sensor to filter on, all sensors are listed rather than none."""
+    await set_states(hass, [("sensor.existing_energy", "10", _KWH)])
+
+    config = _price_sensor_selector_config(hass)
+
+    assert config["domain"] == ["sensor"]
+    assert "filter" not in config
+
+
+async def test_energy_price_sensor_selector_keeps_configured_sensor_visible(hass: HomeAssistant) -> None:
+    """A configured price sensor without a price unit disables the filter.
+
+    Otherwise the options flow would hide the very sensor that is currently in use.
+    """
+    await set_states(hass, [("sensor.energy_price", "0.32", {ATTR_UNIT_OF_MEASUREMENT: "€/kWh"})])
+    await set_states(hass, [("sensor.unitless_price", "0.32", {})])
+
+    config = _price_sensor_selector_config(hass, "sensor.unitless_price")
+
+    assert config["domain"] == ["sensor"]
+    assert "filter" not in config


### PR DESCRIPTION
Energy price sensor selector was incorrectly filtered on monetary sensors. That caused only cost sensors to be returned, but not the EUR/kWh sensors etc.
It's now corrected and Powercalc will scan the HA installation for all */kWh sensors