### PR TITLE
Reduce test suite duplication with shared helpers

### DIFF
--- a/tests/analytics/test_analytics.py
+++ b/tests/analytics/test_analytics.py
@@ -11,7 +11,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 import pytest
-from pytest_homeassistant_custom_component.common import async_fire_time_changed
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
 from custom_components.powercalc import (
@@ -38,7 +37,7 @@ from custom_components.powercalc.const import (
     PowerProfileSource,
     SensorType,
 )
-from tests.common import create_mock_config_entry, get_simple_fixed_config, run_powercalc_setup
+from tests.common import async_advance_time, create_mock_config_entry, get_simple_fixed_config, run_powercalc_setup
 
 MOCK_PAYLOAD = {
     "test": "data",
@@ -63,7 +62,6 @@ def enable_analytics(hass: HomeAssistant) -> Generator[None]:
 async def test_send_analytics_success(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the send_analytics method with a successful response."""
 
@@ -85,11 +83,7 @@ async def test_send_analytics_success(
         },
     )
 
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(minutes=20),
-    )
-    await hass.async_block_till_done()
+    await async_advance_time(hass, timedelta(minutes=20))
 
     assert len(aioclient_mock.mock_calls) == 1
     mock_call = aioclient_mock.mock_calls[0]

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,32 +1,29 @@
 from collections.abc import Mapping
+from datetime import timedelta
 import os
 from typing import Any
 import uuid
 
 from homeassistant import config_entries
-from homeassistant.components import input_boolean, light
-from homeassistant.components.light import ColorMode
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_NAME,
-    CONF_PLATFORM,
     CONF_UNIQUE_ID,
     EVENT_HOMEASSISTANT_STARTED,
-    STATE_ON,
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.helpers.typing import ConfigType, StateType
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     RegistryEntryWithDefaults,
+    async_fire_time_changed,
     mock_device_registry,
     mock_registry,
-    setup_test_component_platform,
 )
 
 from custom_components.powercalc import (
@@ -47,63 +44,10 @@ from custom_components.powercalc.const import (
     CalculationStrategy,
     SensorType,
 )
-import custom_components.test.light as test_light_platform
 
 type StateDefinition = (
     tuple[str, StateType] | tuple[str, StateType, Mapping[str, Any]] | tuple[str, StateType, Mapping[str, Any], bool]
 )
-
-
-async def create_mock_light_entity(
-    hass: HomeAssistant,
-    entities: test_light_platform.MockLight | list[test_light_platform.MockLight],
-) -> None:
-    """Create a mocked light entity, and bind it to a device having a manufacturer/model"""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-
-    if not isinstance(entities, list):
-        entities = [entities]
-
-    setup_test_component_platform(hass, light.DOMAIN, entities)
-
-    assert await async_setup_component(
-        hass,
-        light.DOMAIN,
-        {light.DOMAIN: {CONF_PLATFORM: "test"}},
-    )
-    await hass.async_block_till_done()
-
-    # Bind to device
-    for entity in entities:
-        config_entry = MockConfigEntry(domain="test")
-        config_entry.add_to_hass(hass)
-        device_entry = device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
-            connections={("dummy", entity.unique_id)},
-            manufacturer=entity.manufacturer,
-            model=entity.model,
-        )
-
-        entity_registry.async_get_or_create(
-            "light",
-            "test",
-            entity.unique_id,
-            device_id=device_entry.id,
-        )
-        await hass.async_block_till_done()
-
-
-def create_discoverable_light(
-    name: str,
-    unique_id: str = "99f899fefes",
-) -> test_light_platform.MockLight:
-    light = test_light_platform.MockLight(name, STATE_ON, unique_id)
-    light.manufacturer = "lidl"
-    light.model = "HG06462A"
-    light.supported_color_modes = [ColorMode.BRIGHTNESS]
-    light.brightness = 125
-    return light
 
 
 async def run_powercalc_setup(
@@ -132,25 +76,6 @@ async def run_powercalc_setup(
     await hass.async_block_till_done()
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    await hass.async_block_till_done()
-
-
-async def create_input_boolean(hass: HomeAssistant, name: str = "test") -> None:
-    assert await async_setup_component(
-        hass,
-        input_boolean.DOMAIN,
-        {"input_boolean": {name: None}},
-    )
-    await hass.async_block_till_done()
-
-
-async def create_input_booleans(hass: HomeAssistant, names: list[str]) -> None:
-    config = {"input_boolean": dict.fromkeys(names)}
-    assert await async_setup_component(
-        hass,
-        input_boolean.DOMAIN,
-        config,
-    )
     await hass.async_block_till_done()
 
 
@@ -206,23 +131,114 @@ async def create_mock_config_entry(
     return config_entry
 
 
+async def create_mock_group_entry(
+    hass: HomeAssistant,
+    name: str,
+    entry_data: dict | None = None,
+    **kwargs: Any,  # noqa: ANN401
+) -> MockConfigEntry:
+    """Add a Powercalc group config entry named `name`."""
+    return await create_mock_config_entry(
+        hass,
+        {CONF_SENSOR_TYPE: SensorType.GROUP, CONF_NAME: name, **(entry_data or {})},
+        **kwargs,
+    )
+
+
+def mock_devices(
+    hass: HomeAssistant,
+    devices: Mapping[str, Mapping[str, Any] | None],
+) -> dict[str, DeviceEntry]:
+    """Register mocked devices, replacing any prior mocked registry.
+
+    Keys are device ids, values the extra `DeviceEntry` kwargs. Entries without an explicit
+    `config_entry_id` share a single mock config entry. Devices cannot be registered one by one,
+    every call replaces the whole registry, so pass all of them at once.
+    """
+    shared_config_entry_id: str | None = None
+    entries: dict[str, DeviceEntry] = {}
+    for device_id, device_kwargs in devices.items():
+        kwargs = dict(device_kwargs or {})
+        if "config_entry_id" not in kwargs:
+            if shared_config_entry_id is None:
+                config_entry = MockConfigEntry(domain="test")
+                config_entry.add_to_hass(hass)
+                shared_config_entry_id = config_entry.entry_id
+            kwargs["config_entry_id"] = shared_config_entry_id
+        entries[device_id] = DeviceEntry(id=device_id, **kwargs)
+
+    mock_device_registry(hass, entries)
+    return entries
+
+
 def mock_device(
     hass: HomeAssistant,
     device_id: str = "test-device",
-    manufacturer: str = "test",
-    model: str = "test",
+    manufacturer: str | None = "test",
+    model: str | None = "test",
     **kwargs: Any,  # noqa: ANN401
 ) -> DeviceEntry:
-    """Register a single mocked device, replacing any prior mocked registry."""
-    config_entry_id = kwargs.pop("config_entry_id", None)
-    if config_entry_id is None:
-        config_entry = MockConfigEntry(domain="test")
-        config_entry.add_to_hass(hass)
-        config_entry_id = config_entry.entry_id
+    """Register a single mocked device, replacing any prior mocked registry.
 
-    entry = DeviceEntry(config_entry_id=config_entry_id, id=device_id, manufacturer=manufacturer, model=model, **kwargs)
-    mock_device_registry(hass, {device_id: entry})
-    return entry
+    Use `mock_devices` when a test needs more than one device.
+    """
+    return mock_devices(hass, {device_id: {"manufacturer": manufacturer, "model": model, **kwargs}})[device_id]
+
+
+def mock_entities_in_registry(
+    hass: HomeAssistant,
+    entities: Mapping[str, Mapping[str, Any] | None],
+) -> EntityRegistry:
+    """Register mocked entities, replacing any prior mocked registry.
+
+    Keys are entity ids, values the extra `RegistryEntryWithDefaults` kwargs. `platform` defaults
+    to the domain of the entity id and `unique_id` is derived from it, so a test only needs to spell
+    out the fields it actually cares about.
+    """
+    entries = {}
+    for entity_id, entity_kwargs in entities.items():
+        kwargs = dict(entity_kwargs or {})
+        kwargs.setdefault("platform", split_entity_id(entity_id)[0])
+        kwargs.setdefault("unique_id", entity_id)
+        entries[entity_id] = RegistryEntryWithDefaults(entity_id=entity_id, **kwargs)
+
+    return mock_registry(hass, entries)
+
+
+def mock_device_with_entities(
+    hass: HomeAssistant,
+    entity_ids: str | list[str],
+    manufacturer: str = "signify",
+    model: str = "LCT010",
+    model_id: str | None = None,
+    **entity_kwargs: Any,  # noqa: ANN401
+) -> None:
+    """Register entities on a single device carrying manufacturer/model info, so discovery can match a profile.
+
+    Replaces both registries, so call it once per test and use `mock_devices` /
+    `mock_entities_in_registry` directly when a test needs several devices or per-entity kwargs.
+    """
+    device_id = "model-device"
+    mock_devices(hass, {device_id: {"manufacturer": manufacturer, "model": model, "model_id": model_id}})
+
+    if isinstance(entity_ids, str):
+        entity_ids = [entity_ids]
+    unique_id = entity_kwargs.pop("unique_id", None)
+    mock_entities_in_registry(
+        hass,
+        {
+            entity_id: {
+                "platform": "foo",
+                "device_id": device_id,
+                # Keep unique ids distinct when one explicit id is shared by several entities.
+                **(
+                    {"unique_id": f"{unique_id}_{entity_id}" if len(entity_ids) > 1 else unique_id} if unique_id else {}
+                ),
+                **entity_kwargs,
+            }
+            for entity_id in entity_ids
+        },
+    )
 
 
 async def migrate_legacy_entry(
@@ -266,24 +282,14 @@ def mock_sensors_in_registry(
     power_entities: list[str] | None = None,
     energy_entities: list[str] | None = None,
 ) -> EntityRegistry:
-    entries = {}
-    for entity_id in power_entities or []:
-        entries[entity_id] = RegistryEntryWithDefaults(
-            entity_id=entity_id,
-            name=entity_id,
-            unique_id=entity_id,
-            platform="sensor",
-            device_class=SensorDeviceClass.POWER,
-        )
-    for entity_id in energy_entities or []:
-        entries[entity_id] = RegistryEntryWithDefaults(
-            entity_id=entity_id,
-            name=entity_id,
-            unique_id=entity_id,
-            platform="sensor",
-            device_class=SensorDeviceClass.ENERGY,
-        )
-    return mock_registry(hass, entries)
+    """Register power and/or energy sensors, named after their entity id."""
+    return mock_entities_in_registry(
+        hass,
+        {
+            **{eid: {"name": eid, "device_class": SensorDeviceClass.POWER} for eid in power_entities or []},
+            **{eid: {"name": eid, "device_class": SensorDeviceClass.ENERGY} for eid in energy_entities or []},
+        },
+    )
 
 
 async def set_states(hass: HomeAssistant, states: list[StateDefinition], block_count: int = 1) -> None:
@@ -301,11 +307,31 @@ async def set_states(hass: HomeAssistant, states: list[StateDefinition], block_c
         await hass.async_block_till_done()
 
 
+async def async_advance_time(hass: HomeAssistant, delta: timedelta | float, block: bool = True) -> None:
+    """Fire a time changed event `delta` into the future, a plain number meaning seconds.
+
+    Pass `block=False` for the rare test that must inspect state before pending jobs are flushed.
+    """
+    if not isinstance(delta, timedelta):
+        delta = timedelta(seconds=delta)
+    async_fire_time_changed(hass, dt.utcnow() + delta)
+    if block:
+        await hass.async_block_till_done()
+
+
 def assert_entity_state(
     hass: HomeAssistant,
     entity_id: str,
-    expected_state: StateType,
+    expected_state: StateType = None,
+    attributes: Mapping[str, Any] | None = None,
 ) -> None:
+    """Assert an entity exists and, when given, that its state and attributes match.
+
+    Pass `expected_state=None` to only assert on the attributes.
+    """
     state = hass.states.get(entity_id)
-    assert state
-    assert state.state == expected_state
+    assert state, f"Entity {entity_id} not found"
+    if expected_state is not None:
+        assert state.state == expected_state
+    for attribute, expected in (attributes or {}).items():
+        assert state.attributes.get(attribute) == expected, f"Attribute {attribute} of {entity_id} does not match"

--- a/tests/config_flow/test_cost.py
+++ b/tests/config_flow/test_cost.py
@@ -8,7 +8,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 import pytest
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_registry
 
 from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
@@ -24,7 +23,13 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.flow_helper.schema import SECTION_COST_PRICING, build_cost_pricing_schema
-from tests.common import create_mock_config_entry, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    create_mock_config_entry,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 from tests.config_flow.common import (
     handle_options_flow_update,
     initialize_options_flow,
@@ -36,14 +41,10 @@ _KWH = {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR}
 
 
 def _mock_energy_sensor(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_energy",
-                unique_id="1234",
-                platform="sensor",
-            ),
+            "sensor.existing_energy": {},
         },
     )
 
@@ -174,9 +175,7 @@ async def test_cost_flow_creates_sensor(hass: HomeAssistant) -> None:
     assert result["data"][CONF_SENSOR_TYPE] == SensorType.COST
     assert result["data"][CONF_ENERGY_SENSOR_ID] == "sensor.existing_energy"
 
-    cost_state = hass.states.get("sensor.fridge_cost")
-    assert cost_state
-    assert cost_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
+    assert_entity_state(hass, "sensor.fridge_cost", attributes={ATTR_UNIT_OF_MEASUREMENT: "EUR"})
 
     await set_states(hass, [("sensor.existing_energy", "10", _KWH)])  # baseline
     await set_states(hass, [("sensor.existing_energy", "20", _KWH)])  # +10 kWh * 0.25

--- a/tests/config_flow/test_discovery.py
+++ b/tests/config_flow/test_discovery.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.selector import SelectSelector
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_device_registry, mock_registry
+from pytest_homeassistant_custom_component.common import mock_device_registry
 import voluptuous as vol
 
 from custom_components.powercalc.common import SourceEntity, create_source_entity
@@ -23,7 +23,13 @@ from custom_components.powercalc.const import (
 from custom_components.powercalc.discovery import get_power_profile_by_source_entity
 from custom_components.powercalc.power_profile.factory import get_power_profile
 from custom_components.powercalc.power_profile.library import ModelInfo
-from tests.common import create_mock_config_entry, get_test_profile_dir
+from tests.common import (
+    create_mock_config_entry,
+    get_test_profile_dir,
+    mock_device,
+    mock_device_with_entities,
+    mock_entities_in_registry,
+)
 from tests.config_flow.common import (
     DEFAULT_ENTITY_ID,
     DEFAULT_UNIQUE_ID,
@@ -31,14 +37,13 @@ from tests.config_flow.common import (
     handle_options_flow_update,
     initialize_discovery_flow,
 )
-from tests.conftest import MockEntityWithModel
 
 
 async def test_discovery_flow(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "signify",
         "LCT010",
@@ -71,35 +76,17 @@ async def test_discovery_flow_remarks_are_shown(hass: HomeAssistant) -> None:
 
 async def _setup_ups_discovery_flow(hass: HomeAssistant) -> tuple[SourceEntity, data_entry_flow.FlowResult]:
     """Set up UPS device with translation key entities and initialize discovery flow."""
-    device_entry = DeviceEntry(
-        config_entry_id="test",
-        name="UPS",
-        id="ups-device",
-        manufacturer="test",
-        model="discovery_translation_key",
-    )
-    mock_device_registry(
+    device_entry = mock_device(hass, "ups-device", model="discovery_translation_key", name="UPS")
+    mock_entities_in_registry(
         hass,
         {
-            device_entry.id: device_entry,
-        },
-    )
-    mock_registry(
-        hass,
-        {
-            "sensor.ups_output": RegistryEntryWithDefaults(
-                entity_id="sensor.ups_output",
-                unique_id="ups_output",
-                device_id=device_entry.id,
-                platform="test",
-            ),
-            "sensor.ups_nominal_power": RegistryEntryWithDefaults(
-                entity_id="sensor.ups_nominal_power",
-                unique_id="ups_nominal_power",
-                device_id=device_entry.id,
-                platform="test",
-                translation_key="ups_power_nominal",
-            ),
+            "sensor.ups_output": {"unique_id": "ups_output", "device_id": device_entry.id, "platform": "test"},
+            "sensor.ups_nominal_power": {
+                "unique_id": "ups_nominal_power",
+                "device_id": device_entry.id,
+                "platform": "test",
+                "translation_key": "ups_power_nominal",
+            },
         },
     )
 
@@ -126,19 +113,7 @@ async def test_discovery_flow_remarks_are_hidden_when_translation_key_entities_r
 
 
 async def test_discovery_flow_uses_device_name_as_source_placeholder(hass: HomeAssistant) -> None:
-    device_entry = DeviceEntry(
-        config_entry_id="test",
-        name="FooBar",
-        id="youless-device",
-        manufacturer="test",
-        model="discovery_type_device",
-    )
-    mock_device_registry(
-        hass,
-        {
-            device_entry.id: device_entry,
-        },
-    )
+    device_entry = mock_device(hass, "youless-device", model="discovery_type_device", name="FooBar")
     source_entity = SourceEntity(
         object_id=device_entry.name,
         name=device_entry.name,
@@ -154,28 +129,11 @@ async def test_discovery_flow_uses_device_name_as_source_placeholder(hass: HomeA
 
 
 async def test_discovery_flow_remarks_are_shown_when_translation_key_entity_missing(hass: HomeAssistant) -> None:
-    device_entry = DeviceEntry(
-        config_entry_id="test",
-        name="UPS",
-        id="ups-device",
-        manufacturer="test",
-        model="discovery_translation_key",
-    )
-    mock_device_registry(
+    device_entry = mock_device(hass, "ups-device", model="discovery_translation_key", name="UPS")
+    mock_entities_in_registry(
         hass,
         {
-            device_entry.id: device_entry,
-        },
-    )
-    mock_registry(
-        hass,
-        {
-            "sensor.ups_output": RegistryEntryWithDefaults(
-                entity_id="sensor.ups_output",
-                unique_id="ups_output",
-                device_id=device_entry.id,
-                platform="test",
-            ),
+            "sensor.ups_output": {"unique_id": "ups_output", "device_id": device_entry.id, "platform": "test"},
         },
     )
 
@@ -206,9 +164,9 @@ async def test_discovery_flow_auto_resolves_availability_entity_from_translation
 
 async def test_discovery_flow_with_subprofile_selection(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "lifx",
         "LIFX Z",
@@ -241,10 +199,10 @@ async def test_discovery_flow_with_subprofile_selection(
 
 async def test_discovery_flow_multi_profiles(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """Test that discovery provides the user with a choice when multiple profiles are available"""
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "signify",
         "LCT010",
@@ -305,28 +263,11 @@ async def test_autodiscovered_option_flow(hass: HomeAssistant) -> None:
 
 
 async def test_discovery_by_device(hass: HomeAssistant) -> None:
-    device_entry = DeviceEntry(
-        config_entry_id="test",
-        name="FooBar",
-        id="youless-device",
-        manufacturer="test",
-        model="discovery_type_device",
-    )
-    mock_device_registry(
+    device_entry = mock_device(hass, "youless-device", model="discovery_type_device", name="FooBar")
+    mock_entities_in_registry(
         hass,
         {
-            device_entry.id: device_entry,
-        },
-    )
-    mock_registry(
-        hass,
-        {
-            "switch.test": RegistryEntryWithDefaults(
-                entity_id="switch.test",
-                unique_id="54543",
-                device_id=device_entry.id,
-                platform="youless",
-            ),
+            "switch.test": {"device_id": device_entry.id, "platform": "youless"},
         },
     )
     source_entity = SourceEntity(

--- a/tests/config_flow/test_dynamic_field_builder.py
+++ b/tests/config_flow/test_dynamic_field_builder.py
@@ -2,12 +2,11 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import EntitySelector, NumberSelector
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_registry
 
 from custom_components.powercalc.common import SourceEntity, create_source_entity
 from custom_components.powercalc.flow_helper.dynamic_field_builder import build_dynamic_field_schema
 from custom_components.powercalc.power_profile.power_profile import PowerProfile
-from tests.common import mock_device
+from tests.common import mock_device, mock_entities_in_registry
 
 
 def test_build_schema(hass: HomeAssistant) -> None:
@@ -110,21 +109,11 @@ def test_entity_pick_filter_by_device(hass: HomeAssistant) -> None:
         name="Test Device",
     )
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test1": RegistryEntryWithDefaults(
-                entity_id="sensor.test1",
-                unique_id="unique_test1",
-                platform="test_platform",
-                device_id="device_123",
-            ),
-            "switch.test2": RegistryEntryWithDefaults(
-                entity_id="switch.test2",
-                unique_id="unique_test2",
-                platform="test_platform",
-                device_id="device_123",
-            ),
+            "sensor.test1": {"unique_id": "unique_test1", "platform": "test_platform", "device_id": "device_123"},
+            "switch.test2": {"unique_id": "unique_test2", "platform": "test_platform", "device_id": "device_123"},
         },
     )
 

--- a/tests/config_flow/test_global_configuration.py
+++ b/tests/config_flow/test_global_configuration.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import timedelta
 from typing import Any
 
@@ -748,7 +747,7 @@ async def test_entities_are_reloaded_reflecting_changes(hass: HomeAssistant) -> 
         Step.GLOBAL_CONFIGURATION,
         {CONF_POWER_SENSOR_PRECISION: 4},
     )
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     assert_entity_state(hass, "sensor.test_power", "50.0000")
 

--- a/tests/config_flow/test_group.py
+++ b/tests/config_flow/test_group.py
@@ -8,14 +8,14 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_SENSOR_TYPE,
+    STATE_ON,
     Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.area_registry import AreaRegistry
-from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.helpers.floor_registry import FloorRegistry
 from homeassistant.helpers.selector import SelectSelector
-from pytest_homeassistant_custom_component.common import MockConfigEntry, RegistryEntryWithDefaults, mock_registry
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
 
 from custom_components.powercalc import SensorType
@@ -54,13 +54,14 @@ from custom_components.powercalc.const import (
 )
 from custom_components.powercalc.flow_helper.flows.group import SECTION_GROUP_MEMBERS, SECTION_GROUP_OPTIONS
 from custom_components.powercalc.sensors.group.config_entry_utils import add_to_associated_groups
-from custom_components.test.light import MockLight
 from tests.common import (
+    assert_entity_state,
     create_mock_config_entry,
-    create_mock_light_entity,
+    create_mock_group_entry,
     create_mocked_virtual_power_sensor_entry,
     migrate_legacy_entry,
     mock_device,
+    mock_entities_in_registry,
     run_powercalc_setup,
     set_states,
 )
@@ -158,23 +159,11 @@ async def test_create_energy_sensor_enabled(hass: HomeAssistant) -> None:
 async def test_add_device_members_to_group(hass: HomeAssistant) -> None:
     mock_device(hass, "my-device", "Mock", "Device", name="My device")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.balcony_power": RegistryEntryWithDefaults(
-                entity_id="sensor.balcony_power",
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                device_id="my-device",
-            ),
-            "sensor.balcony_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.balcony_energy",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-                device_id="my-device",
-            ),
+            "sensor.balcony_power": {"device_class": SensorDeviceClass.POWER, "device_id": "my-device"},
+            "sensor.balcony_energy": {"device_class": SensorDeviceClass.ENERGY, "device_id": "my-device"},
         },
     )
 
@@ -202,25 +191,19 @@ async def test_add_device_members_to_group(hass: HomeAssistant) -> None:
     }
 
     await set_states(hass, [("sensor.balcony_power", 5), ("sensor.balcony_energy", 5)])
-    power_state = hass.states.get("sensor.my_group_sensor_power")
-    assert power_state
-    assert power_state.attributes.get(CONF_ENTITIES) == {"sensor.balcony_power"}
+    assert_entity_state(hass, "sensor.my_group_sensor_power", attributes={CONF_ENTITIES: {"sensor.balcony_power"}})
 
-    energy_state = hass.states.get("sensor.my_group_sensor_energy")
-    assert energy_state
-    assert energy_state.attributes.get(CONF_ENTITIES) == {"sensor.balcony_energy"}
+    assert_entity_state(hass, "sensor.my_group_sensor_energy", attributes={CONF_ENTITIES: {"sensor.balcony_energy"}})
 
 
 async def test_group_include_area(
     hass: HomeAssistant,
-    entity_registry: EntityRegistry,
     area_registry: AreaRegistry,
 ) -> None:
     # Create light entity and add to group My area
-    light = MockLight("test")
-    await create_mock_light_entity(hass, light)
     area = area_registry.async_get_or_create("My area")
-    entity_registry.async_update_entity(light.entity_id, area_id=area.id)
+    mock_entities_in_registry(hass, {"light.test": {"area_id": area.id}})
+    await set_states(hass, [("light.test", STATE_ON)])
 
     result = await goto_virtual_power_strategy_step(
         hass,
@@ -271,9 +254,7 @@ async def test_group_include_area(
     }
 
     await set_states(hass, [("sensor.test_power", 5)])
-    power_state = hass.states.get("sensor.my_group_sensor_power")
-    assert power_state
-    assert power_state.attributes.get(CONF_ENTITIES) == {"sensor.test_power"}
+    assert_entity_state(hass, "sensor.my_group_sensor_power", attributes={CONF_ENTITIES: {"sensor.test_power"}})
 
     energy_state = hass.states.get("sensor.my_group_sensor_energy")
     assert energy_state
@@ -292,16 +273,10 @@ async def test_group_include_floor(
     area = area_registry.async_get_or_create("My area")
     area_registry.async_update(area.id, floor_id=floor.floor_id)
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_power": RegistryEntryWithDefaults(
-                entity_id="sensor.test_power",
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                area_id=area.id,
-            ),
+            "sensor.test_power": {"device_class": SensorDeviceClass.POWER, "area_id": area.id},
         },
     )
 
@@ -320,18 +295,15 @@ async def test_group_include_floor(
     assert result["data"][CONF_FLOOR] == floor.floor_id
 
     await set_states(hass, [("sensor.test_power", 5)])
-    power_state = hass.states.get("sensor.my_floor_group_power")
-    assert power_state
-    assert power_state.attributes.get(CONF_ENTITIES) == {"sensor.test_power"}
+    assert_entity_state(hass, "sensor.my_floor_group_power", attributes={CONF_ENTITIES: {"sensor.test_power"}})
 
 
 async def test_can_unset_area(hass: HomeAssistant, area_registry: AreaRegistry) -> None:
     area_registry.async_get_or_create("My area")
-    config_entry = await create_mock_config_entry(
+    config_entry = await create_mock_group_entry(
         hass,
+        "TestArea",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestArea",
             CONF_AREA: "My area",
         },
         setup=False,
@@ -362,22 +334,11 @@ async def test_include_area_powercalc_only(
     area_registry: AreaRegistry,
 ) -> None:
     area = area_registry.async_get_or_create("My area")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.switch": RegistryEntryWithDefaults(
-                entity_id="switch.switch",
-                unique_id="1111",
-                platform="switch",
-                area_id=area.id,
-            ),
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_power",
-                unique_id="3333",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                area_id=area.id,
-            ),
+            "switch.switch": {"area_id": area.id},
+            "sensor.existing_power": {"device_class": SensorDeviceClass.POWER, "area_id": area.id},
         },
     )
 
@@ -401,9 +362,7 @@ async def test_include_area_powercalc_only(
     assert not result["data"][CONF_INCLUDE_NON_POWERCALC_SENSORS]
 
     await set_states(hass, [("sensor.test_power", 5)])
-    power_state = hass.states.get("sensor.my_group_sensor_power")
-    assert power_state
-    assert power_state.attributes.get(CONF_ENTITIES) == {"sensor.test_power"}
+    assert_entity_state(hass, "sensor.my_group_sensor_power", attributes={CONF_ENTITIES: {"sensor.test_power"}})
 
 
 async def test_can_select_existing_powercalc_entry_as_group_member(
@@ -504,10 +463,12 @@ async def test_real_power_entry_selectable_as_group_member(
     )
 
     await set_states(hass, [("sensor.real_power", "25.00")])
-    group_state = hass.states.get("sensor.my_group_sensor_power")
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.virtualpower1_power", "sensor.real_power"}
-    assert group_state
-    assert group_state.state == "75.00"
+    assert_entity_state(
+        hass,
+        "sensor.my_group_sensor_power",
+        "75.00",
+        attributes={ATTR_ENTITIES: {"sensor.virtualpower1_power", "sensor.real_power"}},
+    )
 
 
 async def test_group_error_mandatory(hass: HomeAssistant) -> None:
@@ -619,11 +580,10 @@ async def test_migrate_config_entry_from_version_2(hass: HomeAssistant) -> None:
 
 
 async def test_create_group_on_demand_from_virtual_power_flow(hass: HomeAssistant) -> None:
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_TYPE: GroupType.CUSTOM,
         },
         setup=False,

--- a/tests/config_flow/test_real_power.py
+++ b/tests/config_flow/test_real_power.py
@@ -3,10 +3,6 @@ from homeassistant.components.utility_meter.const import DAILY, WEEKLY
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_ENTITY_ID, CONF_NAME, CONF_SENSOR_TYPE
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    mock_registry,
-)
 
 from custom_components.powercalc import (
     CONF_CREATE_UTILITY_METERS,
@@ -23,7 +19,7 @@ from custom_components.powercalc.const import (
     ENERGY_INTEGRATION_METHOD_TRAPEZODIAL,
     UnitPrefix,
 )
-from tests.common import create_mock_config_entry, mock_device
+from tests.common import assert_entity_state, create_mock_config_entry, mock_device, mock_entities_in_registry
 from tests.config_flow.common import (
     handle_options_flow_update,
     select_menu_item,
@@ -65,15 +61,10 @@ async def test_energy_sensor_is_bound_to_power_device(hass: HomeAssistant) -> No
     power_sensor_id = "sensor.my_power"
     device_id = "test"
 
-    entity_registry = mock_registry(
+    entity_registry = mock_entities_in_registry(
         hass,
         {
-            power_sensor_id: RegistryEntryWithDefaults(
-                entity_id=power_sensor_id,
-                unique_id="123",
-                platform="sensor",
-                device_id=device_id,
-            ),
+            power_sensor_id: {"platform": "sensor", "device_id": device_id},
         },
     )
     mock_device(hass, device_id, "foo", "bar")
@@ -122,9 +113,7 @@ async def test_real_power_options(hass: HomeAssistant) -> None:
     assert entry.data[CONF_ENTITY_ID] == "sensor.my_new_real_power"
     assert entry.data[CONF_CREATE_UTILITY_METERS]
 
-    state = hass.states.get("sensor.some_name_energy")
-    assert state
-    assert state.attributes.get("source") == "sensor.my_new_real_power"
+    assert_entity_state(hass, "sensor.some_name_energy", attributes={"source": "sensor.my_new_real_power"})
 
 
 async def test_energy_options_flow(hass: HomeAssistant) -> None:
@@ -163,14 +152,10 @@ async def test_attach_to_custom_device(hass: HomeAssistant) -> None:
     power_sensor_id = "sensor.my_smart_plug"
     device_id = "media_player.my_tv"
 
-    entity_registry = mock_registry(
+    entity_registry = mock_entities_in_registry(
         hass,
         {
-            power_sensor_id: RegistryEntryWithDefaults(
-                entity_id=power_sensor_id,
-                unique_id="123",
-                platform="sensor",
-            ),
+            power_sensor_id: {"platform": "sensor"},
         },
     )
     mock_device(

--- a/tests/config_flow/test_smart_switch.py
+++ b/tests/config_flow/test_smart_switch.py
@@ -20,7 +20,13 @@ from custom_components.powercalc.const import (
     CalculationStrategy,
     SensorType,
 )
-from tests.common import assert_entity_state, create_mock_config_entry, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    create_mock_config_entry,
+    mock_device_with_entities,
+    run_powercalc_setup,
+    set_states,
+)
 from tests.config_flow.common import (
     DEFAULT_UNIQUE_ID,
     confirm_auto_discovered_model,
@@ -28,7 +34,6 @@ from tests.config_flow.common import (
     initialize_options_flow,
     select_menu_item,
 )
-from tests.conftest import MockEntityWithModel
 
 
 @pytest.mark.parametrize(
@@ -42,13 +47,13 @@ from tests.conftest import MockEntityWithModel
 )
 async def test_smart_switch_flow(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     user_input: dict[str, Any],
     expected_fixed_power: float,
 ) -> None:
     await run_powercalc_setup(hass)
 
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "switch.test",
         "test",
         "smart_switch_without_pm",

--- a/tests/config_flow/test_virtual_power_library.py
+++ b/tests/config_flow/test_virtual_power_library.py
@@ -4,10 +4,8 @@ from homeassistant import data_entry_flow
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import CONF_DEVICE, CONF_ENTITY_ID, CONF_NAME, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.selector import SelectSelector
 import pytest
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_device_registry, mock_registry
 import voluptuous as vol
 
 from custom_components.powercalc.common import SourceEntity, create_source_entity
@@ -32,8 +30,14 @@ from custom_components.powercalc.flow_helper.flows.library import CONF_CONFIRM_A
 from custom_components.powercalc.power_profile.factory import get_power_profile
 from custom_components.powercalc.power_profile.library import ModelInfo
 from custom_components.powercalc.power_profile.power_profile import DiscoveryBy
-from custom_components.test.light import MockLight
-from tests.common import create_mock_config_entry, create_mock_light_entity, mock_device
+from tests.common import (
+    create_mock_config_entry,
+    mock_device,
+    mock_device_with_entities,
+    mock_devices,
+    mock_entities_in_registry,
+    set_states,
+)
 from tests.config_flow.common import (
     DEFAULT_UNIQUE_ID,
     confirm_auto_discovered_model,
@@ -45,14 +49,13 @@ from tests.config_flow.common import (
     select_menu_item,
     set_virtual_power_configuration,
 )
-from tests.conftest import MockEntityWithModel
 
 
 async def test_manually_setup_from_library(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "ikea",
         "LED1545G12",
@@ -82,10 +85,10 @@ async def test_manually_setup_from_library(
 
 async def test_manual_setup_from_library_skips_to_manufacturer_step(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """Test that the flow skips to the manufacturer step if the model is not found in the library."""
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "ikea",
         "LEEEEE",
@@ -108,8 +111,8 @@ async def test_manual_setup_from_library_skips_to_manufacturer_step(
 async def test_manufacturer_listing_is_filtered_by_entity_domain(
     hass: HomeAssistant,
 ) -> None:
-    light_entity = MockLight("test", STATE_ON, DEFAULT_UNIQUE_ID)
-    await create_mock_light_entity(hass, light_entity)
+    mock_entities_in_registry(hass, {"light.test": {"unique_id": DEFAULT_UNIQUE_ID}})
+    await set_states(hass, [("light.test", STATE_ON)])
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
 
@@ -199,22 +202,15 @@ async def test_composite_library_profile_options_flow_builds_menu(
 ) -> None:
     mock_device(hass, "vacuum1", "roborock", "rockrobo.vacuum.v1")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "vacuum.robi": RegistryEntryWithDefaults(
-                entity_id="vacuum.robi",
-                unique_id="1111",
-                device_id="vacuum1",
-                platform="test",
-            ),
-            "sensor.robi_battery": RegistryEntryWithDefaults(
-                entity_id="sensor.robi_battery",
-                unique_id="2222",
-                device_id="vacuum1",
-                device_class=SensorDeviceClass.BATTERY,
-                platform="test",
-            ),
+            "vacuum.robi": {"device_id": "vacuum1", "platform": "test"},
+            "sensor.robi_battery": {
+                "device_id": "vacuum1",
+                "device_class": SensorDeviceClass.BATTERY,
+                "platform": "test",
+            },
         },
     )
 
@@ -321,15 +317,14 @@ async def test_device_discovered_entry_keeps_device_type_filter_in_library_optio
 
 
 async def test_config_entry_discovered_entry_keeps_discovery_filter_in_library_options(hass: HomeAssistant) -> None:
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "selected-device": DeviceEntry(
-                config_entry_id="source-entry",
-                id="selected-device",
-                manufacturer="test",
-                model="discovery_type_config_entry",
-            ),
+            "selected-device": {
+                "config_entry_id": "source-entry",
+                "manufacturer": "test",
+                "model": "discovery_type_config_entry",
+            },
         },
     )
     entry = await create_mock_config_entry(
@@ -493,12 +488,12 @@ def test_library_discovery_filter(
 
 async def test_profile_with_custom_fields(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         ["sensor.test", "sensor.foobar"],
         "test",
         "custom_fields",
@@ -545,21 +540,11 @@ async def test_manual_library_flow_autodiscovers_device_profile_with_custom_fiel
     hass: HomeAssistant,
 ) -> None:
     mock_device(hass, "test-device", "test", "device_custom_fields")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.test_device": RegistryEntryWithDefaults(
-                entity_id="switch.test_device",
-                unique_id="test-switch",
-                platform="test",
-                device_id="test-device",
-            ),
-            "sensor.test_dependency": RegistryEntryWithDefaults(
-                entity_id="sensor.test_dependency",
-                unique_id="test-dependency",
-                platform="test",
-                device_id="test-device",
-            ),
+            "switch.test_device": {"unique_id": "test-switch", "platform": "test", "device_id": "test-device"},
+            "sensor.test_dependency": {"unique_id": "test-dependency", "platform": "test", "device_id": "test-device"},
         },
     )
 
@@ -577,21 +562,11 @@ async def test_manual_library_flow_defers_device_profile_custom_field_validation
     hass: HomeAssistant,
 ) -> None:
     mock_device(hass, "test-device", "test", "device_custom_fields")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.test_device": RegistryEntryWithDefaults(
-                entity_id="switch.test_device",
-                unique_id="test-switch",
-                platform="test",
-                device_id="test-device",
-            ),
-            "sensor.test_dependency": RegistryEntryWithDefaults(
-                entity_id="sensor.test_dependency",
-                unique_id="test-dependency",
-                platform="test",
-                device_id="test-device",
-            ),
+            "switch.test_device": {"unique_id": "test-switch", "platform": "test", "device_id": "test-device"},
+            "sensor.test_dependency": {"unique_id": "test-dependency", "platform": "test", "device_id": "test-device"},
         },
     )
 
@@ -669,7 +644,6 @@ async def test_sub_profile_selection_omitted(hass: HomeAssistant) -> None:
 
 async def test_sub_profile_selection_discovery_by_device(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test that sub profile selection is available when discovery_by is device
@@ -677,7 +651,7 @@ async def test_sub_profile_selection_discovery_by_device(
     see: https://github.com/bramstroker/homeassistant-powercalc/issues/3866
     """
 
-    mock_entity_with_model_information("switch.test", "test", "discovery_type_device_sub_profile")
+    mock_device_with_entities(hass, "switch.test", "test", "discovery_type_device_sub_profile")
 
     source_entity = create_source_entity("switch.test", hass)
     result = await initialize_discovery_flow(hass, source_entity)
@@ -714,10 +688,10 @@ async def test_discovery_flow_documentation_url_in_remarks(hass: HomeAssistant) 
 
 async def test_custom_fields_documentation_url_placeholder(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """When model.json has documentation_url, the custom fields step should include it in description_placeholders."""
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         ["sensor.test", "sensor.load"],
         "test",
         "ups",
@@ -742,21 +716,11 @@ async def test_options_flow_initializes_profile_with_custom_fields(
     hass: HomeAssistant,
 ) -> None:
     mock_device(hass, "test-device", "test", "device_custom_fields")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.test_device": RegistryEntryWithDefaults(
-                entity_id="switch.test_device",
-                unique_id="test-switch",
-                platform="test",
-                device_id="test-device",
-            ),
-            "sensor.test_dependency": RegistryEntryWithDefaults(
-                entity_id="sensor.test_dependency",
-                unique_id="test-dependency",
-                platform="test",
-                device_id="test-device",
-            ),
+            "switch.test_device": {"unique_id": "test-switch", "platform": "test", "device_id": "test-device"},
+            "sensor.test_dependency": {"unique_id": "test-dependency", "platform": "test", "device_id": "test-device"},
         },
     )
 
@@ -780,15 +744,10 @@ async def test_options_flow_initializes_profile_with_custom_fields(
 
 
 async def test_availability_entity_step_skipped(hass: HomeAssistant) -> None:
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "test-device": DeviceEntry(
-                config_entry_id="test",
-                manufacturer="test",
-                name="Test Device",
-                model="discovery_type_device",
-            ),
+            "test-device": {"manufacturer": "test", "name": "Test Device", "model": "discovery_type_device"},
         },
     )
 

--- a/tests/config_flow/test_virtual_power_lut.py
+++ b/tests/config_flow/test_virtual_power_lut.py
@@ -1,5 +1,5 @@
 from homeassistant import data_entry_flow
-from homeassistant.components.light import ColorMode
+from homeassistant.components.light import ATTR_COLOR_MODE, ATTR_SUPPORTED_COLOR_MODES, ColorMode
 from homeassistant.const import CONF_ENTITY_ID, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import SelectSelector
@@ -17,8 +17,7 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.flow_helper.flows.library import CONF_CONFIRM_AUTODISCOVERED_MODEL
-from custom_components.test.light import MockLight
-from tests.common import create_mock_config_entry, create_mock_light_entity
+from tests.common import create_mock_config_entry, mock_device_with_entities, mock_entities_in_registry, set_states
 from tests.config_flow.common import (
     DEFAULT_UNIQUE_ID,
     assert_default_virtual_power_entry_data,
@@ -27,14 +26,23 @@ from tests.config_flow.common import (
     handle_options_flow_update,
     set_virtual_power_configuration,
 )
-from tests.conftest import MockEntityWithModel
 
 
 async def test_lut_manual_flow(hass: HomeAssistant) -> None:
-    light_entity = MockLight("test", STATE_ON, DEFAULT_UNIQUE_ID)
-    light_entity.supported_color_modes = [ColorMode.COLOR_TEMP, ColorMode.HS]
-    light_entity.color_mode = ColorMode.COLOR_TEMP
-    await create_mock_light_entity(hass, light_entity)
+    mock_entities_in_registry(hass, {"light.test": {"unique_id": DEFAULT_UNIQUE_ID}})
+    await set_states(
+        hass,
+        [
+            (
+                "light.test",
+                STATE_ON,
+                {
+                    ATTR_SUPPORTED_COLOR_MODES: [ColorMode.COLOR_TEMP, ColorMode.HS],
+                    ATTR_COLOR_MODE: ColorMode.COLOR_TEMP,
+                },
+            ),
+        ],
+    )
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -82,11 +90,11 @@ async def test_lut_manual_flow(hass: HomeAssistant) -> None:
 
 async def test_lut_autodiscover_flow(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     manufacturer = "ikea"
     model = "LED1545G12"
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         manufacturer,
         model,
@@ -123,9 +131,8 @@ async def test_lut_autodiscover_flow(
 
 async def test_lut_not_autodiscovered_model_unsupported(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information("light.test", "ikea", "unknown_model")
+    mock_device_with_entities(hass, "light.test", "ikea", "unknown_model")
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -133,9 +140,9 @@ async def test_lut_not_autodiscovered_model_unsupported(
 
 
 async def test_lut_not_autodiscovered(hass: HomeAssistant) -> None:
-    light_entity = MockLight("test", STATE_ON)
-    light_entity._attr_unique_id = None  # noqa: SLF001
-    await create_mock_light_entity(hass, light_entity)
+    # Without a unique id the light cannot be autodiscovered.
+    mock_entities_in_registry(hass, {"light.test": {"unique_id": None}})
+    await set_states(hass, [("light.test", STATE_ON)])
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -144,13 +151,13 @@ async def test_lut_not_autodiscovered(hass: HomeAssistant) -> None:
 
 async def test_lut_autodiscover_flow_not_confirmed(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     When manufacturer and model are auto detected and user chooses to not accept it,
     make sure he/she is forwarded to the manufacturer listing
     """
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "ikea",
         "LED1545G12",
@@ -169,9 +176,8 @@ async def test_lut_autodiscover_flow_not_confirmed(
 
 async def test_lut_flow_with_sub_profiles(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information("light.test", "", "")
+    mock_device_with_entities(hass, "light.test", "", "")
 
     result = await goto_virtual_power_strategy_step(hass, CalculationStrategy.LUT)
 

--- a/tests/config_flow/test_virtual_power_multi_switch.py
+++ b/tests/config_flow/test_virtual_power_multi_switch.py
@@ -7,7 +7,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.helpers.selector import EntitySelector
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_device_registry, mock_registry
+from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_registry
 import voluptuous as vol
 
 from custom_components.powercalc import DiscoveryManager
@@ -28,7 +28,15 @@ from custom_components.powercalc.const import (
 )
 from custom_components.powercalc.power_profile.factory import get_power_profile
 from custom_components.powercalc.power_profile.library import ModelInfo
-from tests.common import assert_entity_state, create_mock_config_entry, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    create_mock_config_entry,
+    mock_device,
+    mock_device_with_entities,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 from tests.config_flow.common import (
     DEFAULT_UNIQUE_ID,
     goto_virtual_power_strategy_step,
@@ -37,7 +45,6 @@ from tests.config_flow.common import (
     initialize_options_flow,
     set_virtual_power_configuration,
 )
-from tests.conftest import MockEntityWithModel
 
 
 async def test_create_multi_switch_sensor_entry(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:
@@ -67,7 +74,6 @@ async def test_create_multi_switch_sensor_entry(hass: HomeAssistant, entity_regi
 
 async def test_discovery_flow(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     await run_powercalc_setup(hass)
 
@@ -173,14 +179,15 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert entry.data[CONF_MULTI_SWITCH] == {CONF_POWER: 5, CONF_POWER_OFF: 20, CONF_ENTITIES: ["switch.a", "switch.c"]}
 
 
-async def test_regression_2612(hass: HomeAssistant, mock_entity_with_model_information: MockEntityWithModel) -> None:
+async def test_regression_2612(hass: HomeAssistant) -> None:
     """
     See #2612
     When the source entity had manufacturer and model information the multi switch setup would fail
     And raise error "Model not found in library" in the logs
     """
 
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "switch.test",
         "_TZ3000_u3oupgdy",
         "TS0004",
@@ -210,7 +217,6 @@ async def test_regression_2612(hass: HomeAssistant, mock_entity_with_model_infor
 
 async def test_setup_without_switches(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     See https://github.com/bramstroker/homeassistant-powercalc/issues/3218
@@ -238,36 +244,12 @@ async def test_light_switches_selectable(hass: HomeAssistant) -> None:
     Make sure that light entities are also selectable in the multi switch setup
     """
     device_id = "abcdef"
-    device_entry = DeviceEntry(
-        config_entry_id="test",
-        id=device_id,
-        manufacturer="test",
-        model="multi_switch",
-        name="Test",
-    )
-    mock_device_registry(
+    device_entry = mock_device(hass, device_id, model="multi_switch", name="Test")
+    mock_entities_in_registry(
         hass,
         {
-            device_id: device_entry,
-        },
-    )
-    mock_registry(
-        hass,
-        {
-            "switch.test1": RegistryEntryWithDefaults(
-                id="switch.test1",
-                entity_id="switch.test1",
-                unique_id=f"{device_id}1",
-                device_id=device_id,
-                platform="switch",
-            ),
-            "light.test2": RegistryEntryWithDefaults(
-                id="light.test2",
-                entity_id="light.test2",
-                unique_id=f"{device_id}2",
-                device_id=device_id,
-                platform="light",
-            ),
+            "switch.test1": {"id": "switch.test1", "unique_id": f"{device_id}1", "device_id": device_id},
+            "light.test2": {"id": "light.test2", "unique_id": f"{device_id}2", "device_id": device_id},
         },
     )
 
@@ -322,19 +304,7 @@ def mock_device_with_switches(
     model: str = "multi_switch",
 ) -> DeviceEntry:
     device_id = "abcdef"
-    device_entry = DeviceEntry(
-        config_entry_id="test",
-        id=device_id,
-        manufacturer=manufacturer,
-        model=model,
-        name="Test",
-    )
-    mock_device_registry(
-        hass,
-        {
-            device_id: device_entry,
-        },
-    )
+    device_entry = mock_device(hass, device_id, manufacturer, model, name="Test")
 
     entities: dict[str, RegistryEntry] = {}
     for i in range(num_switches):

--- a/tests/config_flow/test_virtual_power_wled.py
+++ b/tests/config_flow/test_virtual_power_wled.py
@@ -17,9 +17,8 @@ from custom_components.powercalc.const import (
     CalculationStrategy,
     SensorType,
 )
-from custom_components.test.light import MockLight
 import custom_components.test.sensor as test_sensor_platform
-from tests.common import create_mock_config_entry, create_mock_light_entity
+from tests.common import create_mock_config_entry, mock_entities_in_registry, set_states
 from tests.config_flow.common import (
     DEFAULT_UNIQUE_ID,
     assert_default_virtual_power_entry_data,
@@ -71,8 +70,8 @@ async def test_wled_options_flow(hass: HomeAssistant) -> None:
 
 
 async def _create_wled_entities(hass: HomeAssistant) -> None:
-    light_entity = MockLight("test", STATE_ON, DEFAULT_UNIQUE_ID)
-    await create_mock_light_entity(hass, light_entity)
+    mock_entities_in_registry(hass, {"light.test": {"unique_id": DEFAULT_UNIQUE_ID}})
+    await set_states(hass, [("light.test", STATE_ON)])
 
     estimated_current_entity = test_sensor_platform.MockSensor(
         name="test_estimated_current",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,8 @@ import json
 import logging
 import os
 import shutil
-from typing import Any, Protocol, cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
-import uuid
 
 from _pytest.fixtures import SubRequest
 import aiohttp
@@ -19,8 +18,6 @@ from homeassistant.core import HomeAssistant
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
-    RegistryEntryWithDefaults,
-    mock_registry,
 )
 
 from custom_components.powercalc.const import (
@@ -31,7 +28,7 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.helpers import get_library_json_path, get_library_path
-from tests.common import get_test_config_dir, mock_device
+from tests.common import get_test_config_dir
 
 # Remove this once aioresponses supports aiohttp 3.14+.
 # See https://github.com/pnuckowski/aioresponses/issues/289.
@@ -124,58 +121,6 @@ def mock_flow_init(hass: HomeAssistant) -> Generator:
         return_value=AsyncMock(),
     ) as mock_init:
         yield mock_init
-
-
-class MockEntityWithModel(Protocol):
-    def __call__(
-        self,
-        entity_id: str | list[str],
-        manufacturer: str = "signify",
-        model: str = "LCT010",
-        model_id: str | None = None,
-        **entity_reg_kwargs: Any,  # noqa: ANN401
-    ) -> None: ...
-
-
-@pytest.fixture
-def mock_entity_with_model_information(hass: HomeAssistant) -> MockEntityWithModel:
-    def _mock_entity_with_model_information(
-        entity_id: str,
-        manufacturer: str = "signify",
-        model: str = "LCT010",
-        model_id: str | None = None,
-        **entity_reg_kwargs: Any,  # noqa: ANN401
-    ) -> None:
-        device_id = str(uuid.uuid4())
-        if "device_id" in entity_reg_kwargs:
-            device_id = entity_reg_kwargs["device_id"]
-            del entity_reg_kwargs["device_id"]
-
-        unique_id = str(uuid.uuid4())
-        if "unique_id" in entity_reg_kwargs:
-            unique_id = entity_reg_kwargs["unique_id"]
-            del entity_reg_kwargs["unique_id"]
-
-        platform = "foo"
-        if "platform" in entity_reg_kwargs:
-            platform = entity_reg_kwargs["platform"]
-            del entity_reg_kwargs["platform"]
-
-        mock_entries: dict[str, Any] = {}
-        entity_ids = entity_id if isinstance(entity_id, list) else [entity_id]
-        for entity_id in entity_ids:
-            mock_entries[entity_id] = RegistryEntryWithDefaults(
-                entity_id=entity_id,
-                unique_id=unique_id + "_" + entity_id,
-                platform=platform,
-                device_id=device_id,
-                **entity_reg_kwargs,
-            )
-
-        mock_registry(hass, mock_entries)
-        mock_device(hass, device_id, manufacturer, model, model_id=model_id)
-
-    return _mock_entity_with_model_information
 
 
 @pytest.fixture(autouse=True)

--- a/tests/group_include/test_filter.py
+++ b/tests/group_include/test_filter.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.floor_registry import FloorRegistry
 from homeassistant.helpers.label_registry import LabelRegistry
 import pytest
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_registry
+from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults
 
 from custom_components.powercalc.const import CONF_AND, CONF_AREA, CONF_FILTER, CONF_OR, CONF_WILDCARD
 from custom_components.powercalc.errors import SensorConfigurationError
@@ -28,7 +28,7 @@ from custom_components.powercalc.group_include.filter import (
     create_composite_filter,
     create_filter,
 )
-from tests.common import mock_device, set_states
+from tests.common import mock_device, mock_entities_in_registry, set_states
 
 
 @pytest.mark.parametrize(
@@ -365,19 +365,11 @@ async def test_group_filter(
     entity_id: str,
     expected_result: bool,
 ) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "group.some_group": RegistryEntryWithDefaults(
-                entity_id="group.some_group",
-                unique_id="def",
-                platform="test",
-            ),
-            "group.other_group": RegistryEntryWithDefaults(
-                entity_id="group.other_group",
-                unique_id="ghi",
-                platform="test",
-            ),
+            "group.some_group": {"unique_id": "def", "platform": "test"},
+            "group.other_group": {"unique_id": "ghi", "platform": "test"},
         },
     )
 

--- a/tests/group_include/test_include.py
+++ b/tests/group_include/test_include.py
@@ -2,6 +2,7 @@ import logging
 
 from homeassistant.components import light
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_MODE, ATTR_SUPPORTED_COLOR_MODES, ColorMode
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
@@ -15,16 +16,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers.area_registry import AreaRegistry
-from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntryDisabler
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.helpers.label_registry import LabelRegistry
 from homeassistant.setup import async_setup_component
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
-    RegistryEntryWithDefaults,
-    mock_device_registry,
-    mock_registry,
 )
 
 from custom_components.powercalc import CONF_CREATE_UTILITY_METERS
@@ -56,18 +53,25 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.group_include.include import find_entities
-from custom_components.test.light import MockLight
 from tests.common import (
-    create_discoverable_light,
+    assert_entity_state,
     create_mock_config_entry,
-    create_mock_light_entity,
     get_simple_fixed_config,
     mock_device,
+    mock_device_with_entities,
+    mock_devices,
+    mock_entities_in_registry,
     run_powercalc_setup,
     set_states,
 )
 from tests.config_flow.common import initialize_discovery_flow
-from tests.conftest import MockEntityWithModel
+
+# State attributes a lidl HG06462A light reports; needed for the LUT profile to match on discovery.
+DISCOVERABLE_LIGHT_ATTRIBUTES = {
+    ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS],
+    ATTR_COLOR_MODE: ColorMode.BRIGHTNESS,
+    ATTR_BRIGHTNESS: 125,
+}
 
 
 @pytest.mark.parametrize(
@@ -79,14 +83,12 @@ from tests.conftest import MockEntityWithModel
 )
 async def test_include_area(
     hass: HomeAssistant,
-    entity_registry: EntityRegistry,
     area_registry: AreaRegistry,
     area_input: str,
 ) -> None:
-    await create_mock_light_entity(hass, create_discoverable_light("bathroom_mirror"))
-
     area = area_registry.async_get_or_create("Bathroom 1")
-    entity_registry.async_update_entity("light.bathroom_mirror", area_id=area.id)
+    mock_device_with_entities(hass, "light.bathroom_mirror", "lidl", "HG06462A", area_id=area.id)
+    await set_states(hass, [("light.bathroom_mirror", STATE_ON)])
 
     await _create_powercalc_config_entry(hass, "light.bathroom_mirror")
 
@@ -95,9 +97,7 @@ async def test_include_area(
         {CONF_CREATE_GROUP: "Test include", CONF_INCLUDE: {CONF_AREA: area_input}},
     )
 
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.bathroom_mirror_power"}
+    assert_entity_state(hass, "sensor.test_include_power", attributes={ATTR_ENTITIES: {"sensor.bathroom_mirror_power"}})
 
 
 async def test_include_area_not_found(
@@ -116,17 +116,14 @@ async def test_include_area_not_found(
 
 
 async def test_include_light_group(hass: HomeAssistant) -> None:
-    discoverable_light = create_discoverable_light("bathroom_mirror")
     await _create_powercalc_config_entry(hass, "light.bathroom_mirror")
 
-    non_discoverable_light = MockLight("bathroom_spots")
-
-    await create_mock_light_entity(hass, [discoverable_light, non_discoverable_light])
-
-    # Ugly hack, maybe I can figure out something better in the future.
-    # Light domain is already setup for platform test, remove the component so we can setup light group
-    if light.DOMAIN in hass.config.components:
-        hass.config.components.remove(light.DOMAIN)
+    mock_devices(hass, {"bathroom_mirror-device": {"manufacturer": "lidl", "model": "HG06462A"}})
+    mock_entities_in_registry(
+        hass,
+        {"light.bathroom_mirror": {"device_id": "bathroom_mirror-device"}, "light.bathroom_spots": {}},
+    )
+    await set_states(hass, [("light.bathroom_mirror", STATE_ON), ("light.bathroom_spots", STATE_ON)])
 
     await async_setup_component(
         hass,
@@ -154,9 +151,11 @@ async def test_include_light_group(hass: HomeAssistant) -> None:
 
     await hass.async_start()
 
-    group_state = hass.states.get("sensor.test_include_lightgroup_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.bathroom_mirror_power"}
+    assert_entity_state(
+        hass,
+        "sensor.test_include_lightgroup_power",
+        attributes={ATTR_ENTITIES: {"sensor.bathroom_mirror_power"}},
+    )
 
 
 async def test_error_is_logged_when_light_group_not_exists(
@@ -178,13 +177,21 @@ async def test_error_is_logged_when_light_group_not_exists(
 
 async def test_include_domain(hass: HomeAssistant) -> None:
     """Test domain include option, which includes all entities where the source entity matches a certain domain"""
-    await create_mock_light_entity(
+    mock_devices(
         hass,
-        [
-            create_discoverable_light("bathroom_spots", "1111"),
-            create_discoverable_light("kitchen", "2222"),
-        ],
+        {
+            "bathroom_spots-device": {"manufacturer": "lidl", "model": "HG06462A"},
+            "kitchen-device": {"manufacturer": "lidl", "model": "HG06462A"},
+        },
     )
+    mock_entities_in_registry(
+        hass,
+        {
+            "light.bathroom_spots": {"unique_id": "1111", "device_id": "bathroom_spots-device"},
+            "light.kitchen": {"unique_id": "2222", "device_id": "kitchen-device"},
+        },
+    )
+    await set_states(hass, [("light.bathroom_spots", STATE_ON), ("light.kitchen", STATE_ON)])
 
     await _create_powercalc_config_entry(hass, "light.bathroom_spots")
     await _create_powercalc_config_entry(hass, "light.kitchen")
@@ -199,33 +206,25 @@ async def test_include_domain(hass: HomeAssistant) -> None:
         ],
     )
 
-    group_state = hass.states.get("sensor.lights_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.bathroom_spots_power",
-        "sensor.kitchen_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.lights_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.bathroom_spots_power",
+                "sensor.kitchen_power",
+            },
+        },
+    )
 
 
 async def test_include_domain_list(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.test": RegistryEntryWithDefaults(
-                entity_id="switch.test",
-                unique_id="1111",
-                platform="switch",
-            ),
-            "light.test2": RegistryEntryWithDefaults(
-                entity_id="light.test2",
-                unique_id="2222",
-                platform="light",
-            ),
-            "sensor.test3": RegistryEntryWithDefaults(
-                entity_id="sensor.test3",
-                unique_id="3333",
-                platform="sensor",
-            ),
+            "switch.test": {},
+            "light.test2": {},
+            "sensor.test3": {},
         },
     )
     await _create_powercalc_config_entry(hass, "switch.test")
@@ -243,22 +242,34 @@ async def test_include_domain_list(hass: HomeAssistant) -> None:
         ],
     )
 
-    group_state = hass.states.get("sensor.mygroup_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test_power",
-        "sensor.test2_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.mygroup_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test_power",
+                "sensor.test2_power",
+            },
+        },
+    )
 
 
 async def test_include_template(hass: HomeAssistant) -> None:
-    await create_mock_light_entity(
+    mock_devices(
         hass,
-        [
-            create_discoverable_light("bathroom_spots", "1111"),
-            create_discoverable_light("kitchen", "2222"),
-        ],
+        {
+            "bathroom_spots-device": {"manufacturer": "lidl", "model": "HG06462A"},
+            "kitchen-device": {"manufacturer": "lidl", "model": "HG06462A"},
+        },
     )
+    mock_entities_in_registry(
+        hass,
+        {
+            "light.bathroom_spots": {"unique_id": "1111", "device_id": "bathroom_spots-device"},
+            "light.kitchen": {"unique_id": "2222", "device_id": "kitchen-device"},
+        },
+    )
+    await set_states(hass, [("light.bathroom_spots", STATE_ON), ("light.kitchen", STATE_ON)])
 
     await _create_powercalc_config_entry(hass, "light.bathroom_spots")
     await _create_powercalc_config_entry(hass, "light.kitchen")
@@ -274,26 +285,16 @@ async def test_include_template(hass: HomeAssistant) -> None:
         ],
     )
 
-    group_state = hass.states.get("sensor.lights_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.bathroom_spots_power"}
+    assert_entity_state(hass, "sensor.lights_power", attributes={ATTR_ENTITIES: {"sensor.bathroom_spots_power"}})
 
 
 async def test_include_group(hass: HomeAssistant) -> None:
     await set_states(hass, [("switch.tv", STATE_ON)])
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.tv": RegistryEntryWithDefaults(
-                entity_id="switch.tv",
-                unique_id="12345",
-                platform="switch",
-            ),
-            "switch.soundbar": RegistryEntryWithDefaults(
-                entity_id="switch.soundbar",
-                unique_id="123456",
-                platform="switch",
-            ),
+            "switch.tv": {},
+            "switch.soundbar": {},
         },
     )
 
@@ -323,49 +324,33 @@ async def test_include_group(hass: HomeAssistant) -> None:
         ],
     )
 
-    group_state = hass.states.get("sensor.powercalc_group_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.tv_power",
-        "sensor.soundbar_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.powercalc_group_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.tv_power",
+                "sensor.soundbar_power",
+            },
+        },
+    )
 
 
 async def test_include_skips_unsupported_entities(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.ERROR)
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "device-a": DeviceEntry(
-                config_entry_id="test",
-                id="device-a",
-                manufacturer="signify",
-                model="LCT012",
-            ),
-            "device-b": DeviceEntry(
-                config_entry_id="test",
-                id="device-b",
-                manufacturer="signify",
-                model="Room",
-            ),
+            "device-a": {"manufacturer": "signify", "model": "LCT012"},
+            "device-b": {"manufacturer": "signify", "model": "Room"},
         },
     )
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.a": RegistryEntryWithDefaults(
-                entity_id="light.a",
-                unique_id="111",
-                platform="light",
-                device_id="device-a",
-            ),
-            "light.b": RegistryEntryWithDefaults(
-                entity_id="light.b",
-                unique_id="222",
-                platform="light",
-                device_id="device-b",
-            ),
+            "light.a": {"device_id": "device-a"},
+            "light.b": {"device_id": "device-b"},
         },
     )
 
@@ -380,11 +365,15 @@ async def test_include_skips_unsupported_entities(hass: HomeAssistant, caplog: p
         ],
     )
 
-    group_state = hass.states.get("sensor.powercalc_group_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.a_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.powercalc_group_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.a_power",
+            },
+        },
+    )
 
     assert len(caplog.records) == 0
 
@@ -407,25 +396,40 @@ async def test_error_is_logged_when_group_not_exists(
 
 
 async def test_combine_include_with_entities(hass: HomeAssistant) -> None:
-    light_a = create_discoverable_light("light_a")
-    light_b = MockLight("light_b")
-    light_c = MockLight("light_c")
-    light_d = MockLight("light_d")
-    light_e = create_discoverable_light("light_e", "6765765756")
-    light_f = create_discoverable_light("light_f", "676576575sds6")
-    await create_mock_light_entity(
+    mock_devices(
         hass,
-        [light_a, light_b, light_c, light_d, light_e, light_f],
+        {
+            "light_a-device": {"manufacturer": "lidl", "model": "HG06462A"},
+            "light_e-device": {"manufacturer": "lidl", "model": "HG06462A"},
+            "light_f-device": {"manufacturer": "lidl", "model": "HG06462A"},
+        },
+    )
+    mock_entities_in_registry(
+        hass,
+        {
+            "light.light_a": {"device_id": "light_a-device"},
+            "light.light_b": {},
+            "light.light_c": {},
+            "light.light_d": {},
+            "light.light_e": {"unique_id": "6765765756", "device_id": "light_e-device"},
+            "light.light_f": {"unique_id": "676576575sds6", "device_id": "light_f-device"},
+        },
+    )
+    await set_states(
+        hass,
+        [
+            ("light.light_a", STATE_ON),
+            ("light.light_b", STATE_ON),
+            ("light.light_c", STATE_ON),
+            ("light.light_d", STATE_ON),
+            ("light.light_e", STATE_ON),
+            ("light.light_f", STATE_ON),
+        ],
     )
 
-    await _create_powercalc_config_entry(hass, "light.light_a", light_a.unique_id)
-    await _create_powercalc_config_entry(hass, "light.light_e", light_e.unique_id)
-    await _create_powercalc_config_entry(hass, "light.light_f", light_f.unique_id)
-
-    # Ugly hack, maybe I can figure out something better in the future.
-    # Light domain is already setup for platform test, remove the component so we can setup light group
-    if light.DOMAIN in hass.config.components:
-        hass.config.components.remove(light.DOMAIN)
+    await _create_powercalc_config_entry(hass, "light.light_a", "light.light_a")
+    await _create_powercalc_config_entry(hass, "light.light_e", "6765765756")
+    await _create_powercalc_config_entry(hass, "light.light_f", "676576575sds6")
 
     await async_setup_component(
         hass,
@@ -480,15 +484,19 @@ async def test_combine_include_with_entities(hass: HomeAssistant) -> None:
         },
     )
 
-    group_state = hass.states.get("sensor.powercalc_group_power")
-    assert group_state
-    assert group_state.attributes.get("entities") == {
-        "sensor.light_a_power",
-        "sensor.light_b_power",
-        "sensor.light_c_power",
-        "sensor.light_e_power",
-        "sensor.light_f_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.powercalc_group_power",
+        attributes={
+            "entities": {
+                "sensor.light_a_power",
+                "sensor.light_b_power",
+                "sensor.light_c_power",
+                "sensor.light_e_power",
+                "sensor.light_f_power",
+            },
+        },
+    )
 
 
 async def test_include_filter_domain(
@@ -498,43 +506,19 @@ async def test_include_filter_domain(
     area = area_registry.async_get_or_create("Bathroom 1")
     await hass.async_block_till_done()
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test_light": RegistryEntryWithDefaults(
-                entity_id="light.test_light",
-                unique_id="1111",
-                platform="light",
-                device_id="light-device-id",
-                area_id=area.id,
-            ),
-            "switch.test_switch": RegistryEntryWithDefaults(
-                entity_id="switch.test_switch",
-                unique_id="2222",
-                platform="switch",
-                device_id="switch-device-id",
-                area_id=area.id,
-            ),
+            "light.test_light": {"device_id": "light-device-id", "area_id": area.id},
+            "switch.test_switch": {"device_id": "switch-device-id", "area_id": area.id},
         },
     )
 
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "light-device-id": DeviceEntry(
-                config_entry_id="test",
-                id="light-device-id",
-                manufacturer="Signify",
-                model="LCT012",
-                area_id=area.id,
-            ),
-            "switch-device-id": DeviceEntry(
-                config_entry_id="test",
-                id="switch-device-id",
-                manufacturer="Shelly",
-                model="Shelly Plug S",
-                area_id=area.id,
-            ),
+            "light-device-id": {"manufacturer": "Signify", "model": "LCT012", "area_id": area.id},
+            "switch-device-id": {"manufacturer": "Shelly", "model": "Shelly Plug S", "area_id": area.id},
         },
     )
 
@@ -553,33 +537,37 @@ async def test_include_filter_domain(
     )
 
     await set_states(hass, [("light.test_light", STATE_OFF)], block_count=2)
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.test_light_power"}
+    assert_entity_state(hass, "sensor.test_include_power", attributes={ATTR_ENTITIES: {"sensor.test_light_power"}})
 
 
 async def test_include_yaml_configured_entity(
     hass: HomeAssistant,
-    entity_registry: EntityRegistry,
     area_registry: AreaRegistry,
 ) -> None:
     """Test that include also includes entities that the user configured with YAML"""
 
-    light_a = MockLight("light_a")
-    light_b = MockLight("light_b")
-    light_c = create_discoverable_light("light_c")
-    light_d = MockLight("light_d")
-    await create_mock_light_entity(
+    area = area_registry.async_get_or_create("My area")
+    mock_devices(hass, {"light_c-device": {"manufacturer": "lidl", "model": "HG06462A"}})
+    mock_entities_in_registry(
         hass,
-        [light_a, light_b, light_c, light_d],
+        {
+            "light.light_a": {"area_id": area.id},
+            "light.light_b": {"area_id": area.id},
+            "light.light_c": {"device_id": "light_c-device", "area_id": area.id},
+            "light.light_d": {},
+        },
+    )
+    await set_states(
+        hass,
+        [
+            ("light.light_a", STATE_ON),
+            ("light.light_b", STATE_ON),
+            ("light.light_c", STATE_ON),
+            ("light.light_d", STATE_ON),
+        ],
     )
 
-    area = area_registry.async_get_or_create("My area")
-    entity_registry.async_update_entity(light_a.entity_id, area_id=area.id)
-    entity_registry.async_update_entity(light_b.entity_id, area_id=area.id)
-    entity_registry.async_update_entity(light_c.entity_id, area_id=area.id)
-
-    await _create_powercalc_config_entry(hass, light_a.entity_id)
+    await _create_powercalc_config_entry(hass, "light.light_a")
 
     await run_powercalc_setup(
         hass,
@@ -591,24 +579,28 @@ async def test_include_yaml_configured_entity(
                 },
             },
             {
-                CONF_ENTITY_ID: light_b.entity_id,
+                CONF_ENTITY_ID: "light.light_b",
                 CONF_FIXED: {
                     CONF_POWER: 50,
                 },
             },
             {
-                CONF_ENTITY_ID: light_c.entity_id,
+                CONF_ENTITY_ID: "light.light_c",
             },
         ],
     )
 
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.light_a_power",
-        "sensor.light_b_power",
-        "sensor.light_c_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.test_include_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.light_a_power",
+                "sensor.light_b_power",
+                "sensor.light_c_power",
+            },
+        },
+    )
 
 
 async def test_include_non_powercalc_entities_in_group(
@@ -623,29 +615,12 @@ async def test_include_non_powercalc_entities_in_group(
 
     shelly_power_sensor = "sensor.shelly_power"
     shelly_energy_sensor = "sensor.shelly_energy"
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            shelly_power_sensor: RegistryEntryWithDefaults(
-                entity_id=shelly_power_sensor,
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                area_id=area.id,
-            ),
-            shelly_energy_sensor: RegistryEntryWithDefaults(
-                entity_id=shelly_energy_sensor,
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-                area_id=area.id,
-            ),
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="3333",
-                platform="light",
-                area_id=area.id,
-            ),
+            shelly_power_sensor: {"platform": "sensor", "device_class": SensorDeviceClass.POWER, "area_id": area.id},
+            shelly_energy_sensor: {"platform": "sensor", "device_class": SensorDeviceClass.ENERGY, "area_id": area.id},
+            "light.test": {"area_id": area.id},
         },
     )
 
@@ -660,32 +635,40 @@ async def test_include_non_powercalc_entities_in_group(
         },
     )
 
-    power_state = hass.states.get("sensor.test_include_power")
-    assert power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test_power",
-        shelly_power_sensor,
-    }
+    assert_entity_state(
+        hass,
+        "sensor.test_include_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test_power",
+                shelly_power_sensor,
+            },
+        },
+    )
 
-    energy_state = hass.states.get("sensor.test_include_energy")
-    assert energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test_energy",
-        shelly_energy_sensor,
-    }
+    assert_entity_state(
+        hass,
+        "sensor.test_include_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test_energy",
+                shelly_energy_sensor,
+            },
+        },
+    )
 
 
 async def test_group_setup_continues_when_subgroup_has_no_include_entities(
     hass: HomeAssistant,
-    entity_registry: EntityRegistry,
     area_registry: AreaRegistry,
 ) -> None:
     """
     When one of the subgroups has no include entities resolved the other nested groups should just be setup
     """
-    await create_mock_light_entity(hass, create_discoverable_light("bathroom_mirror"))
-
     area_bathroom = area_registry.async_get_or_create("Bathroom")
     area_registry.async_get_or_create("Bedroom")
-    entity_registry.async_update_entity("light.bathroom_mirror", area_id=area_bathroom.id)
+    mock_device_with_entities(hass, "light.bathroom_mirror", "lidl", "HG06462A", area_id=area_bathroom.id)
+    await set_states(hass, [("light.bathroom_mirror", STATE_ON)])
 
     await _create_powercalc_config_entry(hass, "light.bathroom_mirror")
 
@@ -713,14 +696,12 @@ async def test_group_setup_continues_when_subgroup_has_no_include_entities(
 
 async def test_area_groups_as_subgroups(
     hass: HomeAssistant,
-    entity_registry: EntityRegistry,
     area_registry: AreaRegistry,
 ) -> None:
-    await create_mock_light_entity(hass, create_discoverable_light("bathroom_mirror"))
-
     area_bathroom = area_registry.async_get_or_create("Bathroom")
     area_registry.async_get_or_create("Bedroom")
-    entity_registry.async_update_entity("light.bathroom_mirror", area_id=area_bathroom.id)
+    mock_device_with_entities(hass, "light.bathroom_mirror", "lidl", "HG06462A", area_id=area_bathroom.id)
+    await set_states(hass, [("light.bathroom_mirror", STATE_ON)])
 
     await _create_powercalc_config_entry(hass, "light.bathroom_mirror")
 
@@ -746,17 +727,25 @@ async def test_area_groups_as_subgroups(
 
     await run_powercalc_setup(hass)
 
-    group_a_power = hass.states.get("sensor.groupa_power")
-    assert group_a_power
-    assert group_a_power.attributes.get(CONF_ENTITIES) == {
-        "sensor.bathroom_mirror_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupa_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.bathroom_mirror_power",
+            },
+        },
+    )
 
-    group_b_power = hass.states.get("sensor.groupb_power")
-    assert group_b_power
-    assert group_b_power.attributes.get(CONF_ENTITIES) == {
-        "sensor.bathroom_mirror_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupb_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.bathroom_mirror_power",
+            },
+        },
+    )
 
 
 async def test_power_group_does_not_include_binary_sensors(
@@ -766,23 +755,11 @@ async def test_power_group_does_not_include_binary_sensors(
     area = area_registry.async_get_or_create("Bathroom")
     await hass.async_block_till_done()
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "binary_sensor.test": RegistryEntryWithDefaults(
-                entity_id="binary_sensor.test",
-                unique_id="1111",
-                platform="binary_sensor",
-                device_class=SensorDeviceClass.POWER,
-                area_id=area.id,
-            ),
-            "sensor.test": RegistryEntryWithDefaults(
-                entity_id="sensor.test",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                area_id=area.id,
-            ),
+            "binary_sensor.test": {"device_class": SensorDeviceClass.POWER, "area_id": area.id},
+            "sensor.test": {"device_class": SensorDeviceClass.POWER, "area_id": area.id},
         },
     )
 
@@ -798,38 +775,17 @@ async def test_power_group_does_not_include_binary_sensors(
         },
     )
 
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {"sensor.test"}
+    assert_entity_state(hass, "sensor.test_include_power", attributes={CONF_ENTITIES: {"sensor.test"}})
 
 
 async def test_energy_group_does_not_include_utility_meters(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1111",
-                platform="light",
-            ),
-            "sensor.test": RegistryEntryWithDefaults(
-                entity_id="sensor.test",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
-            "sensor.test_daily": RegistryEntryWithDefaults(
-                entity_id="sensor.test_daily",
-                unique_id="3333",
-                platform="utility_meter",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
-            "sensor.test_hourly": RegistryEntryWithDefaults(
-                entity_id="sensor.test_hourly",
-                unique_id="4444",
-                platform="utility_meter",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
+            "light.test": {},
+            "sensor.test": {"device_class": SensorDeviceClass.ENERGY},
+            "sensor.test_daily": {"platform": "utility_meter", "device_class": SensorDeviceClass.ENERGY},
+            "sensor.test_hourly": {"platform": "utility_meter", "device_class": SensorDeviceClass.ENERGY},
         },
     )
 
@@ -853,41 +809,27 @@ async def test_energy_group_does_not_include_utility_meters(hass: HomeAssistant)
         ],
     )
 
-    group_state = hass.states.get("sensor.test_include_energy")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {"sensor.test", "sensor.test_powercalc_energy"}
+    assert_entity_state(
+        hass,
+        "sensor.test_include_energy",
+        attributes={CONF_ENTITIES: {"sensor.test", "sensor.test_powercalc_energy"}},
+    )
 
 
 async def test_include_group_does_not_include_disabled_sensors(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.test_energy",
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
-            "sensor.test_disabled_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.test_disabled_energy",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-                disabled_by=RegistryEntryDisabler.USER,
-            ),
-            "sensor.test_power": RegistryEntryWithDefaults(
-                entity_id="sensor.test_power",
-                unique_id="3333",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.test_disabled_power": RegistryEntryWithDefaults(
-                entity_id="sensor.test_disabled_power",
-                unique_id="4444",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                disabled_by=RegistryEntryDisabler.USER,
-            ),
+            "sensor.test_energy": {"device_class": SensorDeviceClass.ENERGY},
+            "sensor.test_disabled_energy": {
+                "device_class": SensorDeviceClass.ENERGY,
+                "disabled_by": RegistryEntryDisabler.USER,
+            },
+            "sensor.test_power": {"device_class": SensorDeviceClass.POWER},
+            "sensor.test_disabled_power": {
+                "device_class": SensorDeviceClass.POWER,
+                "disabled_by": RegistryEntryDisabler.USER,
+            },
         },
     )
 
@@ -902,33 +844,17 @@ async def test_include_group_does_not_include_disabled_sensors(hass: HomeAssista
         },
     )
 
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {"sensor.test_power"}
+    assert_entity_state(hass, "sensor.test_include_power", attributes={CONF_ENTITIES: {"sensor.test_power"}})
 
-    group_state = hass.states.get("sensor.test_include_energy")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {"sensor.test_energy"}
+    assert_entity_state(hass, "sensor.test_include_energy", attributes={CONF_ENTITIES: {"sensor.test_energy"}})
 
 
 async def test_include_by_label(hass: HomeAssistant, label_registry: LabelRegistry) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test": RegistryEntryWithDefaults(
-                entity_id="sensor.test",
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                labels=["my_label"],
-            ),
-            "sensor.test2": RegistryEntryWithDefaults(
-                entity_id="sensor.test",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                labels=["other_label"],
-            ),
+            "sensor.test": {"device_class": SensorDeviceClass.POWER, "labels": ["my_label"]},
+            "sensor.test2": {"device_class": SensorDeviceClass.POWER, "labels": ["other_label"]},
         },
     )
 
@@ -945,21 +871,14 @@ async def test_include_by_label(hass: HomeAssistant, label_registry: LabelRegist
         },
     )
 
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {"sensor.test"}
+    assert_entity_state(hass, "sensor.test_include_power", attributes={CONF_ENTITIES: {"sensor.test"}})
 
 
 async def test_include_by_wildcard(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "binary_sensor.test": RegistryEntryWithDefaults(
-                entity_id="sensor.tv_power",
-                unique_id="1111",
-                platform="binary_sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
+            "sensor.tv_power": {"device_class": SensorDeviceClass.POWER},
         },
     )
 
@@ -974,20 +893,34 @@ async def test_include_by_wildcard(hass: HomeAssistant) -> None:
         },
     )
 
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {"sensor.tv_power"}
+    assert_entity_state(hass, "sensor.test_include_power", attributes={CONF_ENTITIES: {"sensor.tv_power"}})
 
 
 async def test_include_by_wildcard_in_nested_groups(
     hass: HomeAssistant,
 ) -> None:
-    light_a = create_discoverable_light("some_a", "111")
-    light_b = create_discoverable_light("other_b", "222")
-    light_c = create_discoverable_light("other_c", "333")
-    await create_mock_light_entity(
+    mock_devices(
         hass,
-        [light_a, light_b, light_c],
+        {
+            "some_a-device": {"manufacturer": "lidl", "model": "HG06462A"},
+            "other_b-device": {"manufacturer": "lidl", "model": "HG06462A"},
+            "other_c-device": {"manufacturer": "lidl", "model": "HG06462A"},
+        },
+    )
+    mock_entities_in_registry(
+        hass,
+        {
+            "light.some_a": {"unique_id": "111", "device_id": "some_a-device"},
+            "light.other_b": {"unique_id": "222", "device_id": "other_b-device"},
+            "light.other_c": {"unique_id": "333", "device_id": "other_c-device"},
+        },
+    )
+    await set_states(
+        hass,
+        [
+            (entity_id, STATE_ON, DISCOVERABLE_LIGHT_ATTRIBUTES)
+            for entity_id in ("light.some_a", "light.other_b", "light.other_c")
+        ],
     )
 
     await run_powercalc_setup(
@@ -1009,20 +942,28 @@ async def test_include_by_wildcard_in_nested_groups(
         },
     )
 
-    group_a_state = hass.states.get("sensor.test_include_a_power")
-    assert group_a_state
-    assert group_a_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.some_a_power",
-        "sensor.other_b_power",
-        "sensor.other_c_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.test_include_a_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.some_a_power",
+                "sensor.other_b_power",
+                "sensor.other_c_power",
+            },
+        },
+    )
 
-    group_b_state = hass.states.get("sensor.test_include_b_power")
-    assert group_b_state
-    assert group_b_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.other_b_power",
-        "sensor.other_c_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.test_include_b_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.other_b_power",
+                "sensor.other_c_power",
+            },
+        },
+    )
 
 
 async def test_include_complex_nested_filters(
@@ -1030,32 +971,13 @@ async def test_include_complex_nested_filters(
     area_registry: AreaRegistry,
 ) -> None:
     area = area_registry.async_get_or_create("Living room")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.test": RegistryEntryWithDefaults(
-                entity_id="binary_sensor.test",
-                unique_id="1111",
-                platform="binary_sensor",
-            ),
-            "switch.tv": RegistryEntryWithDefaults(
-                entity_id="switch.tv",
-                unique_id="2222",
-                platform="switch",
-                area_id=area.id,
-            ),
-            "light.tv_ambilights": RegistryEntryWithDefaults(
-                entity_id="light.tv_ambilights",
-                unique_id="3333",
-                platform="light",
-                area_id=area.id,
-            ),
-            "light.living_room": RegistryEntryWithDefaults(
-                entity_id="light.living_room",
-                unique_id="4444",
-                platform="light",
-                area_id=area.id,
-            ),
+            "switch.test": {},
+            "switch.tv": {"area_id": area.id},
+            "light.tv_ambilights": {"area_id": area.id},
+            "light.living_room": {"area_id": area.id},
         },
     )
 
@@ -1082,45 +1004,29 @@ async def test_include_complex_nested_filters(
         ],
     )
 
-    group_state = hass.states.get("sensor.test_include_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.tv_power",
-        "sensor.tv_ambilights_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.test_include_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.tv_power",
+                "sensor.tv_ambilights_power",
+            },
+        },
+    )
 
 
 async def test_include_by_area_combined_with_domain_filter(hass: HomeAssistant, area_registry: AreaRegistry) -> None:
     """See https://github.com/bramstroker/homeassistant-powercalc/issues/1984"""
     area_kitchen = area_registry.async_get_or_create("kitchen")
     area_conservatory = area_registry.async_get_or_create("conservatory")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.kitchen_switch": RegistryEntryWithDefaults(
-                entity_id="switch.kitchen_switch",
-                unique_id="1111",
-                platform="switch",
-                area_id=area_kitchen.id,
-            ),
-            "switch.conservatory_switch": RegistryEntryWithDefaults(
-                entity_id="switch.conservatory_switch",
-                unique_id="2222",
-                platform="switch",
-                area_id=area_conservatory.id,
-            ),
-            "light.kitchen_light": RegistryEntryWithDefaults(
-                entity_id="light.kitchen_light",
-                unique_id="3333",
-                platform="light",
-                area_id=area_kitchen.id,
-            ),
-            "light.conservatory_light": RegistryEntryWithDefaults(
-                entity_id="light.conservatory_light",
-                unique_id="4444",
-                platform="light",
-                area_id=area_conservatory.id,
-            ),
+            "switch.kitchen_switch": {"area_id": area_kitchen.id},
+            "switch.conservatory_switch": {"area_id": area_conservatory.id},
+            "light.kitchen_light": {"area_id": area_kitchen.id},
+            "light.conservatory_light": {"area_id": area_conservatory.id},
         },
     )
 
@@ -1158,46 +1064,45 @@ async def test_include_by_area_combined_with_domain_filter(hass: HomeAssistant, 
         ],
     )
 
-    group_state = hass.states.get("sensor.indoor_lights_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.kitchen_light_power",
-        "sensor.conservatory_light_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.indoor_lights_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.kitchen_light_power",
+                "sensor.conservatory_light_power",
+            },
+        },
+    )
 
-    group_kitchen_state = hass.states.get("sensor.kitchen_power")
-    assert group_kitchen_state
-    assert group_kitchen_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.kitchen_light_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.kitchen_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.kitchen_light_power",
+            },
+        },
+    )
 
-    group_conservatory_state = hass.states.get("sensor.conservatory_power")
-    assert group_conservatory_state
-    assert group_conservatory_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.conservatory_light_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.conservatory_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.conservatory_light_power",
+            },
+        },
+    )
 
 
 async def test_include_all(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.switch": RegistryEntryWithDefaults(
-                entity_id="switch.switch",
-                unique_id="1111",
-                platform="switch",
-            ),
-            "light.light": RegistryEntryWithDefaults(
-                entity_id="light.light",
-                unique_id="2222",
-                platform="light",
-            ),
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_power",
-                unique_id="3333",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
+            "switch.switch": {},
+            "light.light": {},
+            "sensor.existing_power": {"device_class": SensorDeviceClass.POWER},
         },
     )
 
@@ -1216,13 +1121,17 @@ async def test_include_all(hass: HomeAssistant) -> None:
         ],
     )
 
-    group_state = hass.states.get("sensor.all_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.switch_power",
-        "sensor.light_power",
-        "sensor.existing_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.all_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.switch_power",
+                "sensor.light_power",
+                "sensor.existing_power",
+            },
+        },
+    )
 
 
 async def test_include_by_label_filter_other_label(hass: HomeAssistant, label_registry: LabelRegistry) -> None:
@@ -1233,32 +1142,20 @@ async def test_include_by_label_filter_other_label(hass: HomeAssistant, label_re
 
     mock_device(hass, "device-a", "Signify", "LCT012", labels=["my_label"])
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.some_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.some_energy",
-                unique_id="1111",
-                platform="sensor",
-                device_id="device-a",
-                original_device_class=SensorDeviceClass.ENERGY,
-            ),
-            "sensor.some_energy2": RegistryEntryWithDefaults(
-                entity_id="sensor.some_energy2",
-                unique_id="2222",
-                platform="sensor",
-                device_id="device-a",
-                labels=["exclude_powercalc"],
-                original_device_class=SensorDeviceClass.ENERGY,
-            ),
-            "sensor.some_energy3": RegistryEntryWithDefaults(
-                entity_id="sensor.some_energy3",
-                unique_id="3333",
-                platform="sensor",
-                device_id="device-a",
-                labels=["exclude_powercalc"],
-                original_device_class=SensorDeviceClass.ENERGY,
-            ),
+            "sensor.some_energy": {"device_id": "device-a", "original_device_class": SensorDeviceClass.ENERGY},
+            "sensor.some_energy2": {
+                "device_id": "device-a",
+                "labels": ["exclude_powercalc"],
+                "original_device_class": SensorDeviceClass.ENERGY,
+            },
+            "sensor.some_energy3": {
+                "device_id": "device-a",
+                "labels": ["exclude_powercalc"],
+                "original_device_class": SensorDeviceClass.ENERGY,
+            },
         },
     )
 
@@ -1280,28 +1177,23 @@ async def test_include_by_label_filter_other_label(hass: HomeAssistant, label_re
         ],
     )
 
-    group_state = hass.states.get("sensor.my_group_energy")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.some_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.my_group_energy",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.some_energy",
+            },
+        },
+    )
 
 
 async def test_exclude_non_powercalc_sensors(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.switch": RegistryEntryWithDefaults(
-                entity_id="switch.switch",
-                unique_id="1111",
-                platform="switch",
-            ),
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_power",
-                unique_id="3333",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
+            "switch.switch": {},
+            "sensor.existing_power": {"device_class": SensorDeviceClass.POWER},
         },
     )
 
@@ -1320,11 +1212,15 @@ async def test_exclude_non_powercalc_sensors(hass: HomeAssistant) -> None:
         ],
     )
 
-    group_state = hass.states.get("sensor.all_power")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == {
-        "sensor.switch_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.all_power",
+        attributes={
+            CONF_ENTITIES: {
+                "sensor.switch_power",
+            },
+        },
+    )
 
 
 async def test_include_logs_warning(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
@@ -1358,30 +1254,7 @@ async def test_include_logs_warning(hass: HomeAssistant, caplog: pytest.LogCaptu
 async def test_irrelevant_entity_domains_are_skipped(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
 
-    mock_device(hass, "device-a", "Signify", "LCT012")
-    mock_registry(
-        hass,
-        {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="2222",
-                platform="hue",
-                device_id="device-a",
-            ),
-            "scene.test": RegistryEntryWithDefaults(
-                entity_id="scene.test",
-                unique_id="3333",
-                platform="hue",
-                device_id="device-a",
-            ),
-            "event.test": RegistryEntryWithDefaults(
-                entity_id="event.test",
-                unique_id="4444",
-                platform="hue",
-                device_id="device-a",
-            ),
-        },
-    )
+    mock_device_with_entities(hass, ["light.test", "scene.test", "event.test"], "Signify", "LCT012", platform="hue")
     result = await find_entities(hass)
     assert len(result.discoverable) == 1
     assert "light.test" in result.discoverable
@@ -1392,16 +1265,14 @@ async def test_irrelevant_entity_domains_are_skipped(hass: HomeAssistant, caplog
 
 async def test_powercalc_entity_with_stale_config_entry_is_skipped(hass: HomeAssistant) -> None:
     """A Powercalc entity referencing a removed config entry must not be included."""
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.stale_power": RegistryEntryWithDefaults(
-                entity_id="sensor.stale_power",
-                unique_id="1111",
-                platform=DOMAIN,
-                config_entry_id="non-existing-config-entry",
-                device_class=SensorDeviceClass.POWER,
-            ),
+            "sensor.stale_power": {
+                "platform": DOMAIN,
+                "config_entry_id": "non-existing-config-entry",
+                "device_class": SensorDeviceClass.POWER,
+            },
         },
     )
 
@@ -1413,9 +1284,8 @@ async def test_powercalc_entity_with_stale_config_entry_is_skipped(hass: HomeAss
 
 async def test_prevent_duplicate_entities_when_using_include_all(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     await run_powercalc_setup(
         hass,
@@ -1439,11 +1309,10 @@ async def test_prevent_duplicate_entities_when_using_include_all(
 
 async def test_include_with_gui_and_yaml_entry(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """Test include works correctly when individual entity is configured both with YAML and GUI"""
 
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     await create_mock_config_entry(
         hass,
@@ -1476,9 +1345,7 @@ async def test_include_with_gui_and_yaml_entry(
         ],
     )
 
-    state = hass.states.get("sensor.my_group_power")
-    assert state
-    assert state.attributes.get(CONF_ENTITIES) == {"sensor.test_power"}
+    assert_entity_state(hass, "sensor.my_group_power", attributes={CONF_ENTITIES: {"sensor.test_power"}})
     assert not hass.states.get("sensor.test_power2")
 
 

--- a/tests/power_profile/device_types/test_camera.py
+++ b/tests/power_profile/device_types/test_camera.py
@@ -1,10 +1,9 @@
 from homeassistant.core import HomeAssistant
 
 from tests.common import assert_entity_state, run_powercalc_setup, set_states
-from tests.conftest import MockEntityWithModel
 
 
-async def test_reolink_e1_pro(hass: HomeAssistant, mock_entity_with_model_information: MockEntityWithModel) -> None:
+async def test_reolink_e1_pro(hass: HomeAssistant) -> None:
     camera_id = "camera.test_camera"
 
     power_sensor_id = "sensor.test_camera_power"

--- a/tests/power_profile/device_types/test_infrared_light.py
+++ b/tests/power_profile/device_types/test_infrared_light.py
@@ -16,15 +16,14 @@ from custom_components.powercalc.const import (
 from tests.common import (
     assert_entity_state,
     get_test_profile_dir,
+    mock_device_with_entities,
     run_powercalc_setup,
     set_states,
 )
-from tests.conftest import MockEntityWithModel
 
 
 async def test_infrared_light(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Infrared capable light with several sub profiles
@@ -35,7 +34,8 @@ async def test_infrared_light(
     manufacturer = "LIFX"
     model = "LIFX A19 Night Vision"
 
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         light_id,
         manufacturer,
         model,

--- a/tests/power_profile/device_types/test_lawn_mower.py
+++ b/tests/power_profile/device_types/test_lawn_mower.py
@@ -3,17 +3,18 @@ from homeassistant.components.lawn_mower import LawnMowerActivity
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import CONF_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntry
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    mock_device_registry,
-    mock_registry,
-)
 
 from custom_components.powercalc.const import (
     CONF_CUSTOM_MODEL_DIRECTORY,
 )
-from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    get_test_profile_dir,
+    mock_devices,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 
 
 async def test_lawn_mower(
@@ -28,38 +29,28 @@ async def test_lawn_mower(
     battery_id = "sensor.mymower_battery"
     power_sensor_id = "sensor.mymower_power"
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            mower_id: RegistryEntryWithDefaults(
-                entity_id=mower_id,
-                unique_id="unique_mower_1",
-                platform="test",
-                device_id="device_1",
-            ),
-            battery_id: RegistryEntryWithDefaults(
-                entity_id=battery_id,
-                unique_id="unique_battery_1",
-                platform="test",
-                device_id="device_1",
-                device_class=SensorDeviceClass.BATTERY,
-            ),
-            charging_id: RegistryEntryWithDefaults(
-                entity_id=charging_id,
-                unique_id="unique_charging_1",
-                platform="test",
-                device_id="device_1",
-                device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-            ),
+            mower_id: {"unique_id": "unique_mower_1", "platform": "test", "device_id": "device_1"},
+            battery_id: {
+                "unique_id": "unique_battery_1",
+                "platform": "test",
+                "device_id": "device_1",
+                "device_class": SensorDeviceClass.BATTERY,
+            },
+            charging_id: {
+                "unique_id": "unique_charging_1",
+                "platform": "test",
+                "device_id": "device_1",
+                "device_class": BinarySensorDeviceClass.BATTERY_CHARGING,
+            },
         },
     )
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "device_1": DeviceEntry(
-                config_entry_id="test",
-                id="device_1",
-            ),
+            "device_1": {},
         },
     )
 

--- a/tests/power_profile/device_types/test_media_player.py
+++ b/tests/power_profile/device_types/test_media_player.py
@@ -10,13 +10,17 @@ from custom_components.powercalc.const import (
     CONF_MODEL,
     CONF_STANDBY_POWER,
 )
-from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
-from tests.conftest import MockEntityWithModel
+from tests.common import (
+    assert_entity_state,
+    get_test_profile_dir,
+    mock_device_with_entities,
+    run_powercalc_setup,
+    set_states,
+)
 
 
 async def test_media_player(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test that media player can be setup from profile library
@@ -25,8 +29,9 @@ async def test_media_player(
     manufacturer = "Google Inc."
     model = "Google Nest Mini"
 
-    mock_entity_with_model_information(
-        entity_id=entity_id,
+    mock_device_with_entities(
+        hass,
+        entity_ids=entity_id,
         manufacturer=manufacturer,
         model=model,
     )

--- a/tests/power_profile/device_types/test_network.py
+++ b/tests/power_profile/device_types/test_network.py
@@ -5,8 +5,7 @@ from homeassistant.const import CONF_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVA
 from homeassistant.core import HomeAssistant
 
 from custom_components.powercalc.const import CONF_MANUFACTURER, CONF_MODEL, DUMMY_ENTITY_ID
-from tests.common import assert_entity_state, run_powercalc_setup, set_states
-from tests.conftest import MockEntityWithModel
+from tests.common import assert_entity_state, mock_device_with_entities, run_powercalc_setup, set_states
 
 
 async def test_network_device(hass: HomeAssistant) -> None:
@@ -39,14 +38,14 @@ async def test_network_device(hass: HomeAssistant) -> None:
 
 async def test_router_discovery_by_device(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
     """
     Test that smart plug can be setup from profile library
     """
 
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "switch.freebox",
         "test",
         "network_router",

--- a/tests/power_profile/device_types/test_nightlight_standby.py
+++ b/tests/power_profile/device_types/test_nightlight_standby.py
@@ -1,13 +1,19 @@
 from homeassistant.const import CONF_ENTITY_ID, CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_registry
 
 from custom_components.powercalc.const import (
     CONF_CUSTOM_MODEL_DIRECTORY,
     CONF_MANUFACTURER,
     CONF_MODEL,
 )
-from tests.common import assert_entity_state, get_test_profile_dir, mock_device, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    get_test_profile_dir,
+    mock_device,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 
 
 async def test_translation_key_standby_sub_profile(
@@ -17,23 +23,16 @@ async def test_translation_key_standby_sub_profile(
     Regression for dual-light devices where only one sub-profile should contribute standby power.
     """
     device_id = "device-with-nightlight"
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="main",
-                platform="test",
-                device_id=device_id,
-                translation_key="main",
-            ),
-            "light.test_nightlight": RegistryEntryWithDefaults(
-                entity_id="light.test_nightlight",
-                unique_id="nightlight",
-                platform="test",
-                device_id=device_id,
-                translation_key="nightlight",
-            ),
+            "light.test": {"unique_id": "main", "platform": "test", "device_id": device_id, "translation_key": "main"},
+            "light.test_nightlight": {
+                "unique_id": "nightlight",
+                "platform": "test",
+                "device_id": device_id,
+                "translation_key": "nightlight",
+            },
         },
     )
     mock_device(hass, device_id, "test", "translation_key_standby_sub_profile")

--- a/tests/power_profile/device_types/test_power_meter.py
+++ b/tests/power_profile/device_types/test_power_meter.py
@@ -1,5 +1,6 @@
 from homeassistant.const import CONF_DEVICE, CONF_ENTITY_ID, CONF_NAME, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
+import pytest
 
 from custom_components.powercalc import CONF_SENSOR_TYPE
 from custom_components.powercalc.const import (
@@ -16,16 +17,11 @@ from tests.common import (
     run_powercalc_setup,
     set_states,
 )
-from tests.conftest import MockEntityWithModel
 
 
-async def test_power_meter(
-    hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
-) -> None:
-    """
-    Test that multi switch can be setup from profile library
-    """
+@pytest.mark.parametrize("profile_dir", ["power_meter", "power_meter_legacy"])
+async def test_power_meter(hass: HomeAssistant, profile_dir: str) -> None:
+    """Test that a power meter can be setup from the profile library, in both profile formats"""
     sensor_id = "sensor.pm_mini"
     power_sensor_id = "sensor.pm_mini_device_power"
 
@@ -33,29 +29,7 @@ async def test_power_meter(
         hass,
         {
             CONF_ENTITY_ID: sensor_id,
-            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("power_meter"),
-        },
-    )
-
-    await set_states(hass, [(sensor_id, "50.00")])
-    assert_entity_state(hass, power_sensor_id, "0.30")
-
-
-async def test_power_meter_legacy(
-    hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
-) -> None:
-    """
-    Test that multi switch can be setup from profile library
-    """
-    sensor_id = "sensor.pm_mini"
-    power_sensor_id = "sensor.pm_mini_device_power"
-
-    await run_powercalc_setup(
-        hass,
-        {
-            CONF_ENTITY_ID: sensor_id,
-            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("power_meter_legacy"),
+            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir(profile_dir),
         },
     )
 

--- a/tests/power_profile/device_types/test_smart_dimmer.py
+++ b/tests/power_profile/device_types/test_smart_dimmer.py
@@ -12,14 +12,18 @@ from custom_components.powercalc.const import (
     CONF_MIN_POWER,
     DOMAIN,
 )
-from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    get_test_profile_dir,
+    mock_device_with_entities,
+    run_powercalc_setup,
+    set_states,
+)
 from tests.config_flow.common import confirm_auto_discovered_model, handle_options_flow_update
-from tests.conftest import MockEntityWithModel
 
 
 async def test_smart_dimmer_power_input_yaml(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test a smart dimmer can be setup with YAML and a linear power value for the light provided by the user
@@ -52,7 +56,6 @@ async def test_smart_dimmer_power_input_yaml(
 
 async def test_smart_dimmer_power_input_yaml_omit_linear_config(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test a smart dimmer can be setup with YAML omitting the linear power value for the light
@@ -78,7 +81,6 @@ async def test_smart_dimmer_power_input_yaml_omit_linear_config(
 
 async def test_smart_dimmer_power_input_gui_config_flow(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test a smart dimmer can be setup with GUI and a fixed power value for the light configured by the user
@@ -89,8 +91,9 @@ async def test_smart_dimmer_power_input_gui_config_flow(
     manufacturer = "test"
     model = "smart_dimmer"
 
-    mock_entity_with_model_information(
-        entity_id=light_entity_id,
+    mock_device_with_entities(
+        hass,
+        entity_ids=light_entity_id,
         manufacturer=manufacturer,
         model=model,
     )

--- a/tests/power_profile/device_types/test_smart_switch.py
+++ b/tests/power_profile/device_types/test_smart_switch.py
@@ -15,14 +15,18 @@ from custom_components.powercalc.const import (
     CONF_POWER,
     DOMAIN,
 )
-from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    get_test_profile_dir,
+    mock_device_with_entities,
+    run_powercalc_setup,
+    set_states,
+)
 from tests.config_flow.common import confirm_auto_discovered_model, handle_options_flow_update
-from tests.conftest import MockEntityWithModel
 
 
 async def test_smart_switch_with_yaml(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test that smart plug can be setup from profile library
@@ -31,8 +35,9 @@ async def test_smart_switch_with_yaml(
     manufacturer = "Shelly"
     model = "Shelly Plug S"
 
-    mock_entity_with_model_information(
-        entity_id=switch_id,
+    mock_device_with_entities(
+        hass,
+        entity_ids=switch_id,
         manufacturer=manufacturer,
         model=model,
     )
@@ -60,7 +65,6 @@ async def test_smart_switch_with_yaml(
 
 async def test_smart_switch_power_input_yaml(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test a smart switch can be setup with YAML and a fixed power value for the appliance configured by the user
@@ -71,8 +75,9 @@ async def test_smart_switch_power_input_yaml(
     manufacturer = "IKEA"
     model = "Smart Control Outlet"
 
-    mock_entity_with_model_information(
-        entity_id=switch_id,
+    mock_device_with_entities(
+        hass,
+        entity_ids=switch_id,
         manufacturer=manufacturer,
         model=model,
     )
@@ -101,7 +106,6 @@ async def test_smart_switch_power_input_yaml(
 
 async def test_gui_smart_switch_without_builtin_powermeter(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test setting up smart switch with relay, but without a built-in powermeter
@@ -111,7 +115,6 @@ async def test_gui_smart_switch_without_builtin_powermeter(
 
     result = await start_discovery_flow(
         hass,
-        mock_entity_with_model_information,
         switch_id,
         manufacturer="test",
         model="smart_switch_without_pm",
@@ -145,7 +148,6 @@ async def test_gui_smart_switch_without_builtin_powermeter(
 
 async def test_gui_smart_switch_with_builtin_powermeter(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test setting up smart switch with relay, but with a built-in powermeter
@@ -155,7 +157,6 @@ async def test_gui_smart_switch_with_builtin_powermeter(
 
     result = await start_discovery_flow(
         hass,
-        mock_entity_with_model_information,
         switch_id,
         manufacturer="test",
         model="smart_switch_with_pm",
@@ -175,11 +176,11 @@ async def test_gui_smart_switch_with_builtin_powermeter(
 
 async def test_hue_smart_plug_is_discovered(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
-    mock_entity_with_model_information(
-        entity_id="switch.smartplug",
+    mock_device_with_entities(
+        hass,
+        entity_ids="switch.smartplug",
         manufacturer="signify",
         model="LOM002",
         platform="hue",
@@ -194,13 +195,13 @@ async def test_hue_smart_plug_is_discovered(
 
 async def start_discovery_flow(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     entity_id: str,
     manufacturer: str,
     model: str,
 ) -> FlowResult:
-    mock_entity_with_model_information(
-        entity_id=entity_id,
+    mock_device_with_entities(
+        hass,
+        entity_ids=entity_id,
         manufacturer=manufacturer,
         model=model,
     )

--- a/tests/power_profile/device_types/test_vacuum_robot.py
+++ b/tests/power_profile/device_types/test_vacuum_robot.py
@@ -1,21 +1,19 @@
-from datetime import timedelta
-
 from homeassistant.components.vacuum import VacuumActivity
 from homeassistant.const import CONF_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.util import dt
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    async_fire_time_changed,
-    mock_device_registry,
-    mock_registry,
-)
 
 from custom_components.powercalc.const import (
     CONF_CUSTOM_MODEL_DIRECTORY,
 )
-from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    async_advance_time,
+    get_test_profile_dir,
+    mock_devices,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 
 
 async def test_vacuum_robot(
@@ -28,31 +26,22 @@ async def test_vacuum_robot(
     vacuum_id = "vacuum.roomba"
     battery_id = "sensor.roomba_battery"
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            vacuum_id: RegistryEntryWithDefaults(
-                entity_id=vacuum_id,
-                unique_id="unique_vacuum_1",
-                platform="test",
-                device_id="device_1",
-            ),
-            battery_id: RegistryEntryWithDefaults(
-                entity_id=battery_id,
-                unique_id="unique_battery_1",
-                platform="test",
-                device_id="device_1",
-                device_class="battery",
-            ),
+            vacuum_id: {"unique_id": "unique_vacuum_1", "platform": "test", "device_id": "device_1"},
+            battery_id: {
+                "unique_id": "unique_battery_1",
+                "platform": "test",
+                "device_id": "device_1",
+                "device_class": "battery",
+            },
         },
     )
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "device_1": DeviceEntry(
-                config_entry_id="test",
-                id="device_1",
-            ),
+            "device_1": {},
         },
     )
 
@@ -85,31 +74,22 @@ async def test_with_tapering_playbook(hass: HomeAssistant) -> None:
     vacuum_id = "vacuum.roomba"
     battery_id = "sensor.roomba_battery"
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            vacuum_id: RegistryEntryWithDefaults(
-                entity_id=vacuum_id,
-                unique_id="unique_vacuum_1",
-                platform="test",
-                device_id="device_1",
-            ),
-            battery_id: RegistryEntryWithDefaults(
-                entity_id=battery_id,
-                unique_id="unique_battery_1",
-                platform="test",
-                device_id="device_1",
-                device_class="battery",
-            ),
+            vacuum_id: {"unique_id": "unique_vacuum_1", "platform": "test", "device_id": "device_1"},
+            battery_id: {
+                "unique_id": "unique_battery_1",
+                "platform": "test",
+                "device_id": "device_1",
+                "device_class": "battery",
+            },
         },
     )
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "device_1": DeviceEntry(
-                config_entry_id="test",
-                id="device_1",
-            ),
+            "device_1": {},
         },
     )
 
@@ -129,22 +109,18 @@ async def test_with_tapering_playbook(hass: HomeAssistant) -> None:
     await set_states(hass, [(battery_id, 100), (vacuum_id, VacuumActivity.DOCKED)])
     assert_entity_state(hass, power_sensor_id, "0.00")
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
-    await hass.async_block_till_done()
+    await async_advance_time(hass, 1)
 
     assert_entity_state(hass, power_sensor_id, "9.00")
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3))
-    await hass.async_block_till_done()
+    await async_advance_time(hass, 3)
 
     assert_entity_state(hass, power_sensor_id, "5.00")
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=5))
-    await hass.async_block_till_done()
+    await async_advance_time(hass, 5)
 
     assert_entity_state(hass, power_sensor_id, "3.00")
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=60))
-    await hass.async_block_till_done()
+    await async_advance_time(hass, 60)
 
     assert_entity_state(hass, power_sensor_id, "3.00")

--- a/tests/power_profile/loader/test_local.py
+++ b/tests/power_profile/loader/test_local.py
@@ -11,18 +11,16 @@ from custom_components.powercalc.power_profile.power_profile import DeviceType, 
 from tests.common import assert_entity_state, get_test_config_dir, get_test_profile_dir, run_powercalc_setup, set_states
 
 
-async def test_broken_lib_by_identical_model_alias(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
-    loader = LocalLoader(hass, get_test_profile_dir("double_model"))
+@pytest.mark.parametrize("profile_dir", ["double_model", "double_alias"])
+async def test_broken_lib_by_double_entry(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    profile_dir: str,
+) -> None:
+    loader = LocalLoader(hass, get_test_profile_dir(profile_dir))
     with caplog.at_level(logging.ERROR):
         await loader.initialize()
-    assert "Double entry manufacturer/model in custom library:" in caplog.text
-
-
-async def test_broken_lib_by_identical_alias_alias(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
-    loader = LocalLoader(hass, get_test_profile_dir("double_alias"))
-    with caplog.at_level(logging.ERROR):
-        await loader.initialize()
-        assert "Double entry manufacturer/model in custom library" in caplog.text
+    assert "Double entry manufacturer/model in custom library" in caplog.text
 
 
 async def test_broken_lib_by_missing_model_json(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -290,10 +290,10 @@ async def test_eventual_success_after_download_retry(
         ("018de85593a1b22b906f863677bb4891", "018de85593a1b22b906f863677bb4891", False, True),
     ],
 )
+@pytest.mark.usefixtures("mock_download_profile_endpoints")
 async def test_profile_redownloaded_when_newer_version_available(
     hass: HomeAssistant,
     mock_aioresponse: aioresponses,
-    mock_download_profile_endpoints: None,
     profile_hash: str | None,
     local_hash: str | None,
     exists_locally: bool,
@@ -357,77 +357,29 @@ async def test_profile_redownloaded_when_newer_version_available(
     assert actual_call_count == expected_call_count
 
 
+@pytest.mark.parametrize(
+    "response_kwargs",
+    [
+        pytest.param({"status": 404}, id="not found"),
+        # See: https://github.com/bramstroker/homeassistant-powercalc/issues/2277
+        pytest.param({"status": 200, "exception": ClientError("test")}, id="connection error"),
+        pytest.param({"status": 200, "exception": TimeoutError("test")}, id="timeout"),
+    ],
+)
 async def test_fallback_to_local_library(
     hass: HomeAssistant,
     mock_aioresponse: aioresponses,
     caplog: pytest.LogCaptureFixture,
+    response_kwargs: dict,
 ) -> None:
     """
     Test that the local library is used when the remote library is not available.
     When unavailable, it should retry 3 times before falling back to the local library.
     """
-
     shutil.copy(get_library_json_path(), hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json"))
 
     caplog.set_level(logging.WARNING)
-    mock_aioresponse.get(
-        ENDPOINT_LIBRARY,
-        status=404,
-        repeat=True,
-    )
-
-    loader = RemoteLoader(hass)
-    loader.retry_timeout = 0
-    await loader.initialize()
-
-    assert "signify" in loader.model_lookup
-    assert len(caplog.records) >= 2
-
-
-async def test_fallback_to_local_library_on_client_connection_error(
-    hass: HomeAssistant,
-    mock_aioresponse: aioresponses,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    Test that the local library is used when api.powercalc.nl is not available.
-    See: https://github.com/bramstroker/homeassistant-powercalc/issues/2277
-    """
-    shutil.copy(get_library_json_path(), hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json"))
-
-    caplog.set_level(logging.WARNING)
-    mock_aioresponse.get(
-        ENDPOINT_LIBRARY,
-        status=200,
-        repeat=True,
-        exception=ClientError("test"),
-    )
-
-    loader = RemoteLoader(hass)
-    loader.retry_timeout = 0
-    await loader.initialize()
-
-    assert "signify" in loader.model_lookup
-    assert len(caplog.records) >= 2
-
-
-async def test_fallback_to_local_library_on_timeout(
-    hass: HomeAssistant,
-    mock_aioresponse: aioresponses,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    Test that the local library is used when api.powercalc.nl times out.
-    """
-    shutil.copy(get_library_json_path(), hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json"))
-
-    caplog.set_level(logging.WARNING)
-    mock_aioresponse.get(
-        ENDPOINT_LIBRARY,
-        status=200,
-        repeat=True,
-        exception=TimeoutError("test"),
-    )
+    mock_aioresponse.get(ENDPOINT_LIBRARY, repeat=True, **response_kwargs)
 
     loader = RemoteLoader(hass)
     loader.retry_timeout = 0
@@ -462,7 +414,6 @@ async def test_fallback_to_local_library_fails(
 
 async def test_fallback_to_local_profile(
     mock_aioresponse: aioresponses,
-    mock_library_json_response: None,
     remote_loader: RemoteLoader,
 ) -> None:
     manufacturer = "signify"
@@ -477,13 +428,12 @@ async def test_fallback_to_local_profile(
         repeat=True,
     )
 
-    await remote_loader.load_model(manufacturer, model, force_update=True)
+    assert await remote_loader.load_model(manufacturer, model, force_update=True)
 
 
 async def test_fallback_to_local_profile_on_timeout(
     hass: HomeAssistant,
     mock_aioresponse: aioresponses,
-    mock_library_json_response: None,
     remote_loader: RemoteLoader,
 ) -> None:
     manufacturer = "signify"
@@ -499,13 +449,13 @@ async def test_fallback_to_local_profile_on_timeout(
         exception=TimeoutError("test"),
     )
 
-    await remote_loader.load_model(manufacturer, model, force_update=True)
+    assert await remote_loader.load_model(manufacturer, model, force_update=True)
 
 
+@pytest.mark.usefixtures("mock_download_profile_endpoints")
 async def test_profile_redownloaded_when_model_json_missing(
     hass: HomeAssistant,
     remote_loader: RemoteLoader,
-    mock_download_profile_endpoints: list[dict],
 ) -> None:
     """Test profile is redownloaded when model.json is missing."""
     local_storage_path = remote_loader.get_storage_path("signify", "LCA001")
@@ -562,7 +512,6 @@ async def test_profile_redownloaded_when_model_json_corrupt_retry_limit(
     hass: HomeAssistant,
     remote_loader: RemoteLoader,
     mock_aioresponse: aioresponses,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     When model.json is corrupt, retry 3 times before giving up.

--- a/tests/power_profile/test_library.py
+++ b/tests/power_profile/test_library.py
@@ -14,8 +14,13 @@ from custom_components.powercalc.power_profile.library import ModelInfo, Profile
 from custom_components.powercalc.power_profile.loader.composite import CompositeLoader
 from custom_components.powercalc.power_profile.loader.local import LocalLoader
 from custom_components.powercalc.power_profile.loader.remote import RemoteLoader
-from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
-from tests.conftest import MockEntityWithModel
+from tests.common import (
+    assert_entity_state,
+    get_test_profile_dir,
+    mock_device_with_entities,
+    run_powercalc_setup,
+    set_states,
+)
 
 
 async def test_manufacturer_listing(hass: HomeAssistant) -> None:
@@ -158,10 +163,7 @@ async def test_hidden_directories_are_skipped_from_model_listing(
     assert len(caplog.records) == 0
 
 
-async def test_exception_is_raised_when_no_model_json_present(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+async def test_exception_is_raised_when_no_model_json_present(hass: HomeAssistant) -> None:
     library = await ProfileLibrary.factory(hass)
     model_info = ModelInfo("foo", "bar")
     source_entity = create_source_entity("light.test", hass)
@@ -293,10 +295,10 @@ async def test_linked_profile_loading_failed(hass: HomeAssistant) -> None:
 
 async def test_autodiscover_model_with_default_sub_profile(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """Test autodiscover model with default sub profile."""
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "switch.test",
         "shelly",
         "Shelly Plus 1PM",
@@ -310,12 +312,12 @@ async def test_autodiscover_model_with_default_sub_profile(
 
 async def test_linked_profile_fixed(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     See https://github.com/bramstroker/homeassistant-powercalc/pull/3406
     """
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "switch.test",
         "test",
         "linked_profile_fixed",

--- a/tests/power_profile/user_scenarios/test_lightify_plug.py
+++ b/tests/power_profile/user_scenarios/test_lightify_plug.py
@@ -8,18 +8,18 @@ from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
     CONF_MANUFACTURER,
 )
+from tests.common import mock_device_with_entities
 from tests.config_flow.common import confirm_auto_discovered_model, select_menu_item
-from tests.conftest import MockEntityWithModel
 
 
 async def test_lightify_plug_selectable(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     See https://github.com/bramstroker/homeassistant-powercalc/issues/2858
     """
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "osram",
         "LIGHTIFY Plug 01",

--- a/tests/power_profile/user_scenarios/test_nintendo_switch.py
+++ b/tests/power_profile/user_scenarios/test_nintendo_switch.py
@@ -1,9 +1,5 @@
-from datetime import timedelta
-
 from homeassistant.const import CONF_ENTITY_ID, STATE_HOME, STATE_NOT_HOME, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
-from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.powercalc.const import (
     CONF_DELAY,
@@ -12,7 +8,7 @@ from custom_components.powercalc.const import (
     CONF_SLEEP_POWER,
     CONF_STANDBY_POWER,
 )
-from tests.common import assert_entity_state, run_powercalc_setup, set_states
+from tests.common import assert_entity_state, async_advance_time, run_powercalc_setup, set_states
 
 
 async def test_nintendo_switch(hass: HomeAssistant) -> None:
@@ -53,6 +49,6 @@ async def test_nintendo_switch(hass: HomeAssistant) -> None:
     assert_entity_state(hass, power_sensor_id, "12.00")
 
     # After 10 seconds the device goes into sleep mode, check the sleep power is set on the power sensor
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3000))
+    await async_advance_time(hass, 3000, block=False)
 
     assert_entity_state(hass, power_sensor_id, "0.00")

--- a/tests/power_profile/user_scenarios/test_shelly_plug.py
+++ b/tests/power_profile/user_scenarios/test_shelly_plug.py
@@ -1,18 +1,17 @@
 from homeassistant.const import CONF_ENTITY_ID, STATE_ON
 from homeassistant.core import HomeAssistant
 
-from tests.common import assert_entity_state, run_powercalc_setup, set_states
-from tests.conftest import MockEntityWithModel
+from tests.common import assert_entity_state, mock_device_with_entities, run_powercalc_setup, set_states
 
 
 async def test_shelly_plug_auto_sub_profile(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     See https://github.com/bramstroker/homeassistant-powercalc/issues/3370#issuecomment-3102005428
     """
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "switch.test",
         "shelly",
         "Shelly Plug S",

--- a/tests/power_profile/user_scenarios/test_television_idle.py
+++ b/tests/power_profile/user_scenarios/test_television_idle.py
@@ -9,12 +9,10 @@ from custom_components.powercalc.const import (
     CalculationStrategy,
 )
 from tests.common import assert_entity_state, run_powercalc_setup, set_states
-from tests.conftest import MockEntityWithModel
 
 
 async def test_media_player_idle(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     See https://github.com/bramstroker/homeassistant-powercalc/issues/3492

--- a/tests/power_profile/variables/test_entity_by_device_class.py
+++ b/tests/power_profile/variables/test_entity_by_device_class.py
@@ -2,48 +2,35 @@ import logging
 
 from homeassistant.const import CONF_ENTITY_ID, CONF_NAME, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntry
 import pytest
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    mock_device_registry,
-    mock_registry,
-)
 
 from custom_components.powercalc.const import (
     CONF_CUSTOM_MODEL_DIRECTORY,
 )
-from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
+from tests.common import (
+    assert_entity_state,
+    get_test_profile_dir,
+    mock_devices,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 
 
 async def test_variable_replaced(hass: HomeAssistant) -> None:
     """Test entity_by_device_class variable works as expected"""
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.test": RegistryEntryWithDefaults(
-                entity_id="switch.test",
-                unique_id="1111",
-                platform="test",
-                device_id="device_1",
-            ),
-            "sensor.test": RegistryEntryWithDefaults(
-                entity_id="sensor.test",
-                unique_id="2222",
-                platform="test",
-                device_id="device_1",
-                device_class="temperature",
-            ),
+            "switch.test": {"platform": "test", "device_id": "device_1"},
+            "sensor.test": {"platform": "test", "device_id": "device_1", "device_class": "temperature"},
         },
     )
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "device_1": DeviceEntry(
-                config_entry_id="test",
-                id="device_1",
-            ),
+            "device_1": {},
         },
     )
 
@@ -68,24 +55,16 @@ async def test_exception_raised_when_entity_not_found(hass: HomeAssistant, caplo
 
     caplog.set_level(logging.ERROR)
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "switch.test": RegistryEntryWithDefaults(
-                entity_id="switch.test",
-                unique_id="1111",
-                platform="test",
-                device_id="device_1",
-            ),
+            "switch.test": {"platform": "test", "device_id": "device_1"},
         },
     )
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "device_1": DeviceEntry(
-                config_entry_id="test",
-                id="device_1",
-            ),
+            "device_1": {},
         },
     )
 

--- a/tests/sensors/group/test_custom.py
+++ b/tests/sensors/group/test_custom.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
-from homeassistant.components.sensor import ATTR_STATE_CLASS, DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.utility_meter.sensor import (
     SensorDeviceClass,
     SensorStateClass,
@@ -36,9 +36,7 @@ from homeassistant.util import dt
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
-    RegistryEntryWithDefaults,
     async_fire_time_changed,
-    mock_registry,
     mock_restore_cache_with_extra_data,
 )
 
@@ -97,11 +95,13 @@ from custom_components.powercalc.const import (
 from custom_components.powercalc.sensors.group.custom import PreviousStateStore, resolve_entity_ids_recursively
 from tests.common import (
     assert_entity_state,
-    create_input_booleans,
+    async_advance_time,
     create_mock_config_entry,
+    create_mock_group_entry,
     create_mocked_virtual_power_sensor_entry,
     get_simple_fixed_config,
     mock_device,
+    mock_entities_in_registry,
     run_powercalc_setup,
     set_states,
 )
@@ -132,31 +132,39 @@ async def test_grouped_power_sensor(hass: HomeAssistant, entity_registry: Entity
     assert power_entry
     assert power_entry.unique_id == "group_unique_id"
 
-    power_state = hass.states.get("sensor.testgroup_power")
-    assert power_state
-    assert power_state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert power_state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
-    assert power_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
-    assert power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_power",
-        "sensor.test2_power",
-    }
-    assert power_state.state == "60.50"
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_power",
+        "60.50",
+        attributes={
+            ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT,
+            ATTR_ENTITIES: {
+                "sensor.test1_power",
+                "sensor.test2_power",
+            },
+        },
+    )
 
     await set_states(hass, [("sensor.test1_energy", "40.00")])
     energy_entry = entity_registry.async_get("sensor.testgroup_energy")
     assert energy_entry
     assert energy_entry.unique_id == "group_unique_id_energy"
 
-    energy_state = hass.states.get("sensor.testgroup_energy")
-    assert energy_state
-    assert energy_state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
-    assert energy_state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
-    assert energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_energy",
-        "sensor.test2_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_energy",
+        attributes={
+            ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+            ATTR_ENTITIES: {
+                "sensor.test1_energy",
+                "sensor.test2_energy",
+            },
+        },
+    )
 
     await set_states(hass, [("input_boolean.test1", STATE_OFF)], block_count=0)
 
@@ -164,22 +172,20 @@ async def test_grouped_power_sensor(hass: HomeAssistant, entity_registry: Entity
 
 
 async def test_subgroups_from_config_entry(hass: HomeAssistant) -> None:
-    config_entry_group_a = await create_mock_config_entry(
+    config_entry_group_a = await create_mock_group_entry(
         hass,
+        "GroupA",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "GroupA",
             CONF_GROUP_POWER_ENTITIES: ["sensor.test1_power"],
             CONF_GROUP_ENERGY_ENTITIES: ["sensor.test1_energy"],
             CONF_IGNORE_UNAVAILABLE_STATE: True,
         },
     )
 
-    config_entry_group_b = await create_mock_config_entry(
+    config_entry_group_b = await create_mock_group_entry(
         hass,
+        "GroupB",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "GroupB",
             CONF_GROUP_POWER_ENTITIES: ["sensor.test2_power"],
             CONF_GROUP_ENERGY_ENTITIES: ["sensor.test2_energy"],
             CONF_SUB_GROUPS: [
@@ -190,11 +196,10 @@ async def test_subgroups_from_config_entry(hass: HomeAssistant) -> None:
         },
     )
 
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "GroupC",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "GroupC",
             CONF_GROUP_POWER_ENTITIES: ["sensor.test3_power"],
             CONF_GROUP_ENERGY_ENTITIES: ["sensor.test3_energy"],
             CONF_SUB_GROUPS: [config_entry_group_b.entry_id],
@@ -202,57 +207,75 @@ async def test_subgroups_from_config_entry(hass: HomeAssistant) -> None:
         },
     )
 
-    groupa_power_state = hass.states.get("sensor.groupa_power")
-    assert groupa_power_state
-    assert groupa_power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_power",
-    }
-    groupa_energy_state = hass.states.get("sensor.groupa_energy")
-    assert groupa_energy_state
-    assert groupa_energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupa_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test1_power",
+            },
+        },
+    )
+    assert_entity_state(
+        hass,
+        "sensor.groupa_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test1_energy",
+            },
+        },
+    )
 
-    groupb_power_state = hass.states.get("sensor.groupb_power")
-    assert groupb_power_state
-    assert groupb_power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_power",
-        "sensor.test2_power",
-    }
-    groupb_energy_state = hass.states.get("sensor.groupb_energy")
-    assert groupb_energy_state
-    assert groupb_energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_energy",
-        "sensor.test2_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupb_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test1_power",
+                "sensor.test2_power",
+            },
+        },
+    )
+    assert_entity_state(
+        hass,
+        "sensor.groupb_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test1_energy",
+                "sensor.test2_energy",
+            },
+        },
+    )
 
-    groupc_power_state = hass.states.get("sensor.groupc_power")
-    assert groupc_power_state
-    assert groupc_power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_power",
-        "sensor.test2_power",
-        "sensor.test3_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupc_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test1_power",
+                "sensor.test2_power",
+                "sensor.test3_power",
+            },
+        },
+    )
 
 
 async def test_parent_group_reloaded_on_subgroup_update(hass: HomeAssistant) -> None:
     """When an entity is added to a subgroup all the groups referring this subgroup should be reloaded"""
 
-    config_entry_group_sub = await create_mock_config_entry(
+    config_entry_group_sub = await create_mock_group_entry(
         hass,
+        "GroupSub",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "GroupSub",
             CONF_GROUP_POWER_ENTITIES: ["sensor.test1_power"],
             CONF_IGNORE_UNAVAILABLE_STATE: True,
         },
     )
 
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "GroupMain",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "GroupMain",
             CONF_GROUP_POWER_ENTITIES: ["sensor.test2_power"],
             CONF_SUB_GROUPS: [
                 config_entry_group_sub.entry_id,
@@ -261,12 +284,16 @@ async def test_parent_group_reloaded_on_subgroup_update(hass: HomeAssistant) -> 
         },
     )
 
-    main_group_state = hass.states.get("sensor.groupmain_power")
-    assert main_group_state
-    assert main_group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_power",
-        "sensor.test2_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupmain_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test1_power",
+                "sensor.test2_power",
+            },
+        },
+    )
 
     hass.config_entries.async_update_entry(
         config_entry_group_sub,
@@ -276,17 +303,21 @@ async def test_parent_group_reloaded_on_subgroup_update(hass: HomeAssistant) -> 
         },
     )
 
-    main_group_state = hass.states.get("sensor.groupmain_power")
-    assert main_group_state
-    assert main_group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.test1_power",
-        "sensor.test2_power",
-        "sensor.test3_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupmain_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test1_power",
+                "sensor.test2_power",
+                "sensor.test3_power",
+            },
+        },
+    )
 
 
 async def test_reset_service(hass: HomeAssistant) -> None:
-    await create_input_booleans(hass, ["test1", "test2"])
+    await set_states(hass, [("input_boolean.test1", STATE_OFF), ("input_boolean.test2", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -548,15 +579,17 @@ async def test_hide_members(hass: HomeAssistant, entity_registry: EntityRegistry
     assert entity_registry.async_get("sensor.two_power").hidden_by == er.RegistryEntryHider.INTEGRATION
 
 
-async def test_unhide_members(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:
-    entity_registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "abcdef",
-        suggested_object_id="test_power",
-        hidden_by=er.RegistryEntryHider.INTEGRATION,
+async def test_unhide_members(hass: HomeAssistant) -> None:
+    entity_registry = mock_entities_in_registry(
+        hass,
+        {
+            "sensor.test_power": {
+                "unique_id": "abcdef",
+                "platform": DOMAIN,
+                "hidden_by": er.RegistryEntryHider.INTEGRATION,
+            },
+        },
     )
-    await hass.async_block_till_done()
     await run_powercalc_setup(
         hass,
         {
@@ -574,15 +607,11 @@ async def test_unhide_members(hass: HomeAssistant, entity_registry: EntityRegist
     assert entity_registry.async_get("sensor.test_power").hidden_by is None
 
 
-async def test_user_hidden_entities_remain_hidden(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:
-    entity_registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "abcdef",
-        suggested_object_id="test_power",
-        hidden_by=er.RegistryEntryHider.USER,
+async def test_user_hidden_entities_remain_hidden(hass: HomeAssistant) -> None:
+    entity_registry = mock_entities_in_registry(
+        hass,
+        {"sensor.test_power": {"unique_id": "abcdef", "platform": DOMAIN, "hidden_by": er.RegistryEntryHider.USER}},
     )
-    await hass.async_block_till_done()
 
     await run_powercalc_setup(
         hass,
@@ -603,20 +632,16 @@ async def test_user_hidden_entities_remain_hidden(hass: HomeAssistant, entity_re
 
 async def test_members_are_unhiden_after_group_removed(
     hass: HomeAssistant,
-    entity_registry: EntityRegistry,
 ) -> None:
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        "abcdef",
-        suggested_object_id="test_power",
+    entity_registry = mock_entities_in_registry(
+        hass,
+        {"sensor.test_power": {"unique_id": "abcdef", "platform": DOMAIN}},
     )
 
-    config_entry = await create_mock_config_entry(
+    config_entry = await create_mock_group_entry(
         hass,
+        "MyGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "MyGroup",
             CONF_GROUP_POWER_ENTITIES: ["sensor.test_power"],
             CONF_HIDE_MEMBERS: True,
         },
@@ -635,21 +660,13 @@ async def test_members_are_unhiden_after_group_removed(
     assert not entity_registry.async_get("sensor.mygroup_power")
 
 
-async def test_group_utility_meter(
-    hass: HomeAssistant,
-    entity_registry: EntityRegistry,
-) -> None:
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        "abcdef",
-        suggested_object_id="testgroup_power",
-    )
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        "abcdef_energy",
-        suggested_object_id="testgroup_energy",
+async def test_group_utility_meter(hass: HomeAssistant) -> None:
+    mock_entities_in_registry(
+        hass,
+        {
+            "sensor.testgroup_power": {"unique_id": "abcdef", "platform": DOMAIN},
+            "sensor.testgroup_energy": {"unique_id": "abcdef_energy", "platform": DOMAIN},
+        },
     )
 
     await run_powercalc_setup(
@@ -683,29 +700,36 @@ async def test_include_config_entries_in_group(hass: HomeAssistant) -> None:
         },
     )
 
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "GroupA",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "GroupA",
             CONF_GROUP_MEMBER_SENSORS: [config_entry.entry_id],
             CONF_GROUP_POWER_ENTITIES: ["sensor.other_power"],
             CONF_IGNORE_UNAVAILABLE_STATE: True,
         },
     )
 
-    group_power_state = hass.states.get("sensor.groupa_power")
-    assert group_power_state
-    assert group_power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.virtualsensor_power",
-        "sensor.other_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupa_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.virtualsensor_power",
+                "sensor.other_power",
+            },
+        },
+    )
 
-    group_energy_state = hass.states.get("sensor.groupa_energy")
-    assert group_energy_state
-    assert group_energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.virtualsensor_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupa_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.virtualsensor_energy",
+            },
+        },
+    )
 
 
 async def test_add_virtual_power_sensor_to_group_on_creation(
@@ -722,11 +746,10 @@ async def test_add_virtual_power_sensor_to_group_on_creation(
         "xyz",
     )
 
-    config_entry_group = await create_mock_config_entry(
+    config_entry_group = await create_mock_group_entry(
         hass,
+        "GroupA",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "GroupA",
             CONF_GROUP_MEMBER_SENSORS: [config_entry_sensor1.entry_id],
         },
     )
@@ -753,12 +776,16 @@ async def test_add_virtual_power_sensor_to_group_on_creation(
         CONF_GROUP_MEMBER_SENSORS,
     )
 
-    group_state = hass.states.get("sensor.groupa_power")
-    assert group_state
-    assert group_state.attributes.get("entities") == {
-        "sensor.virtualsensor1_power",
-        "sensor.virtualsensor2_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupa_power",
+        attributes={
+            "entities": {
+                "sensor.virtualsensor1_power",
+                "sensor.virtualsensor2_power",
+            },
+        },
+    )
 
     # Remove config entry from Home Assistant, and see if group is updated accordingly
     await hass.config_entries.async_remove(config_entry_sensor2.entry_id)
@@ -771,11 +798,15 @@ async def test_add_virtual_power_sensor_to_group_on_creation(
         config_entry_sensor1.entry_id,
     ]
 
-    group_state = hass.states.get("sensor.groupa_power")
-    assert group_state
-    assert group_state.attributes.get("entities") == {
-        "sensor.virtualsensor1_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupa_power",
+        attributes={
+            "entities": {
+                "sensor.virtualsensor1_power",
+            },
+        },
+    )
 
 
 async def test_virtual_power_sensor_is_not_added_twice_to_group_after_reload(
@@ -896,11 +927,10 @@ async def test_config_entry_is_removed_from_associated_groups_on_removal(
     groups: list[str] = ["GroupA", "GroupB", "GroupC"]
     group_entry_ids: list[str] = []
     for group in groups:
-        config_entry_group = await create_mock_config_entry(
+        config_entry_group = await create_mock_group_entry(
             hass,
+            group,
             {
-                CONF_SENSOR_TYPE: SensorType.GROUP,
-                CONF_NAME: group,
                 CONF_GROUP_MEMBER_SENSORS: [config_entry_sensor.entry_id],
             },
         )
@@ -1007,11 +1037,10 @@ async def test_energy_unit_conversions(hass: HomeAssistant) -> None:
 
 
 async def test_power_unit_conversions(hass: HomeAssistant) -> None:
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_POWER_ENTITIES: ["sensor.power_w", "sensor.power_kw"],
             CONF_GROUP_ENERGY_ENTITIES: ["sensor.energy_w", "sensor.energy_kw"],
             CONF_ENERGY_SENSOR_UNIT_PREFIX: UnitPrefix.NONE,
@@ -1033,13 +1062,14 @@ async def test_power_unit_conversions(hass: HomeAssistant) -> None:
             ),
         ],
     )
-    power_state = hass.states.get("sensor.testgroup_power")
-    assert power_state
-    assert power_state.state == "200.00"
-    assert power_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_power",
+        "200.00",
+        attributes={ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT},
+    )
 
-    energy_state = hass.states.get("sensor.testgroup_energy")
-    assert energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.WATT_HOUR
+    assert_entity_state(hass, "sensor.testgroup_energy", attributes={ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.WATT_HOUR})
 
 
 async def test_gui_discovered_entity_in_yaml_group(
@@ -1234,10 +1264,7 @@ async def test_storage(hass: HomeAssistant) -> None:
     store = PreviousStateStore(hass)
     store.async_setup_dump()
     store.set_entity_state("sensor.group1_energy", "sensor.dummy", state)
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(hours=1),
-    )
+    await async_advance_time(hass, timedelta(hours=1), block=False)
 
     await hass.async_block_till_done()
 
@@ -1279,11 +1306,10 @@ async def test_unknown_member_config_entry_is_skipped_from_group(
         },
     )
 
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "group",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "group",
             CONF_GROUP_MEMBER_SENSORS: [member_entry.entry_id, "foobar"],
             CONF_IGNORE_UNAVAILABLE_STATE: True,
         },
@@ -1311,31 +1337,17 @@ async def test_reference_existing_sensor_in_group(hass: HomeAssistant) -> None:
         ],
     )
 
-    group_state = hass.states.get("sensor.testgroup_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.test_power"}
+    assert_entity_state(hass, "sensor.testgroup_power", attributes={ATTR_ENTITIES: {"sensor.test_power"}})
 
 
 async def test_create_group_with_real_power_sensors(hass: HomeAssistant) -> None:
     """See https://github.com/bramstroker/homeassistant-powercalc/issues/1895"""
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_power",
-                unique_id="1234",
-                platform="sensor",
-                device_id="shelly-device-id",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.existing_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_energy",
-                unique_id="12345",
-                platform="sensor",
-                device_id="shelly-device-id",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
+            "sensor.existing_power": {"device_id": "shelly-device-id", "device_class": SensorDeviceClass.POWER},
+            "sensor.existing_energy": {"device_id": "shelly-device-id", "device_class": SensorDeviceClass.ENERGY},
         },
     )
 
@@ -1355,9 +1367,7 @@ async def test_create_group_with_real_power_sensors(hass: HomeAssistant) -> None
         ],
     )
 
-    group_state = hass.states.get("sensor.testgroup_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.existing_power"}
+    assert_entity_state(hass, "sensor.testgroup_power", attributes={ATTR_ENTITIES: {"sensor.existing_power"}})
 
 
 async def test_group_entity_binds_to_configured_device(
@@ -1390,11 +1400,10 @@ async def test_group_entity_binds_to_configured_device(
         },
     )
 
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "MyGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "MyGroup",
             CONF_DEVICE: device_entry.id,
             CONF_GROUP_MEMBER_SENSORS: [member_entry.entry_id],
         },
@@ -1428,11 +1437,10 @@ async def test_bind_to_configured_area_for_group_entities(
         ],
     )
 
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "Living Room Ceiling",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "Living Room Ceiling",
             CONF_AREA: area.id,
             CONF_GROUP_POWER_ENTITIES: ["sensor.member_power"],
             CONF_GROUP_ENERGY_ENTITIES: ["sensor.member_energy"],
@@ -1471,11 +1479,10 @@ async def test_bind_to_configured_area_for_calculated_group_energy_sensor(
         ],
     )
 
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "Bedroom Ceiling",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "Bedroom Ceiling",
             CONF_AREA: area.id,
             CONF_GROUP_POWER_ENTITIES: ["sensor.member_power"],
             CONF_CREATE_UTILITY_METERS: False,
@@ -1506,11 +1513,10 @@ async def test_disable_energy_sensor_creation(hass: HomeAssistant) -> None:
 
 async def test_disable_energy_sensor_creation_gui(hass: HomeAssistant) -> None:
     """See https://github.com/bramstroker/homeassistant-powercalc/issues/2143"""
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_CREATE_ENERGY_SENSOR: False,
             CONF_GROUP_ENERGY_ENTITIES: ["sensor.a_energy", "sensor.b_energy"],
         },
@@ -1541,21 +1547,11 @@ async def test_inital_group_sum_calculated(hass: HomeAssistant) -> None:
 
 
 async def test_additional_energy_sensors(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.furnace_power": RegistryEntryWithDefaults(
-                entity_id="sensor.furnace_power",
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.furnace_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.furnace_energy",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
+            "sensor.furnace_power": {"device_class": SensorDeviceClass.POWER},
+            "sensor.furnace_energy": {"device_class": SensorDeviceClass.ENERGY},
         },
     )
 
@@ -1584,11 +1580,17 @@ async def test_additional_energy_sensors(hass: HomeAssistant) -> None:
         },
     )
 
-    power_state = hass.states.get("sensor.testgroup_power")
-    assert power_state.attributes.get(ATTR_ENTITIES) == {"sensor.ceiling_fan_power", "sensor.furnace_power"}
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_power",
+        attributes={ATTR_ENTITIES: {"sensor.ceiling_fan_power", "sensor.furnace_power"}},
+    )
 
-    energy_state = hass.states.get("sensor.testgroup_energy")
-    assert energy_state.attributes.get(ATTR_ENTITIES) == {"sensor.ceiling_fan_energy", "sensor.furnace_energy"}
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_energy",
+        attributes={ATTR_ENTITIES: {"sensor.ceiling_fan_energy", "sensor.furnace_energy"}},
+    )
 
 
 async def test_force_calculate_energy_sensor(hass: HomeAssistant) -> None:
@@ -1597,21 +1599,11 @@ async def test_force_calculate_energy_sensor(hass: HomeAssistant) -> None:
     the energy sensor should be a Riemann sensor integrating the power sensor
     """
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.furnace_power": RegistryEntryWithDefaults(
-                entity_id="sensor.furnace_power",
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.lights_power": RegistryEntryWithDefaults(
-                entity_id="sensor.lights_power",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
+            "sensor.furnace_power": {"device_class": SensorDeviceClass.POWER},
+            "sensor.lights_power": {"device_class": SensorDeviceClass.POWER},
         },
     )
 
@@ -1640,10 +1632,14 @@ async def test_force_calculate_energy_sensor(hass: HomeAssistant) -> None:
         },
     )
 
-    energy_state = hass.states.get("sensor.testgroup_energy")
-    assert energy_state
-    assert energy_state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_energy",
+        attributes={
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        },
+    )
 
 
 async def test_decimal_conversion_error_is_logged(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
@@ -1683,11 +1679,10 @@ async def test_force_calculate_energy(hass: HomeAssistant) -> None:
         },
     )
 
-    group_entry = await create_mock_config_entry(
+    group_entry = await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_MEMBER_SENSORS: [member_entry.entry_id],
             CONF_FORCE_CALCULATE_GROUP_ENERGY: True,
         },
@@ -1777,11 +1772,10 @@ async def test_debug_group_action_for_power_group(hass: HomeAssistant) -> None:
             ("sensor.b_power", "0.1", {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT}),
         ],
     )
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_POWER_ENTITIES: ["sensor.a_power", "sensor.b_power"],
             CONF_IGNORE_UNAVAILABLE_STATE: True,
         },
@@ -1822,11 +1816,10 @@ async def test_debug_group_action_for_power_group_with_unavailable_member(hass: 
             ("sensor.b_power", STATE_UNAVAILABLE, {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT}),
         ],
     )
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_POWER_ENTITIES: ["sensor.a_power", "sensor.b_power"],
             CONF_IGNORE_UNAVAILABLE_STATE: True,
         },
@@ -1861,11 +1854,10 @@ async def test_debug_group_action_for_power_group_with_unavailable_member(hass: 
 
 async def test_debug_group_action_for_power_group_with_missing_member_state(hass: HomeAssistant) -> None:
     await set_states(hass, [("sensor.a_power", "50", {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT})])
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_POWER_ENTITIES: ["sensor.a_power", "sensor.b_power"],
             CONF_IGNORE_UNAVAILABLE_STATE: True,
         },
@@ -1906,11 +1898,10 @@ async def test_debug_group_action_for_energy_group(hass: HomeAssistant) -> None:
             ("sensor.b_energy", "500", {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.WATT_HOUR}),
         ],
     )
-    await create_mock_config_entry(
+    await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_ENERGY_ENTITIES: ["sensor.a_energy", "sensor.b_energy"],
             CONF_GROUP_ENERGY_START_AT_ZERO: False,
             CONF_IGNORE_UNAVAILABLE_STATE: True,
@@ -2130,23 +2121,21 @@ async def test_power_throttle(
 async def test_resolve_entity_ids_area(hass: HomeAssistant, area_registry: AreaRegistry) -> None:
     area = area_registry.async_get_or_create("Bedroom")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_power": RegistryEntryWithDefaults(
-                entity_id="sensor.test_power",
-                unique_id=1111,
-                platform="powercalc",
-                device_class=SensorDeviceClass.POWER,
-                area_id=area.id,
-            ),
-            "sensor.test_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.test_energy",
-                unique_id=2222,
-                platform="powercalc",
-                device_class=SensorDeviceClass.ENERGY,
-                area_id=area.id,
-            ),
+            "sensor.test_power": {
+                "unique_id": 1111,
+                "platform": "powercalc",
+                "device_class": SensorDeviceClass.POWER,
+                "area_id": area.id,
+            },
+            "sensor.test_energy": {
+                "unique_id": 2222,
+                "platform": "powercalc",
+                "device_class": SensorDeviceClass.ENERGY,
+                "area_id": area.id,
+            },
         },
     )
 
@@ -2195,17 +2184,16 @@ async def test_resolve_entity_ids_area_excludes_persisted_powercalc_derived_enti
         setup=False,
     )
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            entity_id: RegistryEntryWithDefaults(
-                entity_id=entity_id,
-                unique_id=entity_id,
-                platform=DOMAIN,
-                config_entry_id=config_entry_id,
-                device_class=device_class,
-                area_id=area.id,
-            )
+            entity_id: {
+                "unique_id": entity_id,
+                "platform": DOMAIN,
+                "config_entry_id": config_entry_id,
+                "device_class": device_class,
+                "area_id": area.id,
+            }
             for entity_id, config_entry_id, device_class in (
                 ("sensor.bedside_lamp_power", sensor_entry.entry_id, SensorDeviceClass.POWER),
                 ("sensor.bedside_lamp_energy", sensor_entry.entry_id, SensorDeviceClass.ENERGY),
@@ -2225,23 +2213,21 @@ async def test_resolve_entity_ids_area_excludes_persisted_powercalc_derived_enti
 
 
 async def test_resolve_entity_ids_skips_tasmota_yesterday_and_today(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_total": RegistryEntryWithDefaults(
-                entity_id="sensor.test_total",
-                unique_id=1111,
-                platform="tasmota",
-                device_class=SensorDeviceClass.ENERGY,
-                device_id="device_1",
-            ),
-            "sensor.test_yesterday": RegistryEntryWithDefaults(
-                entity_id="sensor.test_yesterday",
-                unique_id=2222,
-                platform="tasmota",
-                device_class=SensorDeviceClass.ENERGY,
-                device_id="device_1",
-            ),
+            "sensor.test_total": {
+                "unique_id": 1111,
+                "platform": "tasmota",
+                "device_class": SensorDeviceClass.ENERGY,
+                "device_id": "device_1",
+            },
+            "sensor.test_yesterday": {
+                "unique_id": 2222,
+                "platform": "tasmota",
+                "device_class": SensorDeviceClass.ENERGY,
+                "device_id": "device_1",
+            },
         },
     )
 
@@ -2280,11 +2266,10 @@ async def test_remove_member_from_group(hass: HomeAssistant) -> None:
         member_config_entries.append(config_entry)
         member_entity_ids.append(f"sensor.virtualsensor{i}_energy")
 
-    group_entry = await create_mock_config_entry(
+    group_entry = await create_mock_group_entry(
         hass,
+        "TestGroup",
         {
-            CONF_SENSOR_TYPE: SensorType.GROUP,
-            CONF_NAME: "TestGroup",
             CONF_GROUP_MEMBER_SENSORS: [entry.entry_id for entry in member_config_entries],
         },
     )
@@ -2294,9 +2279,7 @@ async def test_remove_member_from_group(hass: HomeAssistant) -> None:
         await set_states(hass, [(f"sensor.virtualsensor{i}_power", "60.00")], block_count=2)
 
     # Assert the group sensor has the correct 3 member sensors added
-    group_state = hass.states.get("sensor.testgroup_energy")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == set(member_entity_ids)
+    assert_entity_state(hass, "sensor.testgroup_energy", attributes={CONF_ENTITIES: set(member_entity_ids)})
 
     assert state_storage.get_entity_state("sensor.testgroup_energy", member_entity_ids[0])
     assert state_storage.get_entity_state("sensor.testgroup_energy", member_entity_ids[1])
@@ -2314,9 +2297,7 @@ async def test_remove_member_from_group(hass: HomeAssistant) -> None:
     )
 
     # Assert the group sensor has the correct 2 member sensors added, and the removed sensor is not there anymore
-    group_state = hass.states.get("sensor.testgroup_energy")
-    assert group_state
-    assert group_state.attributes.get(CONF_ENTITIES) == set(member_entity_ids)
+    assert_entity_state(hass, "sensor.testgroup_energy", attributes={CONF_ENTITIES: set(member_entity_ids)})
 
     assert state_storage.get_entity_state("sensor.testgroup_energy", member_entity_ids[0])
     assert not state_storage.get_entity_state("sensor.testgroup_energy", "sensor.virtualsensor1_energy")

--- a/tests/sensors/group/test_domain.py
+++ b/tests/sensors/group/test_domain.py
@@ -6,10 +6,6 @@ from homeassistant.const import (
     CONF_NAME,
 )
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    mock_registry,
-)
 
 from custom_components.powercalc.const import (
     ATTR_ENTITIES,
@@ -21,50 +17,22 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from tests.common import (
+    assert_entity_state,
     create_mock_config_entry,
+    mock_entities_in_registry,
 )
 
 
 async def test_domain_group_all(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.a_power": RegistryEntryWithDefaults(
-                entity_id="sensor.a_power",
-                unique_id="1111",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.b_power": RegistryEntryWithDefaults(
-                entity_id="sensor.b_power",
-                unique_id="2222",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.c_power": RegistryEntryWithDefaults(
-                entity_id="sensor.c_power",
-                unique_id="3333",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.d_power": RegistryEntryWithDefaults(
-                entity_id="sensor.c_power",
-                unique_id="4444",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.a_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.a_energy",
-                unique_id="5555",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
-            "sensor.b_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.b_energy",
-                unique_id="6666",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
+            "sensor.a_power": {"device_class": SensorDeviceClass.POWER},
+            "sensor.b_power": {"device_class": SensorDeviceClass.POWER},
+            "sensor.c_power": {"device_class": SensorDeviceClass.POWER},
+            "sensor.d_power": {"device_class": SensorDeviceClass.POWER},
+            "sensor.a_energy": {"device_class": SensorDeviceClass.ENERGY},
+            "sensor.b_energy": {"device_class": SensorDeviceClass.ENERGY},
         },
     )
 
@@ -80,17 +48,25 @@ async def test_domain_group_all(hass: HomeAssistant) -> None:
         },
     )
 
-    group_power_state = hass.states.get("sensor.groupall_power")
-    assert group_power_state
-    assert group_power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.a_power",
-        "sensor.b_power",
-        "sensor.c_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupall_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.a_power",
+                "sensor.b_power",
+                "sensor.c_power",
+            },
+        },
+    )
 
-    group_energy_state = hass.states.get("sensor.groupall_energy")
-    assert group_energy_state
-    assert group_energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.a_energy",
-        "sensor.b_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.groupall_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.a_energy",
+                "sensor.b_energy",
+            },
+        },
+    )

--- a/tests/sensors/group/test_subtract.py
+++ b/tests/sensors/group/test_subtract.py
@@ -139,10 +139,6 @@ async def test_friendly_naming(hass: HomeAssistant) -> None:
         },
     )
 
-    power_state = hass.states.get("sensor.test_powercalc_power")
-    assert power_state
-    assert power_state.attributes["friendly_name"] == "test Powercalc Power"
+    assert_entity_state(hass, "sensor.test_powercalc_power", attributes={"friendly_name": "test Powercalc Power"})
 
-    energy_state = hass.states.get("sensor.test_powercalc_energy")
-    assert energy_state
-    assert energy_state.attributes["friendly_name"] == "test Powercalc Energy"
+    assert_entity_state(hass, "sensor.test_powercalc_energy", attributes={"friendly_name": "test Powercalc Energy"})

--- a/tests/sensors/test_cost.py
+++ b/tests/sensors/test_cost.py
@@ -19,8 +19,6 @@ from homeassistant.util import dt as dt_util
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
-    RegistryEntryWithDefaults,
-    mock_registry,
     mock_restore_cache,
 )
 
@@ -57,7 +55,9 @@ from custom_components.powercalc.const import (
 from custom_components.powercalc.sensors.cost import CostSensor
 from custom_components.powercalc.sensors.group.tracked_untracked import TrackedPowerSensorFactory
 from tests.common import (
+    assert_entity_state,
     get_simple_fixed_config,
+    mock_entities_in_registry,
     mock_sensors_in_registry,
     run_powercalc_setup,
     set_states,
@@ -78,25 +78,26 @@ def _assert_cost(hass: HomeAssistant, expected: float, entity_id: str = "sensor.
     assert float(state.state) == pytest.approx(expected)
 
 
+def _cost_sensor_config(overrides: dict | None = None) -> dict:
+    """The virtual power config every cost sensor test builds on."""
+    return {
+        CONF_NAME: "Test",
+        CONF_ENTITY_ID: "sensor.dummy",
+        CONF_MODE: CalculationStrategy.FIXED,
+        CONF_FIXED: {CONF_POWER: 50},
+        CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
+        CONF_IGNORE_UNAVAILABLE_STATE: True,
+        **(overrides or {}),
+    }
+
+
 async def _setup_cost_sensor(
     hass: HomeAssistant,
     sensor_config: dict,
     domain_config: dict,
 ) -> None:
     mock_sensors_in_registry(hass, energy_entities=["sensor.existing_energy"])
-    await run_powercalc_setup(
-        hass,
-        {
-            CONF_NAME: "Test",
-            CONF_ENTITY_ID: "sensor.dummy",
-            CONF_MODE: CalculationStrategy.FIXED,
-            CONF_FIXED: {CONF_POWER: 50},
-            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
-            CONF_IGNORE_UNAVAILABLE_STATE: True,
-            **sensor_config,
-        },
-        domain_config,
-    )
+    await run_powercalc_setup(hass, _cost_sensor_config(sensor_config), domain_config)
 
 
 async def test_cost_sensor_fixed_price(hass: HomeAssistant) -> None:
@@ -107,11 +108,15 @@ async def test_cost_sensor_fixed_price(hass: HomeAssistant) -> None:
         {CONF_ENERGY_PRICE: 0.25},
     )
 
-    cost_state = hass.states.get("sensor.test_cost")
-    assert cost_state
-    assert cost_state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.MONETARY
-    assert cost_state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
-    assert cost_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
+    assert_entity_state(
+        hass,
+        "sensor.test_cost",
+        attributes={
+            ATTR_DEVICE_CLASS: SensorDeviceClass.MONETARY,
+            ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+            ATTR_UNIT_OF_MEASUREMENT: "EUR",
+        },
+    )
 
     await set_states(hass, [("sensor.existing_energy", "10", _KWH)])  # baseline
     _assert_cost(hass, 0)
@@ -296,9 +301,7 @@ async def test_cost_sensor_unit_derived_from_price_sensor(
         {CONF_ENERGY_PRICE_SENSOR: "sensor.energy_price"},
     )
 
-    cost_state = hass.states.get("sensor.test_cost")
-    assert cost_state
-    assert cost_state.attributes[ATTR_UNIT_OF_MEASUREMENT] == expected_unit
+    assert_entity_state(hass, "sensor.test_cost", attributes={ATTR_UNIT_OF_MEASUREMENT: expected_unit})
 
 
 @pytest.mark.parametrize(
@@ -384,15 +387,7 @@ async def test_price_change_settles_pending_energy_at_previous_price(hass: HomeA
 
     await run_powercalc_setup(
         hass,
-        {
-            CONF_NAME: "Test",
-            CONF_ENTITY_ID: "sensor.dummy",
-            CONF_MODE: CalculationStrategy.FIXED,
-            CONF_FIXED: {CONF_POWER: 50},
-            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
-            CONF_CREATE_COST_SENSOR: True,
-            CONF_IGNORE_UNAVAILABLE_STATE: True,
-        },
+        _cost_sensor_config({CONF_CREATE_COST_SENSOR: True}),
         {CONF_ENERGY_PRICE_SENSOR: "sensor.energy_price"},
     )
     _assert_cost(hass, 0)
@@ -414,15 +409,7 @@ async def test_price_change_ignored_when_energy_unavailable(hass: HomeAssistant)
 
     await run_powercalc_setup(
         hass,
-        {
-            CONF_NAME: "Test",
-            CONF_ENTITY_ID: "sensor.dummy",
-            CONF_MODE: CalculationStrategy.FIXED,
-            CONF_FIXED: {CONF_POWER: 50},
-            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
-            CONF_CREATE_COST_SENSOR: True,
-            CONF_IGNORE_UNAVAILABLE_STATE: True,
-        },
+        _cost_sensor_config({CONF_CREATE_COST_SENSOR: True}),
         {CONF_ENERGY_PRICE_SENSOR: "sensor.energy_price"},
     )
 
@@ -430,9 +417,13 @@ async def test_price_change_ignored_when_energy_unavailable(hass: HomeAssistant)
     _assert_cost(hass, 0)
 
 
-async def test_price_sensor_unavailable_defers_cost(hass: HomeAssistant) -> None:
-    """When the price sensor is unavailable the consumption is priced once it returns."""
-    await set_states(hass, [("sensor.energy_price", "unavailable")])
+@pytest.mark.parametrize(
+    "initial_price",
+    [pytest.param("unavailable", id="unavailable"), pytest.param("invalid", id="non-numeric")],
+)
+async def test_unusable_price_sensor_defers_cost(hass: HomeAssistant, initial_price: str) -> None:
+    """Consumption is priced once the price sensor reports a usable value."""
+    await set_states(hass, [("sensor.energy_price", initial_price)])
     await _setup_cost_sensor(
         hass,
         {CONF_CREATE_COST_SENSOR: True},
@@ -440,7 +431,7 @@ async def test_price_sensor_unavailable_defers_cost(hass: HomeAssistant) -> None
     )
 
     await set_states(hass, [("sensor.existing_energy", "0", _KWH)])  # baseline
-    await set_states(hass, [("sensor.existing_energy", "10", _KWH)])  # price unavailable -> deferred
+    await set_states(hass, [("sensor.existing_energy", "10", _KWH)])  # no usable price -> deferred
     _assert_cost(hass, 0)
 
     await set_states(hass, [("sensor.energy_price", "0.30")])
@@ -480,9 +471,7 @@ async def test_yaml_standalone_cost_sensor(hass: HomeAssistant) -> None:
         {CONF_ENERGY_PRICE: 0.25},
     )
 
-    cost_state = hass.states.get("sensor.fridge_cost")
-    assert cost_state
-    assert cost_state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.MONETARY
+    assert_entity_state(hass, "sensor.fridge_cost", attributes={ATTR_DEVICE_CLASS: SensorDeviceClass.MONETARY})
 
     await set_states(hass, [("sensor.existing_energy", "10", _KWH)])  # baseline
     await set_states(hass, [("sensor.existing_energy", "20", _KWH)])  # +10 kWh * 0.25
@@ -491,15 +480,10 @@ async def test_yaml_standalone_cost_sensor(hass: HomeAssistant) -> None:
 
 async def test_yaml_standalone_cost_sensor_name_derived_from_energy_sensor(hass: HomeAssistant) -> None:
     """When no name is given the cost sensor name is derived from the tracked energy sensor."""
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_energy",
-                name="Fridge energy",
-                unique_id="1234",
-                platform="sensor",
-            ),
+            "sensor.existing_energy": {"name": "Fridge energy"},
         },
     )
     await run_powercalc_setup(
@@ -521,9 +505,7 @@ async def test_cost_sensor_naming_pattern(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("sensor.test_cost") is None
-    state = hass.states.get("sensor.test_energy_costs")
-    assert state
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "Test energy costs"
+    assert_entity_state(hass, "sensor.test_energy_costs", attributes={ATTR_FRIENDLY_NAME: "Test energy costs"})
 
 
 async def test_cost_sensor_friendly_naming_pattern(hass: HomeAssistant) -> None:
@@ -535,9 +517,7 @@ async def test_cost_sensor_friendly_naming_pattern(hass: HomeAssistant) -> None:
     )
 
     # Entity id keeps the default naming, only the friendly name follows the pattern.
-    state = hass.states.get("sensor.test_cost")
-    assert state
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "Costs of Test"
+    assert_entity_state(hass, "sensor.test_cost", attributes={ATTR_FRIENDLY_NAME: "Costs of Test"})
 
 
 async def test_cost_sensor_created_per_utility_meter(hass: HomeAssistant) -> None:
@@ -559,11 +539,15 @@ async def test_cost_sensor_created_per_utility_meter(hass: HomeAssistant) -> Non
     assert hass.states.get("sensor.test_cost") is not None
 
     # Cost sensor for the daily utility meter.
-    meter_cost = hass.states.get("sensor.test_energy_daily_cost")
-    assert meter_cost
-    assert meter_cost.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.MONETARY
-    assert meter_cost.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL
-    assert meter_cost.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
+    assert_entity_state(
+        hass,
+        "sensor.test_energy_daily_cost",
+        attributes={
+            ATTR_DEVICE_CLASS: SensorDeviceClass.MONETARY,
+            ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+            ATTR_UNIT_OF_MEASUREMENT: "EUR",
+        },
+    )
 
 
 async def test_no_utility_meter_cost_sensor_when_meters_disabled(hass: HomeAssistant) -> None:
@@ -589,17 +573,13 @@ async def test_utility_meter_cost_sensor_accumulates(hass: HomeAssistant) -> Non
     mock_sensors_in_registry(hass, energy_entities=["sensor.existing_energy"])
     await run_powercalc_setup(
         hass,
-        {
-            CONF_NAME: "Test",
-            CONF_ENTITY_ID: "sensor.dummy",
-            CONF_MODE: CalculationStrategy.FIXED,
-            CONF_FIXED: {CONF_POWER: 50},
-            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
-            CONF_IGNORE_UNAVAILABLE_STATE: True,
-            CONF_CREATE_COST_SENSOR: True,
-            CONF_CREATE_UTILITY_METERS: True,
-            CONF_UTILITY_METER_TYPES: [DAILY],
-        },
+        _cost_sensor_config(
+            {
+                CONF_CREATE_COST_SENSOR: True,
+                CONF_CREATE_UTILITY_METERS: True,
+                CONF_UTILITY_METER_TYPES: [DAILY],
+            },
+        ),
         {CONF_ENERGY_PRICE: 0.25},
     )
 
@@ -629,17 +609,13 @@ async def test_utility_meter_cost_sensor_exposes_last_reset(hass: HomeAssistant)
     mock_sensors_in_registry(hass, energy_entities=["sensor.existing_energy"])
     await run_powercalc_setup(
         hass,
-        {
-            CONF_NAME: "Test",
-            CONF_ENTITY_ID: "sensor.dummy",
-            CONF_MODE: CalculationStrategy.FIXED,
-            CONF_FIXED: {CONF_POWER: 50},
-            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
-            CONF_IGNORE_UNAVAILABLE_STATE: True,
-            CONF_CREATE_COST_SENSOR: True,
-            CONF_CREATE_UTILITY_METERS: True,
-            CONF_UTILITY_METER_TYPES: [DAILY],
-        },
+        _cost_sensor_config(
+            {
+                CONF_CREATE_COST_SENSOR: True,
+                CONF_CREATE_UTILITY_METERS: True,
+                CONF_UTILITY_METER_TYPES: [DAILY],
+            },
+        ),
         {CONF_ENERGY_PRICE: 0.25},
     )
 
@@ -685,23 +661,17 @@ async def test_utility_meter_cost_sensor_restores_last_reset(hass: HomeAssistant
     )
     await run_powercalc_setup(
         hass,
-        {
-            CONF_NAME: "Test",
-            CONF_ENTITY_ID: "sensor.dummy",
-            CONF_MODE: CalculationStrategy.FIXED,
-            CONF_FIXED: {CONF_POWER: 50},
-            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
-            CONF_IGNORE_UNAVAILABLE_STATE: True,
-            CONF_CREATE_COST_SENSOR: True,
-            CONF_CREATE_UTILITY_METERS: True,
-            CONF_UTILITY_METER_TYPES: [DAILY],
-        },
+        _cost_sensor_config(
+            {
+                CONF_CREATE_COST_SENSOR: True,
+                CONF_CREATE_UTILITY_METERS: True,
+                CONF_UTILITY_METER_TYPES: [DAILY],
+            },
+        ),
         {CONF_ENERGY_PRICE: 0.25},
     )
 
-    cost_state = hass.states.get("sensor.sensor_existing_energy_daily_cost")
-    assert cost_state
-    assert cost_state.attributes[ATTR_LAST_RESET] == restored_reset
+    assert_entity_state(hass, "sensor.sensor_existing_energy_daily_cost", attributes={ATTR_LAST_RESET: restored_reset})
 
 
 async def test_restore_state(hass: HomeAssistant) -> None:
@@ -791,9 +761,7 @@ async def test_calibrate_cost_service(hass: HomeAssistant) -> None:
     )
 
     _assert_cost(hass, 7)
-    cost_state = hass.states.get("sensor.test_cost")
-    assert cost_state
-    assert cost_state.attributes["last_energy"] == "10"
+    assert_entity_state(hass, "sensor.test_cost", attributes={"last_energy": "10"})
 
     await set_states(hass, [("sensor.existing_energy", "12", _KWH)])
     _assert_cost(hass, 7.5)
@@ -815,24 +783,6 @@ async def test_cost_sensor_ignores_invalid_energy_states(hass: HomeAssistant) ->
 
     await set_states(hass, [("sensor.existing_energy", "15", _KWH)])  # +5 kWh * 0.25
     _assert_cost(hass, 1.25)
-
-
-async def test_price_sensor_invalid_value_defers_cost(hass: HomeAssistant) -> None:
-    """A non-numeric price sensor value defers the cost until a valid price is available."""
-    await set_states(hass, [("sensor.energy_price", "invalid")])
-    await _setup_cost_sensor(
-        hass,
-        {CONF_CREATE_COST_SENSOR: True},
-        {CONF_ENERGY_PRICE_SENSOR: "sensor.energy_price"},
-    )
-
-    await set_states(hass, [("sensor.existing_energy", "0", _KWH)])  # baseline
-    await set_states(hass, [("sensor.existing_energy", "10", _KWH)])  # invalid price -> deferred
-    _assert_cost(hass, 0)
-
-    await set_states(hass, [("sensor.energy_price", "0.30")])
-    await set_states(hass, [("sensor.existing_energy", "12", _KWH)])  # +12 kWh * 0.30
-    _assert_cost(hass, 3.6)
 
 
 async def test_restore_invalid_state(hass: HomeAssistant) -> None:
@@ -888,33 +838,16 @@ async def test_cost_sensor_name_derived_from_source(hass: HomeAssistant) -> None
 
 async def test_cost_sensor_reuses_existing_entity_id(hass: HomeAssistant) -> None:
     """An already registered cost sensor entity id is reused."""
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_energy",
-                unique_id="sensor.existing_energy",
-                platform="sensor",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
-            "sensor.preexisting_cost": RegistryEntryWithDefaults(
-                entity_id="sensor.preexisting_cost",
-                unique_id="sensor.existing_energy_cost",
-                platform=DOMAIN,
-            ),
+            "sensor.existing_energy": {"unique_id": "sensor.existing_energy", "device_class": SensorDeviceClass.ENERGY},
+            "sensor.preexisting_cost": {"unique_id": "sensor.existing_energy_cost", "platform": DOMAIN},
         },
     )
     await run_powercalc_setup(
         hass,
-        {
-            CONF_NAME: "Test",
-            CONF_ENTITY_ID: "sensor.dummy",
-            CONF_MODE: CalculationStrategy.FIXED,
-            CONF_FIXED: {CONF_POWER: 50},
-            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
-            CONF_CREATE_COST_SENSOR: True,
-            CONF_IGNORE_UNAVAILABLE_STATE: True,
-        },
+        _cost_sensor_config({CONF_CREATE_COST_SENSOR: True}),
         {CONF_ENERGY_PRICE: 0.25},
     )
     assert hass.states.get("sensor.preexisting_cost") is not None

--- a/tests/sensors/test_daily_energy.py
+++ b/tests/sensors/test_daily_energy.py
@@ -16,10 +16,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt
 import pytest
 from pytest_homeassistant_custom_component.common import (
-    async_fire_time_changed,
     mock_restore_cache,
 )
 
@@ -47,7 +45,7 @@ from custom_components.powercalc.sensors.daily_energy import (
 )
 from tests.common import (
     assert_entity_state,
-    create_input_boolean,
+    async_advance_time,
     create_mock_config_entry,
     run_powercalc_setup,
     set_states,
@@ -108,11 +106,15 @@ async def test_daily_energy_sensor_from_kwh_value(hass: HomeAssistant) -> None:
     )
 
     sensor_entity_id = "sensor.ip_camera_upstairs_energy"
-    state = hass.states.get(sensor_entity_id)
-    assert state
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
+    assert_entity_state(
+        hass,
+        sensor_entity_id,
+        attributes={
+            ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        },
+    )
 
     await _trigger_periodic_update(hass)
     assert_entity_state(hass, sensor_entity_id, "0.2500")
@@ -163,10 +165,14 @@ async def test_daily_energy_sensor_also_creates_power_sensor(
         },
     )
 
-    state = hass.states.get("sensor.ip_camera_upstairs_energy")
-    assert state
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
+    assert_entity_state(
+        hass,
+        "sensor.ip_camera_upstairs_energy",
+        attributes={
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+        },
+    )
 
     power_state = hass.states.get("sensor.ip_camera_upstairs_power")
     assert power_state
@@ -301,7 +307,7 @@ async def test_template_value(hass: HomeAssistant) -> None:
     )
 
     # Trigger calculation in the future
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=43200))
+    await async_advance_time(hass, 43200, block=False)
 
     assert_entity_state(hass, "sensor.router_energy", "0.0250")
 
@@ -439,16 +445,16 @@ async def test_calibrate_service(hass: HomeAssistant) -> None:
     assert_entity_state(hass, entity_id, "100.0000")
 
 
-async def test_restore_state(hass: HomeAssistant) -> None:
-    mock_restore_cache(
-        hass,
-        [
-            State(
-                "sensor.my_daily_energy",
-                "0.5",
-            ),
-        ],
-    )
+@pytest.mark.parametrize(
+    ("restored_state", "expected_state"),
+    [
+        pytest.param("0.5", "0.5000", id="numeric"),
+        # A state that cannot be converted to a decimal must fall back to zero rather than raise.
+        pytest.param("unknown", "0.0000", id="not a number"),
+    ],
+)
+async def test_restore_state(hass: HomeAssistant, restored_state: str, expected_state: str) -> None:
+    mock_restore_cache(hass, [State("sensor.my_daily_energy", restored_state)])
 
     await run_powercalc_setup(
         hass,
@@ -460,33 +466,7 @@ async def test_restore_state(hass: HomeAssistant) -> None:
         },
     )
 
-    assert_entity_state(hass, "sensor.my_daily_energy", "0.5000")
-
-
-async def test_restore_state_catches_decimal_conversion_exception(
-    hass: HomeAssistant,
-) -> None:
-    mock_restore_cache(
-        hass,
-        [
-            State(
-                "sensor.my_daily_energy",
-                "unknown",
-            ),
-        ],
-    )
-
-    await run_powercalc_setup(
-        hass,
-        {
-            CONF_NAME: "My daily",
-            CONF_DAILY_FIXED_ENERGY: {
-                CONF_VALUE: 1.5,
-            },
-        },
-    )
-
-    assert_entity_state(hass, "sensor.my_daily_energy", "0.0000")
+    assert_entity_state(hass, "sensor.my_daily_energy", expected_state)
 
 
 async def test_small_update_frequency_updates_correctly(hass: HomeAssistant) -> None:
@@ -511,7 +491,6 @@ async def test_small_update_frequency_updates_correctly(hass: HomeAssistant) -> 
 async def test_name_and_entity_id_can_be_inherited_from_source_entity(
     hass: HomeAssistant,
 ) -> None:
-    await create_input_boolean(hass, "test")
     await run_powercalc_setup(
         hass,
         {
@@ -591,8 +570,4 @@ async def _trigger_periodic_update(
     number_of_updates: int = 1,
 ) -> None:
     for _i in range(number_of_updates):
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(seconds=DEFAULT_DAILY_UPDATE_FREQUENCY),
-        )
-        await hass.async_block_till_done()
+        await async_advance_time(hass, DEFAULT_DAILY_UPDATE_FREQUENCY)

--- a/tests/sensors/test_energy.py
+++ b/tests/sensors/test_energy.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_UNIQUE_ID,
+    STATE_OFF,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     EntityCategory,
@@ -20,14 +21,9 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt
 import pytest
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    async_fire_time_changed,
-    mock_registry,
-)
 
 from custom_components.powercalc import CONF_ENERGY_UPDATE_INTERVAL
 from custom_components.powercalc.const import (
@@ -53,37 +49,24 @@ from custom_components.powercalc.const import (
 from custom_components.powercalc.sensors.energy import VirtualEnergySensor
 from tests.common import (
     assert_entity_state,
-    create_input_boolean,
+    async_advance_time,
     get_simple_fixed_config,
     mock_device,
+    mock_entities_in_registry,
     mock_sensors_in_registry,
     run_powercalc_setup,
     set_states,
 )
 
 
-async def test_related_energy_sensor_is_used_for_existing_power_sensor(
-    hass: HomeAssistant,
-) -> None:
+async def test_related_energy_sensor_is_used_for_existing_power_sensor(hass: HomeAssistant) -> None:
     mock_device(hass, "shelly-device-id", "Shelly", "Plug S")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_power",
-                unique_id="1234",
-                platform="sensor",
-                device_id="shelly-device-id",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.existing_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_energy",
-                unique_id="12345",
-                platform="sensor",
-                device_id="shelly-device-id",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
+            "sensor.existing_power": {"device_id": "shelly-device-id", "device_class": SensorDeviceClass.POWER},
+            "sensor.existing_energy": {"device_id": "shelly-device-id", "device_class": SensorDeviceClass.ENERGY},
         },
     )
 
@@ -101,17 +84,25 @@ async def test_related_energy_sensor_is_used_for_existing_power_sensor(
         },
     )
 
-    power_state = hass.states.get("sensor.testgroup_power")
-    assert power_state
-    assert power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.existing_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.existing_power",
+            },
+        },
+    )
 
-    energy_state = hass.states.get("sensor.testgroup_energy")
-    assert energy_state
-    assert energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.existing_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.existing_energy",
+            },
+        },
+    )
 
 
 async def test_force_create_energy_sensor_for_existing_power_sensor(
@@ -121,27 +112,14 @@ async def test_force_create_energy_sensor_for_existing_power_sensor(
     When the user uses `power_sensor_id` option and a related energy sensor already exists in the system,
     creation can be forced with `force_energy_sensor_creation`
     """
-    await create_input_boolean(hass)
 
     mock_device(hass, "shelly-device-id", "Shelly", "Plug S")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_power",
-                unique_id="1234",
-                platform="sensor",
-                device_id="shelly-device-id",
-                device_class=SensorDeviceClass.POWER,
-            ),
-            "sensor.existing_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_energy",
-                unique_id="12345",
-                platform="sensor",
-                device_id="shelly-device-id",
-                device_class=SensorDeviceClass.ENERGY,
-            ),
+            "sensor.existing_power": {"device_id": "shelly-device-id", "device_class": SensorDeviceClass.POWER},
+            "sensor.existing_energy": {"device_id": "shelly-device-id", "device_class": SensorDeviceClass.ENERGY},
         },
     )
 
@@ -160,17 +138,25 @@ async def test_force_create_energy_sensor_for_existing_power_sensor(
         },
     )
 
-    power_state = hass.states.get("sensor.testgroup_power")
-    assert power_state
-    assert power_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.existing_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.existing_power",
+            },
+        },
+    )
 
-    energy_state = hass.states.get("sensor.testgroup_energy")
-    assert energy_state
-    assert energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.mysensor_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.mysensor_energy",
+            },
+        },
+    )
 
 
 async def test_force_create_energy_sensor_overrides_create_energy_sensors_option(hass: HomeAssistant) -> None:
@@ -178,15 +164,10 @@ async def test_force_create_energy_sensor_overrides_create_energy_sensors_option
     When you use force_energy_sensor_creation, it should override create_energy_sensors option,
     and create an energy sensor
     """
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.bedroom_airco_power",
-                unique_id="1234",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
+            "sensor.bedroom_airco_power": {"device_class": SensorDeviceClass.POWER},
         },
     )
 
@@ -208,7 +189,6 @@ async def test_force_create_energy_sensor_overrides_create_energy_sensors_option
 
 
 async def test_disable_extended_attributes(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
 
     await run_powercalc_setup(
         hass,
@@ -221,8 +201,10 @@ async def test_disable_extended_attributes(hass: HomeAssistant) -> None:
     assert ATTR_SOURCE_ENTITY not in energy_state.attributes
 
 
-async def test_rounding_precision(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:
-    await create_input_boolean(hass)
+async def test_rounding_precision(hass: HomeAssistant) -> None:
+    # The source entity needs a unique id, otherwise the energy sensor is not registered.
+    entity_registry = mock_entities_in_registry(hass, {"input_boolean.test": {}})
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -256,11 +238,15 @@ async def test_real_energy_sensor(hass: HomeAssistant) -> None:
     )
 
     await hass.async_block_till_done()
-    energy_state = hass.states.get("sensor.testgroup_energy")
-    assert energy_state
-    assert energy_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.existing_energy",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_energy",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.existing_energy",
+            },
+        },
+    )
 
 
 async def test_real_energy_sensor_error_on_non_existing_entity(
@@ -288,42 +274,25 @@ async def test_real_energy_sensor_error_on_non_existing_entity(
     assert "No energy sensor with id" in caplog.text
 
 
-async def test_unit_prefix_none(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
-
+@pytest.mark.parametrize(
+    ("domain_config", "expected_unit"),
+    [
+        pytest.param({CONF_ENERGY_SENSOR_UNIT_PREFIX: UnitPrefix.NONE}, UnitOfEnergy.WATT_HOUR, id="none"),
+        # Without an explicit prefix it defaults to k, so a W power sensor yields a kWh energy sensor.
+        pytest.param({}, UnitOfEnergy.KILO_WATT_HOUR, id="kilo by default"),
+    ],
+)
+async def test_unit_prefix(hass: HomeAssistant, domain_config: ConfigType, expected_unit: str) -> None:
     await run_powercalc_setup(
         hass,
         get_simple_fixed_config("input_boolean.test"),
-        {CONF_ENERGY_SENSOR_UNIT_PREFIX: UnitPrefix.NONE},
+        domain_config,
     )
 
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(hours=1),
-    )
+    await async_advance_time(hass, timedelta(hours=1), block=False)
 
     await set_states(hass, [("sensor.test_power", "50.00", {ATTR_UNIT_OF_MEASUREMENT: "W"})])
-    state_attributes = hass.states.get("sensor.test_energy").attributes
-    assert state_attributes.get("unit_of_measurement") == UnitOfEnergy.WATT_HOUR
-
-
-async def test_unit_prefix_kwh_default(hass: HomeAssistant) -> None:
-    """By default, unit prefix should be k, resulting in kWh energy sensor created for a W power sensor"""
-    await create_input_boolean(hass)
-
-    await run_powercalc_setup(
-        hass,
-        get_simple_fixed_config("input_boolean.test"),
-    )
-
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(hours=1),
-    )
-
-    await set_states(hass, [("sensor.test_power", "50.00", {ATTR_UNIT_OF_MEASUREMENT: "W"})])
-    state_attributes = hass.states.get("sensor.test_energy").attributes
-    assert state_attributes.get("unit_of_measurement") == UnitOfEnergy.KILO_WATT_HOUR
+    assert_entity_state(hass, "sensor.test_energy", attributes={ATTR_UNIT_OF_MEASUREMENT: expected_unit})
 
 
 def test_set_entity_category(hass: HomeAssistant) -> None:
@@ -343,7 +312,7 @@ def test_set_entity_category(hass: HomeAssistant) -> None:
 
 
 async def test_calibrate_service(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -370,16 +339,13 @@ async def test_real_power_sensor_kw(hass: HomeAssistant) -> None:
     Fixes https://github.com/bramstroker/homeassistant-powercalc/issues/1676
     """
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_power": RegistryEntryWithDefaults(
-                entity_id="sensor.test_power",
-                unique_id="12345",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                unit_of_measurement=UnitOfPower.KILO_WATT,
-            ),
+            "sensor.test_power": {
+                "device_class": SensorDeviceClass.POWER,
+                "unit_of_measurement": UnitOfPower.KILO_WATT,
+            },
         },
     )
 
@@ -425,23 +391,15 @@ async def test_real_power_sensor_kw(hass: HomeAssistant) -> None:
                 ),
             ],
         )
-    state = hass.states.get("sensor.test_energy")
-    assert state
-    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
+    assert_entity_state(hass, "sensor.test_energy", attributes={ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR})
 
 
 async def test_real_power_sensor_invalid_unit(hass: HomeAssistant) -> None:
     """Test that an invalid unit on the source power sensor falls back gracefully."""
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_power": RegistryEntryWithDefaults(
-                entity_id="sensor.test_power",
-                unique_id="12345",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-                unit_of_measurement="bogus_unit",
-            ),
+            "sensor.test_power": {"device_class": SensorDeviceClass.POWER, "unit_of_measurement": "bogus_unit"},
         },
     )
 
@@ -469,9 +427,7 @@ async def test_device_class_is_set_after_startup(hass: HomeAssistant) -> None:
         },
     )
 
-    state = hass.states.get("sensor.test_energy")
-    assert state
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
+    assert_entity_state(hass, "sensor.test_energy", attributes={ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY})
 
 
 async def test_force_updated_at_interval(hass: HomeAssistant) -> None:
@@ -495,9 +451,9 @@ async def test_force_updated_at_interval(hass: HomeAssistant) -> None:
     energy_sensor_id = "sensor.test_energy"
 
     await set_states(hass, [(power_sensor_id, "100", {ATTR_UNIT_OF_MEASUREMENT: "W"})])
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=60))
+    await async_advance_time(hass, timedelta(minutes=60), block=False)
     assert_entity_state(hass, energy_sensor_id, "0.1000")
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=40))
+    await async_advance_time(hass, 40, block=False)
     assert_entity_state(hass, energy_sensor_id, "0.1011")
 
 

--- a/tests/sensors/test_power.py
+++ b/tests/sensors/test_power.py
@@ -38,9 +38,7 @@ from homeassistant.helpers.template import Template
 from homeassistant.util import dt
 import pytest
 from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
     async_fire_time_changed,
-    mock_registry,
 )
 
 from custom_components.powercalc import CONF_IGNORE_UNAVAILABLE_STATE, CONF_POWER_UPDATE_INTERVAL
@@ -78,14 +76,15 @@ from custom_components.powercalc.const import (
 )
 from tests.common import (
     assert_entity_state,
-    create_input_boolean,
+    async_advance_time,
     create_mock_config_entry,
     get_simple_fixed_config,
     get_test_profile_dir,
+    mock_device_with_entities,
+    mock_entities_in_registry,
     run_powercalc_setup,
     set_states,
 )
-from tests.conftest import MockEntityWithModel
 
 
 @pytest.mark.parametrize(
@@ -128,17 +127,12 @@ def test_resolve_standby_power_value(
 
 
 async def test_use_real_power_sensor_in_group(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.existing_power": RegistryEntryWithDefaults(
-                entity_id="sensor.existing_power",
-                unique_id="1234",
-                platform="sensor",
-                device_class=SensorDeviceClass.POWER,
-            ),
+            "sensor.existing_power": {"device_class": SensorDeviceClass.POWER},
         },
     )
 
@@ -160,16 +154,22 @@ async def test_use_real_power_sensor_in_group(hass: HomeAssistant) -> None:
         },
     )
 
-    group_state = hass.states.get("sensor.testgroup_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {
-        "sensor.existing_power",
-        "sensor.test_power",
-    }
+    assert_entity_state(
+        hass,
+        "sensor.testgroup_power",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.existing_power",
+                "sensor.test_power",
+            },
+        },
+    )
 
 
-async def test_rounding_precision(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:
-    await create_input_boolean(hass)
+async def test_rounding_precision(hass: HomeAssistant) -> None:
+    # The source entity needs a unique id, otherwise the power sensor is not registered.
+    entity_registry = mock_entities_in_registry(hass, {"input_boolean.test": {}})
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -227,7 +227,7 @@ async def test_standby_power(hass: HomeAssistant) -> None:
 
 
 async def test_multiply_factor(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -251,7 +251,6 @@ async def test_error_when_no_strategy_has_been_configured(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.ERROR)
-    await create_input_boolean(hass)
 
     await run_powercalc_setup(
         hass,
@@ -375,7 +374,6 @@ async def test_template_entity_not_double_tracked(hass: HomeAssistant, caplog: p
 
 async def test_unknown_source_entity_state(hass: HomeAssistant) -> None:
     """Power sensor should be unavailable when source entity state is unknown"""
-    await create_input_boolean(hass)
     await run_powercalc_setup(
         hass,
         {
@@ -426,7 +424,7 @@ async def test_sleep_power(hass: HomeAssistant) -> None:
     assert_entity_state(hass, power_entity_id, "20.00")
 
     # After 10 seconds the device goes into sleep mode, check the sleep power is set on the power sensor
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=10))
+    await async_advance_time(hass, 10, block=False)
 
     assert_entity_state(hass, power_entity_id, "5.00")
 
@@ -438,14 +436,13 @@ async def test_sleep_power(hass: HomeAssistant) -> None:
 
     # Check that the sleepmode timer is reset correctly when the device goes to a non OFF state again
     await set_states(hass, [(entity_id, STATE_ON)])
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=20))
+    await async_advance_time(hass, 20, block=False)
 
     assert_entity_state(hass, power_entity_id, "100.00")
 
 
 async def test_unavailable_power(hass: HomeAssistant) -> None:
     """Test specifying an alternative power value if the source entity is unavailable"""
-    await create_input_boolean(hass)
 
     await run_powercalc_setup(
         hass,
@@ -475,14 +472,13 @@ async def test_disable_extended_attributes(hass: HomeAssistant) -> None:
 
 async def test_manually_configured_sensor_overrides_profile(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Make sure that config settings done by user are not overridden by power profile
     """
     entity_id = "light.test"
 
-    mock_entity_with_model_information(entity_id, "sonoff", "ZBMINI")
+    mock_device_with_entities(hass, entity_id, "sonoff", "ZBMINI")
 
     await run_powercalc_setup(
         hass,
@@ -503,7 +499,7 @@ async def test_manually_configured_sensor_overrides_profile(
 
 
 async def test_standby_power_template(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -589,7 +585,7 @@ async def test_multiply_factor_sleep_power(hass: HomeAssistant) -> None:
     )
 
     await set_states(hass, [("switch.test", STATE_OFF)])
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=25))
+    await async_advance_time(hass, 25, block=False)
 
     assert_entity_state(hass, "sensor.test_power", "4.00")
 
@@ -615,7 +611,7 @@ async def test_unload_entry_cancels_pending_sleep_power_timer(hass: HomeAssistan
 
     await hass.config_entries.async_unload(entry.entry_id)
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=25))
+    await async_advance_time(hass, 25, block=False)
 
     assert_entity_state(hass, "sensor.test_power", STATE_UNAVAILABLE)
 

--- a/tests/sensors/test_utility_meter.py
+++ b/tests/sensors/test_utility_meter.py
@@ -13,16 +13,12 @@ from homeassistant.components.utility_meter.sensor import (
     CONF_UNIQUE_ID,
     PAUSED,
 )
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, CONF_ENTITY_ID, CONF_NAME, UnitOfEnergy
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, CONF_ENTITY_ID, CONF_NAME, STATE_OFF, UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 import pytest
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    mock_registry,
-)
 
 from custom_components.powercalc.const import (
     CONF_CREATE_UTILITY_METERS,
@@ -42,17 +38,17 @@ from custom_components.powercalc.const import (
 )
 from tests.common import (
     assert_entity_state,
-    create_input_boolean,
     create_mock_config_entry,
     create_mocked_virtual_power_sensor_entry,
     mock_device,
+    mock_entities_in_registry,
     run_powercalc_setup,
     set_states,
 )
 
 
 async def test_tariff_sensors_are_created(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     assert await async_setup_component(hass, utility_meter.DOMAIN, {})
 
@@ -70,15 +66,17 @@ async def test_tariff_sensors_are_created(hass: HomeAssistant) -> None:
 
     assert_entity_state(hass, "select.test_energy_daily", "peak")
 
-    peak_sensor = hass.states.get("sensor.test_energy_daily_peak")
-    assert peak_sensor
-    assert peak_sensor.attributes[ATTR_TARIFF] == "peak"
-    assert peak_sensor.attributes[ATTR_STATUS] == COLLECTING
+    assert_entity_state(
+        hass,
+        "sensor.test_energy_daily_peak",
+        attributes={ATTR_TARIFF: "peak", ATTR_STATUS: COLLECTING},
+    )
 
-    offpeak_sensor = hass.states.get("sensor.test_energy_daily_offpeak")
-    assert offpeak_sensor
-    assert offpeak_sensor.attributes[ATTR_TARIFF] == "offpeak"
-    assert offpeak_sensor.attributes[ATTR_STATUS] == PAUSED
+    assert_entity_state(
+        hass,
+        "sensor.test_energy_daily_offpeak",
+        attributes={ATTR_TARIFF: "offpeak", ATTR_STATUS: PAUSED},
+    )
 
     general_sensor_daily = hass.states.get("sensor.test_energy_daily")
     assert general_sensor_daily
@@ -89,11 +87,9 @@ async def test_tariff_sensors_are_created(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "select.test_energy_daily", "peak")
 
     await set_states(hass, [("select.test_energy_daily", "offpeak")])
-    peak_sensor = hass.states.get("sensor.test_energy_daily_peak")
-    assert peak_sensor.attributes[ATTR_STATUS] == PAUSED
+    assert_entity_state(hass, "sensor.test_energy_daily_peak", attributes={ATTR_STATUS: PAUSED})
 
-    offpeak_sensor = hass.states.get("sensor.test_energy_daily_offpeak")
-    assert offpeak_sensor.attributes[ATTR_STATUS] == COLLECTING
+    assert_entity_state(hass, "sensor.test_energy_daily_offpeak", attributes={ATTR_STATUS: COLLECTING})
 
 
 async def test_tariff_sensors_created_for_gui_sensors(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:
@@ -144,27 +140,12 @@ async def test_utility_meter_is_not_created_twice(
     power_sensor_id = "sensor.test_power"
     energy_sensor_id = "sensor.test_energy"
     utility_meter_id = "sensor.test_energy_daily"
-    entity_registry = mock_registry(
+    entity_registry = mock_entities_in_registry(
         hass,
         {
-            power_sensor_id: RegistryEntryWithDefaults(
-                entity_id=power_sensor_id,
-                unique_id="1234",
-                name="Test power",
-                platform="powercalc",
-            ),
-            energy_sensor_id: RegistryEntryWithDefaults(
-                entity_id=energy_sensor_id,
-                unique_id="1234_energy",
-                name="Test energy",
-                platform="powercalc",
-            ),
-            utility_meter_id: RegistryEntryWithDefaults(
-                entity_id=utility_meter_id,
-                unique_id="1234_energy_daily",
-                name="Test energy daily",
-                platform="powercalc",
-            ),
+            power_sensor_id: {"name": "Test power", "platform": "powercalc"},
+            energy_sensor_id: {"unique_id": "1234_energy", "name": "Test energy", "platform": "powercalc"},
+            utility_meter_id: {"unique_id": "1234_energy_daily", "name": "Test energy daily", "platform": "powercalc"},
         },
     )
 
@@ -224,48 +205,46 @@ async def test_rounding_digits(hass: HomeAssistant, entity_registry: EntityRegis
     assert registry_entry
     assert registry_entry.options == {"sensor": {"suggested_display_precision": 2}}
 
-    state = hass.states.get("sensor.test_energy_daily")
-    assert state
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.KILO_WATT_HOUR
-    assert state.state == "2.00"
+    assert_entity_state(
+        hass,
+        "sensor.test_energy_daily",
+        "2.00",
+        attributes={ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR},
+    )
 
 
-async def test_regression(hass: HomeAssistant) -> None:
-    # - entity_id: switch.gerateschranke_licht_servodrive
-    # name: Geräteschrank
-    # power_sensor_id: sensor.gerateschranke_licht_servodrive_power
-    # - entity_id: switch.gerateschranke_frei
-    #  name: Geräteschrank unbenutzt
-    #  power_sensor_id: sensor.gerateschranke_frei_power
+async def test_utility_meters_not_duplicated_for_shared_energy_sensor(hass: HomeAssistant) -> None:
+    """Two power sensors on one device resolve to the same related energy sensor.
+
+    Only one set of utility meters must be created for it, not one set per configured sensor.
+    See https://github.com/bramstroker/homeassistant-powercalc/issues/1799
+    """
     power_sensor_id = "sensor.test_power"
     power_sensor2_id = "sensor.test2_power"
     energy_sensor_id = "sensor.test_energy"
     device_id = "some_device"
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            power_sensor_id: RegistryEntryWithDefaults(
-                entity_id=power_sensor_id,
-                unique_id="29742725-6F34-49F2-91DE-589951306E9F",
-                name="Test power",
-                platform="sensor",
-                device_id=device_id,
-            ),
-            power_sensor2_id: RegistryEntryWithDefaults(
-                entity_id=power_sensor_id,
-                unique_id="A1CBB81F-A958-482B-A10E-1DAA0652796A",
-                name="Test power2",
-                platform="sensor",
-                device_id=device_id,
-            ),
-            energy_sensor_id: RegistryEntryWithDefaults(
-                entity_id=energy_sensor_id,
-                unique_id="4FA9B62F-E957-4366-B7DA-832C1D5F742D",
-                name="Test energy",
-                platform="sensor",
-                device_id=device_id,
-                device_class=SensorDeviceClass.ENERGY,
-            ),
+            power_sensor_id: {
+                "unique_id": "29742725-6F34-49F2-91DE-589951306E9F",
+                "name": "Test power",
+                "platform": "sensor",
+                "device_id": device_id,
+            },
+            power_sensor2_id: {
+                "unique_id": "A1CBB81F-A958-482B-A10E-1DAA0652796A",
+                "name": "Test power2",
+                "platform": "sensor",
+                "device_id": device_id,
+            },
+            energy_sensor_id: {
+                "unique_id": "4FA9B62F-E957-4366-B7DA-832C1D5F742D",
+                "name": "Test energy",
+                "platform": "sensor",
+                "device_id": device_id,
+                "device_class": SensorDeviceClass.ENERGY,
+            },
         },
     )
 
@@ -287,6 +266,17 @@ async def test_regression(hass: HomeAssistant) -> None:
             CONF_CREATE_UTILITY_METERS: True,
         },
     )
+
+    assert sorted(hass.states.async_entity_ids("sensor")) == [
+        "sensor.all_standby_energy",
+        "sensor.all_standby_energy_daily",
+        "sensor.all_standby_energy_monthly",
+        "sensor.all_standby_energy_weekly",
+        "sensor.all_standby_power",
+        "sensor.test_energy_daily",
+        "sensor.test_energy_monthly",
+        "sensor.test_energy_weekly",
+    ]
 
 
 async def test_net_consumption_option(hass: HomeAssistant) -> None:

--- a/tests/strategy/test_composite.py
+++ b/tests/strategy/test_composite.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_MODE, ATTR_EFFECT, ColorMode
 from homeassistant.const import (
     CONF_CONDITION,
@@ -13,12 +11,6 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    async_fire_time_changed,
-    mock_registry,
-)
 
 from custom_components.powercalc.const import (
     CONF_COMPOSITE,
@@ -41,27 +33,16 @@ from custom_components.powercalc.const import (
 from custom_components.powercalc.strategy.composite import CompositeMode
 from tests.common import (
     assert_entity_state,
+    async_advance_time,
     get_test_profile_dir,
-    mock_device,
+    mock_device_with_entities,
     run_powercalc_setup,
     set_states,
 )
 
 
 async def test_composite(hass: HomeAssistant) -> None:
-    mock_device(hass, "my-device-id", "foo", "bar")
-
-    mock_registry(
-        hass,
-        {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1234",
-                platform="light",
-                device_id="my-device-id",
-            ),
-        },
-    )
+    mock_device_with_entities(hass, "light.test", "foo", "bar")
 
     sensor_config = {
         CONF_ENTITY_ID: "light.test",
@@ -271,11 +252,11 @@ async def test_playbook(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "sensor.dishwasher_power", "1.60")
 
     await set_states(hass, [(dishwasher_mode_entity, "Cycle Active")])
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3))
+    await async_advance_time(hass, 3, block=False)
 
     assert_entity_state(hass, "sensor.dishwasher_power", "20.00")
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=5))
+    await async_advance_time(hass, 5, block=False)
 
     assert_entity_state(hass, "sensor.dishwasher_power", "40.00")
 

--- a/tests/strategy/test_linear.py
+++ b/tests/strategy/test_linear.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.typing import ConfigType
 import pytest
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_registry
 
 from custom_components.powercalc.common import SourceEntity, create_source_entity
 from custom_components.powercalc.const import (
@@ -28,8 +27,14 @@ from custom_components.powercalc.const import (
 )
 from custom_components.powercalc.errors import StrategyConfigurationError
 from custom_components.powercalc.strategy.linear import LinearStrategy
-from tests.common import assert_entity_state, create_mock_config_entry, mock_device, set_states
-from tests.conftest import MockEntityWithModel
+from tests.common import (
+    assert_entity_state,
+    create_mock_config_entry,
+    mock_device,
+    mock_device_with_entities,
+    mock_entities_in_registry,
+    set_states,
+)
 
 
 async def test_light_max_power_only(hass: HomeAssistant) -> None:
@@ -113,22 +118,11 @@ async def test_light_calibrate(hass: HomeAssistant) -> None:
 def _setup_vacuum_test(hass: HomeAssistant) -> None:
     """Set up the vacuum device and entities for testing."""
     mock_device(hass, "vacuum-device", "test", "test")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "vacuum.test": RegistryEntryWithDefaults(
-                entity_id="vacuum.test",
-                unique_id="1111",
-                platform="test",
-                device_id="vacuum-device",
-            ),
-            "sensor.test_battery": RegistryEntryWithDefaults(
-                entity_id="sensor.test_battery",
-                unique_id="2222",
-                platform="sensor",
-                device_id="vacuum-device",
-                original_device_class=SensorDeviceClass.BATTERY,
-            ),
+            "vacuum.test": {"platform": "test", "device_id": "vacuum-device"},
+            "sensor.test_battery": {"device_id": "vacuum-device", "original_device_class": SensorDeviceClass.BATTERY},
         },
     )
 
@@ -153,18 +147,7 @@ async def test_no_battery_entity_for_vacuum(
     hass: HomeAssistant,
 ) -> None:
     # Use a modified setup without the battery entity
-    mock_device(hass, "vacuum-device", "test", "test")
-    mock_registry(
-        hass,
-        {
-            "vacuum.test": RegistryEntryWithDefaults(
-                entity_id="vacuum.test",
-                unique_id="1111",
-                platform="test",
-                device_id="vacuum-device",
-            ),
-        },
-    )
+    mock_device_with_entities(hass, "vacuum.test", "test", "test", platform="test")
 
     source_entity = create_source_entity("vacuum.test", hass)
     with pytest.raises(StrategyConfigurationError, match="No battery entity found for vacuum cleaner"):
@@ -261,9 +244,8 @@ async def _create_strategy_instance(
 
 async def test_config_entry_with_calibrate_list(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information("light.test")
+    mock_device_with_entities(hass, "light.test")
 
     await create_mock_config_entry(
         hass,

--- a/tests/strategy/test_lut.py
+++ b/tests/strategy/test_lut.py
@@ -423,32 +423,26 @@ async def test_fallback_color_temp_to_hs(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "sensor.test_power", "1.42")
 
 
-async def test_warning_is_logged_when_color_mode_is_missing(
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        pytest.param({ATTR_BRIGHTNESS: 100}, id="color mode missing"),
+        pytest.param({ATTR_BRIGHTNESS: 100, ATTR_COLOR_MODE: None}, id="color mode none"),
+    ],
+)
+async def test_warning_is_logged_when_color_mode_is_unknown(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
+    attributes: dict,
 ) -> None:
     """
-    Test that a warning is logged when the color_mode attribute is missing.
+    Test that a warning is logged when the color_mode attribute is missing or none.
     See: https://github.com/bramstroker/homeassistant-powercalc/issues/2323
     """
     caplog.set_level(logging.WARNING)
     strategy = await _create_lut_strategy(hass, "signify", "LCT010")
 
-    state = State("light.test", STATE_ON, {ATTR_BRIGHTNESS: 100})
-    assert not await strategy.calculate(state)
-    assert "color mode unknown" in caplog.text
-
-
-async def test_warning_is_logged_when_color_mode_is_none(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
-    """
-    Test that a warning is logged when the color_mode attribute is none.
-    See: https://github.com/bramstroker/homeassistant-powercalc/issues/2323
-    """
-    caplog.set_level(logging.WARNING)
-    strategy = await _create_lut_strategy(hass, "signify", "LCT010")
-
-    state = State("light.test", STATE_ON, {ATTR_BRIGHTNESS: 100, ATTR_COLOR_MODE: None})
-    assert not await strategy.calculate(state)
+    assert not await strategy.calculate(State("light.test", STATE_ON, attributes))
     assert "color mode unknown" in caplog.text
 
 

--- a/tests/strategy/test_playbook.py
+++ b/tests/strategy/test_playbook.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
@@ -12,9 +10,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.util import dt
 import pytest
-from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.powercalc import CONF_IGNORE_UNAVAILABLE_STATE
 from custom_components.powercalc.const import (
@@ -36,6 +32,7 @@ from custom_components.powercalc.errors import StrategyConfigurationError
 from custom_components.powercalc.strategy.playbook import PlaybookStrategy
 from tests.common import (
     assert_entity_state,
+    async_advance_time,
     get_simple_fixed_config,
     get_test_profile_dir,
     run_powercalc_setup,
@@ -63,10 +60,10 @@ async def test_activate_playbook_service(hass: HomeAssistant) -> None:
 
     await _activate_playbook(hass, "playbook1")
 
-    elapse_and_assert_power(hass, 1.5, "20.50")
-    elapse_and_assert_power(hass, 3, "40.00")
-    elapse_and_assert_power(hass, 4.5, "60.00")
-    elapse_and_assert_power(hass, 6.5, "20.20")
+    await elapse_and_assert_power(hass, 1.5, "20.50")
+    await elapse_and_assert_power(hass, 3, "40.00")
+    await elapse_and_assert_power(hass, 4.5, "60.00")
+    await elapse_and_assert_power(hass, 6.5, "20.20")
 
 
 async def test_stop_playbook_service(hass: HomeAssistant) -> None:
@@ -88,12 +85,12 @@ async def test_stop_playbook_service(hass: HomeAssistant) -> None:
 
     await _activate_playbook(hass, "playbook1")
 
-    elapse_and_assert_power(hass, 1.5, "20.50")
+    await elapse_and_assert_power(hass, 1.5, "20.50")
 
     await _stop_playbook(hass)
 
-    elapse_and_assert_power(hass, 3, "20.50")
-    elapse_and_assert_power(hass, 4.5, "20.50")
+    await elapse_and_assert_power(hass, 3, "20.50")
+    await elapse_and_assert_power(hass, 4.5, "20.50")
 
 
 async def test_get_active_playbook_service(hass: HomeAssistant) -> None:
@@ -144,7 +141,7 @@ async def test_turn_off_stops_running_playbook(hass: HomeAssistant) -> None:
     await _activate_playbook(hass, "playbook1")
 
     await set_states(hass, [("switch.test", STATE_OFF)])
-    elapse_and_assert_power(hass, 3, "0.50")
+    await elapse_and_assert_power(hass, 3, "0.50")
 
 
 async def test_services_raises_error_on_non_playbook_sensor(
@@ -203,16 +200,16 @@ async def test_repeat(hass: HomeAssistant) -> None:
 
     assert_entity_state(hass, "sensor.test_power", "0.00")
 
-    elapse_and_assert_power(hass, 2, "20.00")
-    elapse_and_assert_power(hass, 4, "40.00")
-    elapse_and_assert_power(hass, 6, "20.00")
-    elapse_and_assert_power(hass, 8, "40.00")
-    elapse_and_assert_power(hass, 10, "20.00")
+    await elapse_and_assert_power(hass, 2, "20.00")
+    await elapse_and_assert_power(hass, 4, "40.00")
+    await elapse_and_assert_power(hass, 6, "20.00")
+    await elapse_and_assert_power(hass, 8, "40.00")
+    await elapse_and_assert_power(hass, 10, "20.00")
 
     await _stop_playbook(hass)
 
-    elapse_and_assert_power(hass, 12, "20.00")
-    elapse_and_assert_power(hass, 14, "20.00")
+    await elapse_and_assert_power(hass, 12, "20.00")
+    await elapse_and_assert_power(hass, 14, "20.00")
 
 
 async def test_autostart(hass: HomeAssistant) -> None:
@@ -230,8 +227,8 @@ async def test_autostart(hass: HomeAssistant) -> None:
         },
     )
 
-    elapse_and_assert_power(hass, 2, "20.00")
-    elapse_and_assert_power(hass, 4, "40.00")
+    await elapse_and_assert_power(hass, 2, "20.00")
+    await elapse_and_assert_power(hass, 4, "40.00")
 
 
 async def test_exception_when_providing_unknown_playbook(hass: HomeAssistant) -> None:
@@ -278,7 +275,7 @@ async def test_load_csv_from_subdirectory(hass: HomeAssistant) -> None:
 
     await _activate_playbook(hass, "playbook1")
 
-    elapse_and_assert_power(hass, 2, "20.00")
+    await elapse_and_assert_power(hass, 2, "20.00")
 
 
 async def test_multiply_factor(hass: HomeAssistant) -> None:
@@ -298,7 +295,7 @@ async def test_multiply_factor(hass: HomeAssistant) -> None:
 
     await _activate_playbook(hass, "playbook")
 
-    elapse_and_assert_power(hass, 2, "60.00")
+    await elapse_and_assert_power(hass, 2, "60.00")
 
 
 async def test_source_entity_trigger(hass: HomeAssistant) -> None:
@@ -320,14 +317,14 @@ async def test_source_entity_trigger(hass: HomeAssistant) -> None:
 
     await set_states(hass, [("switch.test", STATE_ON)])
     assert_entity_state(hass, POWER_SENSOR_ID, "0.00")
-    elapse_and_assert_power(hass, 2, "20.00")
+    await elapse_and_assert_power(hass, 2, "20.00")
 
     await set_states(hass, [("switch.test", STATE_OFF)])
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=60))
+    await async_advance_time(hass, 60, block=False)
 
     await set_states(hass, [("switch.test", STATE_ON)])
     assert_entity_state(hass, POWER_SENSOR_ID, "0.00")
-    elapse_and_assert_power(hass, 2, "20.00")
+    await elapse_and_assert_power(hass, 2, "20.00")
 
 
 async def test_state_trigger(hass: HomeAssistant) -> None:
@@ -352,19 +349,19 @@ async def test_state_trigger(hass: HomeAssistant) -> None:
     )
 
     await set_states(hass, [("media_player.sonos", STATE_PAUSED)])
-    elapse_and_assert_power(hass, 2, "2.00")
+    await elapse_and_assert_power(hass, 2, "2.00")
 
     await set_states(hass, [("media_player.sonos", STATE_IDLE)])
-    elapse_and_assert_power(hass, 2, "5.00")
+    await elapse_and_assert_power(hass, 2, "5.00")
 
     await set_states(hass, [("media_player.sonos", STATE_OFF)])
-    elapse_and_assert_power(hass, 1, "0.10")
+    await elapse_and_assert_power(hass, 1, "0.10")
 
     await set_states(hass, [("media_player.sonos", STATE_IDLE)])
-    elapse_and_assert_power(hass, 2, "5.00")
+    await elapse_and_assert_power(hass, 2, "5.00")
 
     await set_states(hass, [("media_player.sonos", STATE_OFF)])
-    elapse_and_assert_power(hass, 1, "0.10")
+    await elapse_and_assert_power(hass, 1, "0.10")
 
     await set_states(hass, [("media_player.sonos", STATE_PLAYING)])
     assert_entity_state(hass, POWER_SENSOR_ID, "0.00")
@@ -380,15 +377,15 @@ async def test_playbook_strategy_from_library_profile(hass: HomeAssistant) -> No
         },
     )
 
-    elapse_and_assert_power(hass, 3, "20.00")
+    await elapse_and_assert_power(hass, 3, "20.00")
 
 
-def elapse_and_assert_power(
+async def elapse_and_assert_power(
     hass: HomeAssistant,
     seconds: float,
     expected_power: str,
 ) -> None:
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=seconds))
+    await async_advance_time(hass, seconds, block=False)
 
     assert_entity_state(hass, POWER_SENSOR_ID, expected_power)
 

--- a/tests/strategy/test_wled.py
+++ b/tests/strategy/test_wled.py
@@ -9,8 +9,6 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 import pytest
 from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    mock_registry,
     setup_test_component_platform,
 )
 
@@ -25,15 +23,20 @@ from custom_components.powercalc.const import (
 from custom_components.powercalc.errors import StrategyConfigurationError
 from custom_components.powercalc.strategy.wled import WledStrategy
 import custom_components.test.sensor as test_sensor_platform
-from tests.common import assert_entity_state, mock_device, run_powercalc_setup, set_states
-from tests.conftest import MockEntityWithModel
+from tests.common import (
+    assert_entity_state,
+    mock_device,
+    mock_device_with_entities,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 
 
 async def test_can_calculate_power(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information("light.test")
+    mock_device_with_entities(hass, "light.test")
     await set_states(hass, [("light.test", STATE_ON)])
     light_source_entity = create_source_entity("light.test", hass)
 
@@ -73,19 +76,11 @@ async def test_can_calculate_power(
 async def test_calculate_returns_none_when_dependent_state_is_missing(
     hass: HomeAssistant,
 ) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1234",
-                platform="light",
-            ),
-            "sensor.test_estimated_current": RegistryEntryWithDefaults(
-                entity_id="sensor.test_estimated_current",
-                unique_id="5678",
-                platform="sensor",
-            ),
+            "light.test": {},
+            "sensor.test_estimated_current": {},
         },
     )
     light_source_entity = create_source_entity("light.test", hass)
@@ -113,23 +108,15 @@ async def test_find_estimated_current_entity_by_device_class(
     """
     mock_device(hass, "wled-device-id", "WLED", "WLED")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1234",
-                platform="light",
-                device_id="wled-device-id",
-            ),
-            "sensor.test_current": RegistryEntryWithDefaults(
-                entity_id="sensor.test_current",
-                unique_id="1234",
-                platform="sensor",
-                device_id="wled-device-id",
-                unit_of_measurement="mA",
-                original_device_class=SensorDeviceClass.CURRENT,
-            ),
+            "light.test": {"device_id": "wled-device-id"},
+            "sensor.test_current": {
+                "device_id": "wled-device-id",
+                "unit_of_measurement": "mA",
+                "original_device_class": SensorDeviceClass.CURRENT,
+            },
         },
     )
 
@@ -146,15 +133,10 @@ async def test_find_estimated_current_entity_by_device_class(
 async def test_exception_is_raised_when_no_estimated_current_entity_found(
     hass: HomeAssistant,
 ) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1234",
-                platform="light",
-                device_id="wled-device-id",
-            ),
+            "light.test": {"device_id": "wled-device-id"},
         },
     )
 
@@ -171,43 +153,22 @@ async def test_exception_is_raised_when_no_estimated_current_entity_found(
 async def test_wled_autodiscovery_flow(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.ERROR)
     mock_device(hass, "wled-device", "WLED", "FOSS")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1234",
-                platform="light",
-                device_id="wled-device",
-            ),
-            "light.test_master": RegistryEntryWithDefaults(
-                entity_id="light.test_master",
-                unique_id="1234-master",
-                platform="light",
-                original_name="Master",
-                device_id="wled-device",
-            ),
-            "light.test_segment1": RegistryEntryWithDefaults(
-                entity_id="light.test_segment1",
-                unique_id="1234-segment",
-                platform="light",
-                original_name="WLED Segment1",
-                device_id="wled-device",
-            ),
-            "light.test_segment_1_2": RegistryEntryWithDefaults(
-                entity_id="light.test_segment_1_2",
-                unique_id="1234-segment",
-                platform="light",
-                device_id="wled-device",
-            ),
-            "sensor.test_current": RegistryEntryWithDefaults(
-                entity_id="sensor.test_current",
-                unique_id="1234",
-                platform="sensor",
-                device_id="wled-device",
-                unit_of_measurement="mA",
-                original_device_class=SensorDeviceClass.CURRENT,
-            ),
+            "light.test": {"device_id": "wled-device"},
+            "light.test_master": {"unique_id": "1234-master", "original_name": "Master", "device_id": "wled-device"},
+            "light.test_segment1": {
+                "unique_id": "1234-segment",
+                "original_name": "WLED Segment1",
+                "device_id": "wled-device",
+            },
+            "light.test_segment_1_2": {"unique_id": "1234-segment", "device_id": "wled-device"},
+            "sensor.test_current": {
+                "device_id": "wled-device",
+                "unit_of_measurement": "mA",
+                "original_device_class": SensorDeviceClass.CURRENT,
+            },
         },
     )
 
@@ -238,23 +199,15 @@ async def test_yaml_configuration(hass: HomeAssistant) -> None:
     Also check standby power can be calculated by the WLED strategy
     """
     mock_device(hass, "wled-device", "WLED", "FOSS")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1234",
-                platform="light",
-                device_id="wled-device",
-            ),
-            "sensor.test_current": RegistryEntryWithDefaults(
-                entity_id="sensor.test_current",
-                unique_id="1234",
-                platform="sensor",
-                device_id="wled-device",
-                unit_of_measurement="mA",
-                original_device_class=SensorDeviceClass.CURRENT,
-            ),
+            "light.test": {"device_id": "wled-device"},
+            "sensor.test_current": {
+                "device_id": "wled-device",
+                "unit_of_measurement": "mA",
+                "original_device_class": SensorDeviceClass.CURRENT,
+            },
         },
     )
 
@@ -283,23 +236,15 @@ async def test_estimated_current_sensor_unavailable(hass: HomeAssistant, caplog:
 
     mock_device(hass, "wled-device-id", "WLED", "WLED")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1234",
-                platform="light",
-                device_id="wled-device-id",
-            ),
-            "sensor.test_current": RegistryEntryWithDefaults(
-                entity_id="sensor.test_current",
-                unique_id="1234",
-                platform="sensor",
-                device_id="wled-device-id",
-                unit_of_measurement="mA",
-                original_device_class=SensorDeviceClass.CURRENT,
-            ),
+            "light.test": {"device_id": "wled-device-id"},
+            "sensor.test_current": {
+                "device_id": "wled-device-id",
+                "unit_of_measurement": "mA",
+                "original_device_class": SensorDeviceClass.CURRENT,
+            },
         },
     )
 

--- a/tests/test_device_binding.py
+++ b/tests/test_device_binding.py
@@ -2,14 +2,12 @@ import logging
 
 from homeassistant.const import CONF_DEVICE, CONF_ENTITY_ID, CONF_NAME, CONF_SENSOR_TYPE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryDisabler, DeviceRegistry
+from homeassistant.helpers.device_registry import DeviceEntryDisabler, DeviceRegistry
 import homeassistant.helpers.entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
-    RegistryEntryWithDefaults,
     mock_device_registry,
-    mock_registry,
 )
 
 from custom_components.powercalc.common import SourceEntity
@@ -25,15 +23,20 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.device_binding import attach_configured_device_entry, is_composite_device_id
-from tests.common import create_mock_config_entry, mock_device, run_powercalc_setup
+from tests.common import (
+    create_mock_config_entry,
+    mock_device,
+    mock_devices,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+)
 
 
 def test_regular_device_is_not_composite(
     hass: HomeAssistant,
 ) -> None:
     """A regular device ID is not treated as a legacy composite device."""
-    device_entry = DeviceEntry(config_entry_id="test", id="regular-device")
-    mock_device_registry(hass, {device_entry.id: device_entry})
+    device_entry = mock_device(hass, "regular-device", manufacturer=None, model=None)
 
     assert not is_composite_device_id(hass, device_entry.id)
 
@@ -43,8 +46,7 @@ def test_device_is_not_composite_when_detection_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A device is not composite on HA versions without the detection API."""
-    device_entry = DeviceEntry(config_entry_id="test", id="regular-device")
-    mock_device_registry(hass, {device_entry.id: device_entry})
+    device_entry = mock_device(hass, "regular-device", manufacturer=None, model=None)
     monkeypatch.setattr(DeviceRegistry, "async_is_composite_device_id", None)
 
     assert not is_composite_device_id(hass, device_entry.id)
@@ -131,21 +133,11 @@ async def test_entities_are_bound_to_source_device2(
 
     mock_device(hass, device_id, "shelly", "Plug S")
 
-    entity_reg = mock_registry(
+    entity_reg = mock_entities_in_registry(
         hass,
         {
-            switch_id: RegistryEntryWithDefaults(
-                entity_id=switch_id,
-                unique_id="1234",
-                platform="switch",
-                device_id=device_id,
-            ),
-            power_sensor_id: RegistryEntryWithDefaults(
-                entity_id=power_sensor_id,
-                unique_id="12345",
-                platform="sensor",
-                device_id=device_id,
-            ),
+            switch_id: {"platform": "switch", "device_id": device_id},
+            power_sensor_id: {"platform": "sensor", "device_id": device_id},
         },
     )
 
@@ -170,23 +162,15 @@ async def test_entities_are_bound_to_disabled_source_device(
 
     mock_device(hass, device_id, "signify", "LCA001", disabled_by=DeviceEntryDisabler.USER)
 
-    entity_reg = mock_registry(
+    entity_reg = mock_entities_in_registry(
         hass,
         {
-            light_id: RegistryEntryWithDefaults(
-                entity_id=light_id,
-                disabled_by=er.RegistryEntryDisabler.DEVICE,
-                unique_id="1234",
-                platform="light",
-                device_id=device_id,
-            ),
-            power_sensor_id: RegistryEntryWithDefaults(
-                entity_id=power_sensor_id,
-                disabled_by=er.RegistryEntryDisabler.DEVICE,
-                unique_id="1234",
-                platform="powercalc",
-                device_id=device_id,
-            ),
+            light_id: {"disabled_by": er.RegistryEntryDisabler.DEVICE, "platform": "light", "device_id": device_id},
+            power_sensor_id: {
+                "disabled_by": er.RegistryEntryDisabler.DEVICE,
+                "platform": "powercalc",
+                "device_id": device_id,
+            },
         },
     )
 
@@ -228,35 +212,23 @@ async def test_entities_are_bound_to_source_device3(
 async def test_configured_device_takes_precedence_over_source_device(
     hass: HomeAssistant,
 ) -> None:
-    source_device = DeviceEntry(
-        config_entry_id="test",
-        id="source-device",
-        manufacturer="source",
-        model="Source Device",
-    )
-    configured_device = DeviceEntry(
-        config_entry_id="test",
-        id="configured-device",
-        manufacturer="configured",
-        model="Configured Device",
-    )
-    mock_device_registry(
+    devices = mock_devices(
         hass,
         {
-            source_device.id: source_device,
-            configured_device.id: configured_device,
+            "source-device": {"manufacturer": "source", "model": "Source Device"},
+            "configured-device": {"manufacturer": "configured", "model": "Configured Device"},
         },
     )
+    source_device = devices["source-device"]
+    configured_device = devices["configured-device"]
 
-    entity_registry = mock_registry(
+    entity_registry = mock_entities_in_registry(
         hass,
         {
-            "switch.configured_precedence": RegistryEntryWithDefaults(
-                entity_id="switch.configured_precedence",
-                unique_id="configured-precedence-source",
-                platform="switch",
-                device_id=source_device.id,
-            ),
+            "switch.configured_precedence": {
+                "unique_id": "configured-precedence-source",
+                "device_id": source_device.id,
+            },
         },
     )
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -17,12 +17,10 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntry
-from homeassistant.util import dt
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     RegistryEntryWithDefaults,
-    async_fire_time_changed,
     mock_device_registry,
     mock_registry,
 )
@@ -57,31 +55,47 @@ from custom_components.powercalc.discovery import (
     get_power_profile_by_source_entity,
 )
 from custom_components.powercalc.power_profile.library import ModelInfo
-from custom_components.test.light import MockLight
-from tests.common import mock_device, set_states
 
-from .common import assert_entity_state, create_mock_config_entry, create_mock_light_entity, run_powercalc_setup
+from .common import (
+    assert_entity_state,
+    async_advance_time,
+    create_mock_config_entry,
+    mock_device,
+    mock_device_with_entities,
+    mock_devices,
+    mock_entities_in_registry,
+    run_powercalc_setup,
+    set_states,
+)
 from .config_flow.test_global_configuration import create_mock_global_config_entry
-from .conftest import MockEntityWithModel
 
 DEFAULT_UNIQUE_ID = "7c009ef6829f"
+LIGHT_ATTRIBUTES = {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS], ATTR_COLOR_MODE: ColorMode.BRIGHTNESS}
 
 
 async def test_autodiscovery(hass: HomeAssistant, mock_flow_init: AsyncMock) -> None:
     """Test that models are automatically discovered and power sensors created"""
 
-    lighta = MockLight("testa")
-    lighta.manufacturer = "lidl"
-    lighta.model = "HG06106C"
-
-    lightb = MockLight("testb")
-    lightb.manufacturer = "signify"
-    lightb.model = "LCA001"
-
-    lightc = MockLight("testc")
-    lightc.manufacturer = "lidl"
-    lightc.model = "NONEXISTING"
-    await create_mock_light_entity(hass, [lighta, lightb, lightc])
+    mock_devices(
+        hass,
+        {
+            "testa-device": {"manufacturer": "lidl", "model": "HG06106C"},
+            "testb-device": {"manufacturer": "signify", "model": "LCA001"},
+            "testc-device": {"manufacturer": "lidl", "model": "NONEXISTING"},
+        },
+    )
+    mock_entities_in_registry(
+        hass,
+        {
+            "light.testa": {"device_id": "testa-device"},
+            "light.testb": {"device_id": "testb-device"},
+            "light.testc": {"device_id": "testc-device"},
+        },
+    )
+    await set_states(
+        hass,
+        [(f"light.test{suffix}", STATE_ON, LIGHT_ATTRIBUTES) for suffix in ("a", "b", "c")],
+    )
 
     await run_powercalc_setup(hass)
 
@@ -98,9 +112,9 @@ async def test_autodiscovery(hass: HomeAssistant, mock_flow_init: AsyncMock) -> 
 async def test_discovery_skipped_when_confirmed_by_user(
     hass: HomeAssistant,
     mock_flow_init: AsyncMock,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "lidl",
         "HG06106C",
@@ -128,11 +142,10 @@ async def test_discovery_skipped_when_confirmed_by_user(
 
 async def test_autodiscovery_disabled(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """Test that power sensors are not automatically added when auto discovery is disabled"""
 
-    mock_entity_with_model_information("light.testa", "lidl", "HG06106C")
+    mock_device_with_entities(hass, "light.testa", "lidl", "HG06106C")
 
     await run_powercalc_setup(hass, {}, {CONF_DISCOVERY: {CONF_ENABLED: False}})
 
@@ -143,7 +156,6 @@ async def test_autodiscovery_disabled(
 async def test_autodiscovery_skipped_for_lut_with_subprofiles(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Lights which can be autodiscovered and have sub profiles need to be skipped
@@ -152,7 +164,8 @@ async def test_autodiscovery_skipped_for_lut_with_subprofiles(
     """
     caplog.set_level(logging.ERROR)
 
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.testa",
         "Yeelight",
         "strip6",
@@ -168,9 +181,8 @@ async def test_autodiscovery_skipped_for_lut_with_subprofiles(
 async def test_manually_configured_light_overrides_autodiscovered(
     hass: HomeAssistant,
     mock_flow_init: AsyncMock,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information("light.testing", "signify", "LCA001")
+    mock_device_with_entities(hass, "light.testing", "signify", "LCA001")
     await set_states(hass, [("light.testing", STATE_ON)])
     await run_powercalc_setup(
         hass,
@@ -185,11 +197,11 @@ async def test_manually_configured_light_overrides_autodiscovered(
 async def test_config_entry_overrides_autodiscovered(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.testing",
         "signify",
         "LWA017",
@@ -272,7 +284,6 @@ async def test_config_entry_overrides_autodiscovered(
 )
 async def test_autodiscover_skipped(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
     entity_id: str,
     manufacturer: str,
@@ -280,7 +291,8 @@ async def test_autodiscover_skipped(
     extra_kwargs: dict,
 ) -> None:
     """Test that auto discovery skips entities based on various conditions."""
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         entity_id,
         manufacturer,
         model,
@@ -294,31 +306,13 @@ async def test_autodiscover_skipped(
 
 async def test_autodiscover_continues_when_one_entity_fails(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Auto discovery should continue when one entity fails to load model information"""
 
     caplog.set_level(logging.ERROR)
 
-    mock_device(hass, "signify-device", "signify", "LCT010")
-    mock_registry(
-        hass,
-        {
-            "light.test1": RegistryEntryWithDefaults(
-                entity_id="light.test1",
-                unique_id="1234",
-                platform="light",
-                device_id="signify-device",
-            ),
-            "light.test2": RegistryEntryWithDefaults(
-                entity_id="light.test2",
-                unique_id="1235",
-                platform="light",
-                device_id="signify-device",
-            ),
-        },
-    )
+    mock_device_with_entities(hass, ["light.test1", "light.test2"])
     with patch(
         "custom_components.powercalc.power_profile.library.ProfileLibrary.find_models",
         new_callable=AsyncMock,
@@ -330,55 +324,24 @@ async def test_autodiscover_continues_when_one_entity_fails(
 
 async def test_exclude_device_types(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
     """Test that entities with excluded device types are not considered for discovery"""
 
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "switch-device": DeviceEntry(
-                config_entry_id="test",
-                id="switch-device",
-                manufacturer="shelly",
-                model="SHPLG-S",
-            ),
-            "light-device": DeviceEntry(
-                config_entry_id="test",
-                id="light-device",
-                manufacturer="signify",
-                model="LCT010",
-            ),
-            "cover-device": DeviceEntry(
-                config_entry_id="test",
-                id="cover-device",
-                manufacturer="eq-3",
-                model="HmIP-FROLL",
-            ),
+            "switch-device": {"manufacturer": "shelly", "model": "SHPLG-S"},
+            "light-device": {"manufacturer": "signify", "model": "LCT010"},
+            "cover-device": {"manufacturer": "eq-3", "model": "HmIP-FROLL"},
         },
     )
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.test": RegistryEntryWithDefaults(
-                entity_id="light.test",
-                unique_id="1111",
-                platform="hue",
-                device_id="light-device",
-            ),
-            "switch.test": RegistryEntryWithDefaults(
-                entity_id="switch.test",
-                unique_id="2222",
-                platform="shelly",
-                device_id="switch-device",
-            ),
-            "cover.test": RegistryEntryWithDefaults(
-                entity_id="cover.test",
-                unique_id="3333",
-                platform="shelly",
-                device_id="cover-device",
-            ),
+            "light.test": {"platform": "hue", "device_id": "light-device"},
+            "switch.test": {"platform": "shelly", "device_id": "switch-device"},
+            "cover.test": {"platform": "shelly", "device_id": "cover-device"},
         },
     )
 
@@ -400,11 +363,11 @@ async def test_exclude_device_types(
 
 async def test_exclude_self_usage(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
     """Test that entities with excluded device types are not considered for discovery"""
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "switch.test",
         "test",
         "smart_switch_with_pm_new",
@@ -425,12 +388,12 @@ async def test_exclude_self_usage(
 
 async def test_load_model_with_slashes(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Discovered model with slashes should not be treated as a sub lut profile
     """
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.testa",
         "ikea",
         "TRADFRI bulb E14 W op/ch 400lm",
@@ -444,22 +407,11 @@ async def test_load_model_with_slashes(
 
 
 async def test_get_power_profile_by_source_device_returns_none_without_required_entries(hass: HomeAssistant) -> None:
-    device_entry = DeviceEntry(
-        config_entry_id="test",
-        id="test-device",
-        manufacturer="test",
-        model="discovery_type_device",
-    )
-    mock_device_registry(hass, {device_entry.id: device_entry})
-    mock_registry(
+    device_entry = mock_device(hass, model="discovery_type_device")
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test": RegistryEntryWithDefaults(
-                entity_id="sensor.test",
-                unique_id="test-entity",
-                device_id=device_entry.id,
-                platform="test",
-            ),
+            "sensor.test": {"unique_id": "test-entity", "device_id": device_entry.id, "platform": "test"},
         },
     )
 
@@ -534,13 +486,12 @@ async def test_discover_entity(
     model_info: ModelInfo,
     expected_manufacturer: str | None,
     expected_model: str | None,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     Test the autodiscovery lookup from the library by manufacturer and model information
     A given entity_entry is trying to be matched in the library and a PowerProfile instance returned when it is matched
     """
-    mock_entity_with_model_information(entity_id, model_info.manufacturer, model_info.model, model_info.model_id)
+    mock_device_with_entities(hass, entity_id, model_info.manufacturer, model_info.model, model_info.model_id)
 
     source_entity = create_source_entity(entity_id, hass)
     power_profile = await get_power_profile_by_source_entity(hass, source_entity)
@@ -555,7 +506,6 @@ async def test_discover_entity(
 
 async def test_same_entity_is_not_discovered_twice(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
     await create_mock_config_entry(
@@ -571,7 +521,7 @@ async def test_same_entity_is_not_discovered_twice(
         setup=False,
     )
 
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     await run_powercalc_setup(hass)
 
@@ -581,7 +531,6 @@ async def test_same_entity_is_not_discovered_twice(
 
 async def test_wled_not_discovered_twice(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
     await create_mock_config_entry(
@@ -605,7 +554,7 @@ async def test_wled_not_discovered_twice(
         setup=False,
     )
 
-    mock_entity_with_model_information("light.test", "WLED", "FOSS")
+    mock_device_with_entities(hass, "light.test", "WLED", "FOSS")
 
     await run_powercalc_setup(hass)
 
@@ -615,10 +564,9 @@ async def test_wled_not_discovered_twice(
 
 async def test_wled_skipped_when_light_device_type_excluded(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
-    mock_entity_with_model_information("light.test", "WLED", "FOSS")
+    mock_device_with_entities(hass, "light.test", "WLED", "FOSS")
 
     await run_powercalc_setup(
         hass,
@@ -632,7 +580,6 @@ async def test_wled_skipped_when_light_device_type_excluded(
 
 async def test_govee_segment_lights_skipped(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
     """
@@ -641,33 +588,29 @@ async def test_govee_segment_lights_skipped(
     """
     mock_device(hass, "govee-device", "Govee", "H6076")
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.floor_lamp_livingroom": RegistryEntryWithDefaults(
-                entity_id="light.floor_lamp_livingroom",
-                unique_id="gv2mqtt-F23DD0C844866B65",
-                platform="mqtt",
-                device_id="govee-device",
-            ),
-            "light.floor_lamp_livingroom_segment_001": RegistryEntryWithDefaults(
-                entity_id="light.floor_lamp_livingroom_segment_001",
-                unique_id="gv2mqtt-F23DD0C844866B65-0",
-                platform="mqtt",
-                device_id="govee-device",
-            ),
-            "light.floor_lamp_livingroom_segment_002": RegistryEntryWithDefaults(
-                entity_id="light.floor_lamp_livingroom_segment_002",
-                unique_id="gv2mqtt-F23DD0C844866B65-1",
-                platform="mqtt",
-                device_id="govee-device",
-            ),
-            "light.floor_lamp_livingroom_segment_003": RegistryEntryWithDefaults(
-                entity_id="light.floor_lamp_livingroom_segment_003",
-                unique_id="gv2mqtt-F23DD0C844866B65-2",
-                platform="mqtt",
-                device_id="govee-device",
-            ),
+            "light.floor_lamp_livingroom": {
+                "unique_id": "gv2mqtt-F23DD0C844866B65",
+                "platform": "mqtt",
+                "device_id": "govee-device",
+            },
+            "light.floor_lamp_livingroom_segment_001": {
+                "unique_id": "gv2mqtt-F23DD0C844866B65-0",
+                "platform": "mqtt",
+                "device_id": "govee-device",
+            },
+            "light.floor_lamp_livingroom_segment_002": {
+                "unique_id": "gv2mqtt-F23DD0C844866B65-1",
+                "platform": "mqtt",
+                "device_id": "govee-device",
+            },
+            "light.floor_lamp_livingroom_segment_003": {
+                "unique_id": "gv2mqtt-F23DD0C844866B65-2",
+                "platform": "mqtt",
+                "device_id": "govee-device",
+            },
         },
     )
 
@@ -680,11 +623,10 @@ async def test_govee_segment_lights_skipped(
 async def test_get_power_profile_empty_manufacturer(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    mock_entity_with_model_information("light.test", "", "some model")
+    mock_device_with_entities(hass, "light.test", "", "some model")
 
     source_entity = create_source_entity("light.test", hass)
     profile = await get_power_profile_by_source_entity(hass, source_entity)
@@ -696,12 +638,12 @@ async def test_get_power_profile_empty_manufacturer(
 async def test_no_power_sensors_are_created_for_ignored_config_entries(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
     unique_id = "abc"
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         "light.test",
         "Signify",
         "LCT010",
@@ -788,19 +730,18 @@ async def test_get_model_information(
 
 async def test_interval_based_rediscovery(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     await run_powercalc_setup(hass)
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=2))
+    await async_advance_time(hass, timedelta(hours=2), block=False)
     await hass.async_block_till_done(True)
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=2))
+    await async_advance_time(hass, timedelta(hours=2), block=False)
     await hass.async_block_till_done(True)
 
     assert len([record for record in caplog.records if "Start auto discovery" in record.message]) == 3
@@ -808,12 +749,11 @@ async def test_interval_based_rediscovery(
 
 async def test_update_profile_service(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     await run_powercalc_setup(hass)
 
@@ -850,15 +790,14 @@ async def test_discovery_by_config_entry(
 ) -> None:
     source_entry = MockConfigEntry(domain="test", title="Shared integration")
     source_entry.add_to_hass(hass)
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            f"device-{index}": DeviceEntry(
-                config_entry_id=source_entry.entry_id,
-                id=f"device-{index}",
-                manufacturer="test",
-                model="discovery_type_config_entry",
-            )
+            f"device-{index}": {
+                "config_entry_id": source_entry.entry_id,
+                "manufacturer": "test",
+                "model": "discovery_type_config_entry",
+            }
             for index in range(6)
         },
     )
@@ -878,20 +817,15 @@ async def test_discovery_by_config_entry(
 async def test_composite_devices_are_ignored_for_device_discovery(
     hass: HomeAssistant,
 ) -> None:
-    regular_device = DeviceEntry(config_entry_id="test", id="regular-device", manufacturer="test", model="regular")
-    composite_device = DeviceEntry(
-        config_entry_id="test",
-        id="composite-device",
-        manufacturer="test",
-        model="composite",
-    )
-    mock_device_registry(
+    mocked_devices = mock_devices(
         hass,
         {
-            regular_device.id: regular_device,
-            composite_device.id: composite_device,
+            "regular-device": {"manufacturer": "test", "model": "regular"},
+            "composite-device": {"manufacturer": "test", "model": "composite"},
         },
     )
+    regular_device = mocked_devices["regular-device"]
+    composite_device = mocked_devices["composite-device"]
     discovery_manager = DiscoveryManager(hass, {})
 
     with patch(
@@ -909,21 +843,11 @@ async def test_powercalc_sensors_are_ignored_for_discovery(
 ) -> None:
     """Powercalc sensors should not be considered for discovery"""
     mock_device(hass, "my-device", "test", "generic-iot")
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_powercalc": RegistryEntryWithDefaults(
-                entity_id="sensor.test_powercalc",
-                unique_id="1111",
-                platform="powercalc",
-                device_id="my-device",
-            ),
-            "sensor.test_other": RegistryEntryWithDefaults(
-                entity_id="sensor.test_other",
-                unique_id="2222",
-                platform="other-platform",
-                device_id="my-device",
-            ),
+            "sensor.test_powercalc": {"platform": "powercalc", "device_id": "my-device"},
+            "sensor.test_other": {"platform": "other-platform", "device_id": "my-device"},
         },
     )
 
@@ -1010,10 +934,9 @@ async def test_get_entities(
 
 async def test_discovery_enable_runtime(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     mock_flow_init: AsyncMock,
 ) -> None:
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     entry = await create_mock_global_config_entry(
         hass,
@@ -1038,11 +961,10 @@ async def test_discovery_enable_runtime(
 
 async def test_discovery_disable_runtime(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG)
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     entry = await create_mock_global_config_entry(
         hass,
@@ -1062,7 +984,7 @@ async def test_discovery_disable_runtime(
     assert len(flows) == 0
 
     caplog.clear()
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=2))
+    await async_advance_time(hass, timedelta(hours=2), block=False)
     await hass.async_block_till_done(True)
 
     assert "Start auto discovery" not in caplog.text
@@ -1077,10 +999,9 @@ async def test_discovery_disable_runtime(
 )
 async def test_discovery_disabled(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
     global_config: dict[str, Any],
 ) -> None:
-    mock_entity_with_model_information("light.test", "signify", "LCT010")
+    mock_device_with_entities(hass, "light.test", "signify", "LCT010")
 
     await run_powercalc_setup(hass, {}, global_config)
 
@@ -1113,42 +1034,21 @@ async def test_discovery_process_is_locked(hass: HomeAssistant, caplog: pytest.L
 async def test_discovery_compatible_integrations(
     hass: HomeAssistant,
     mock_flow_init: AsyncMock,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """Test that only entities with compatible integrations are discovered."""
 
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "light.hue_light": RegistryEntryWithDefaults(
-                entity_id="light.hue_light",
-                unique_id="1111",
-                platform="hue",
-                device_id="hue-device-id",
-            ),
-            "light.other_light": RegistryEntryWithDefaults(
-                entity_id="light.other_light",
-                unique_id="2222",
-                platform="other",
-                device_id="other-device-id",
-            ),
+            "light.hue_light": {"platform": "hue", "device_id": "hue-device-id"},
+            "light.other_light": {"platform": "other", "device_id": "other-device-id"},
         },
     )
-    mock_device_registry(
+    mock_devices(
         hass,
         {
-            "hue-device-id": DeviceEntry(
-                config_entry_id="test",
-                id="hue-device-id",
-                manufacturer="test",
-                model="compatible_integrations",
-            ),
-            "other-device-id": DeviceEntry(
-                config_entry_id="test",
-                id="other-device-id",
-                manufacturer="test",
-                model="compatible_integrations",
-            ),
+            "hue-device-id": {"manufacturer": "test", "model": "compatible_integrations"},
+            "other-device-id": {"manufacturer": "test", "model": "compatible_integrations"},
         },
     )
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,7 +10,6 @@ from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.template import Template
 import pytest
-from pytest_homeassistant_custom_component.common import RegistryEntryWithDefaults, mock_registry
 
 from custom_components.powercalc.common import SourceEntity
 from custom_components.powercalc.const import DUMMY_ENTITY_ID, PLACEHOLDER_ENTITY_BY_DEVICE_CLASS, CalculationStrategy
@@ -25,7 +24,7 @@ from custom_components.powercalc.helpers import (
     resolve_related_entity_placeholder,
 )
 from custom_components.powercalc.unit import evaluate_to_decimal
-from tests.common import get_test_profile_dir
+from tests.common import get_test_profile_dir, mock_entities_in_registry
 
 
 @pytest.mark.parametrize(
@@ -104,23 +103,11 @@ def test_get_related_entity_by_device_class_no_device_id(hass: HomeAssistant, ca
 
 
 def test_get_related_entity_by_translation_key(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_power": RegistryEntryWithDefaults(
-                entity_id="sensor.test_power",
-                unique_id="1234",
-                platform="test",
-                device_id="device_1",
-                translation_key="power",
-            ),
-            "sensor.test_energy": RegistryEntryWithDefaults(
-                entity_id="sensor.test_energy",
-                unique_id="5678",
-                platform="test",
-                device_id="device_1",
-                translation_key="energy",
-            ),
+            "sensor.test_power": {"platform": "test", "device_id": "device_1", "translation_key": "power"},
+            "sensor.test_energy": {"platform": "test", "device_id": "device_1", "translation_key": "energy"},
         },
     )
 
@@ -169,16 +156,14 @@ def test_resolve_related_entity_placeholder_no_source_entity(hass: HomeAssistant
 
 
 def test_resolve_related_entity_placeholder_unknown_device_class(hass: HomeAssistant) -> None:
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            "sensor.test_battery": RegistryEntryWithDefaults(
-                entity_id="sensor.test_battery",
-                unique_id="1234",
-                platform="test",
-                device_id="device_1",
-                device_class=SensorDeviceClass.BATTERY,
-            ),
+            "sensor.test_battery": {
+                "platform": "test",
+                "device_id": "device_1",
+                "device_class": SensorDeviceClass.BATTERY,
+            },
         },
     )
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_UNIQUE_ID,
+    STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
@@ -44,21 +45,19 @@ from custom_components.powercalc.const import (
     ENTRY_GLOBAL_CONFIG_UNIQUE_ID,
     SensorType,
 )
-from tests.common import set_states
+from tests.common import create_mock_group_entry, mock_device_with_entities, set_states
 
 from .common import (
     assert_entity_state,
-    create_input_boolean,
     create_mock_config_entry,
     create_mocked_virtual_power_sensor_entry,
     get_simple_fixed_config,
     run_powercalc_setup,
 )
-from .conftest import MockEntityWithModel
 
 
 async def test_domain_groups(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     domain_config = {
         CONF_DISCOVERY: {
@@ -76,9 +75,7 @@ async def test_domain_groups(hass: HomeAssistant, entity_registry: EntityRegistr
         domain_config,
     )
 
-    group_state = hass.states.get("sensor.all_input_boolean_power")
-    assert group_state
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.test_power"}
+    assert_entity_state(hass, "sensor.all_input_boolean_power", attributes={ATTR_ENTITIES: {"sensor.test_power"}})
 
     assert_entity_state(hass, "sensor.all_light_power", STATE_UNAVAILABLE)
 
@@ -109,12 +106,11 @@ async def test_unload_entry(hass: HomeAssistant, entity_registry: EntityRegistry
 
 async def test_domain_group_with_utility_meter(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """
     See https://github.com/bramstroker/homeassistant-powercalc/issues/939
     """
-    mock_entity_with_model_information("light.testb", "signify", "LCA001")
+    mock_device_with_entities(hass, "light.testb", "signify", "LCA001")
 
     await create_mock_config_entry(
         hass,
@@ -183,15 +179,12 @@ async def test_repair_issue_with_none_sensors(hass: HomeAssistant) -> None:
     power_entry = await create_mocked_virtual_power_sensor_entry(hass, "Power")
 
     none_entries = [
-        await create_mock_config_entry(
+        await create_mock_group_entry(
             hass,
-            {
-                CONF_SENSOR_TYPE: SensorType.GROUP,
-                CONF_NAME: "None",
-                CONF_GROUP_MEMBER_SENSORS: [power_entry.entry_id],
-            },
             "None",
-            "None",
+            {CONF_GROUP_MEMBER_SENSORS: [power_entry.entry_id]},
+            unique_id="None",
+            title="None",
         )
         for _ in range(10)
     ]

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -7,7 +7,7 @@ from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.issue_registry import IssueRegistry
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry, mock_device_registry
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.powercalc import (
     CONF_DISCOVERY_EXCLUDE_SELF_USAGE_DEPRECATED,
@@ -46,7 +46,7 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.power_profile.library import ModelInfo
-from tests.common import migrate_legacy_entry, run_powercalc_setup
+from tests.common import migrate_legacy_entry, mock_devices, run_powercalc_setup
 
 COMPOSITE_ID = "composite00000000000000000000ab"
 
@@ -235,22 +235,24 @@ async def test_migrate_config_entry_removes_split_helper_device(
     powercalc_entry = MockConfigEntry(domain=DOMAIN, data=powercalc_entry_data, version=8)
     powercalc_entry.add_to_hass(hass)
 
-    source_device = dr.DeviceEntry(
-        id="source-device",
-        config_entry_id=source_entry.entry_id,
-        identifiers={("test", "source")},
-        composite_device_id=COMPOSITE_ID,
-    )
-    helper_device = dr.DeviceEntry(
-        id="helper-device",
-        config_entry_id=powercalc_entry.entry_id,
-        identifiers={(DOMAIN, "helper")},
-        composite_device_id=COMPOSITE_ID,
-    )
-    device_registry = mock_device_registry(
+    devices = mock_devices(
         hass,
-        {source_device.id: source_device, helper_device.id: helper_device},
+        {
+            "source-device": {
+                "config_entry_id": source_entry.entry_id,
+                "identifiers": {("test", "source")},
+                "composite_device_id": COMPOSITE_ID,
+            },
+            "helper-device": {
+                "config_entry_id": powercalc_entry.entry_id,
+                "identifiers": {(DOMAIN, "helper")},
+                "composite_device_id": COMPOSITE_ID,
+            },
+        },
     )
+    device_registry = dr.async_get(hass)
+    source_device = devices["source-device"]
+    helper_device = devices["helper-device"]
     helper_entity = entity_registry.async_get_or_create(
         "sensor",
         DOMAIN,
@@ -273,12 +275,10 @@ async def test_migrate_config_entry_removes_legacy_device_link(hass: HomeAssista
     """Test migration removes the legacy device link on older HA versions."""
     powercalc_entry = MockConfigEntry(domain=DOMAIN, version=8)
     powercalc_entry.add_to_hass(hass)
-    device_entry = dr.DeviceEntry(
-        id="source-device",
-        config_entry_id=powercalc_entry.entry_id,
-        identifiers={("test", "source")},
-    )
-    mock_device_registry(hass, {device_entry.id: device_entry})
+    device_entry = mock_devices(
+        hass,
+        {"source-device": {"config_entry_id": powercalc_entry.entry_id, "identifiers": {("test", "source")}}},
+    )["source-device"]
     remove_legacy_link = Mock()
 
     with (

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -5,7 +5,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 import pytest
-from pytest_homeassistant_custom_component.common import mock_device_registry
 
 from custom_components.powercalc import CONF_SENSOR_TYPE, DOMAIN, SensorType
 from custom_components.powercalc.const import (
@@ -16,7 +15,7 @@ from custom_components.powercalc.const import (
     ISSUE_COMPOSITE_DEVICE_ID,
 )
 from custom_components.powercalc.repairs import async_create_fix_flow
-from tests.common import create_mock_config_entry
+from tests.common import create_mock_config_entry, mock_devices
 
 COMPOSITE_ID = "composite00000000000000000000ab"
 
@@ -87,20 +86,22 @@ def split_devices(
     hass: HomeAssistant,
 ) -> tuple[dr.DeviceEntry, dr.DeviceEntry]:
     """Create two devices split from the same pre-migration composite device."""
-    device_1 = dr.DeviceEntry(
-        config_entry_id="test-entry-1",
-        id="split-device-1",
-        name="Split device 1",
-        composite_device_id=COMPOSITE_ID,
+    devices = mock_devices(
+        hass,
+        {
+            "split-device-1": {
+                "config_entry_id": "test-entry-1",
+                "name": "Split device 1",
+                "composite_device_id": COMPOSITE_ID,
+            },
+            "split-device-2": {
+                "config_entry_id": "test-entry-2",
+                "name": "Split device 2",
+                "composite_device_id": COMPOSITE_ID,
+            },
+        },
     )
-    device_2 = dr.DeviceEntry(
-        config_entry_id="test-entry-2",
-        id="split-device-2",
-        name="Split device 2",
-        composite_device_id=COMPOSITE_ID,
-    )
-    mock_device_registry(hass, {device_1.id: device_1, device_2.id: device_2})
-    return device_1, device_2
+    return devices["split-device-1"], devices["split-device-2"]
 
 
 @pytest.mark.usefixtures("split_devices")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -31,10 +31,6 @@ import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 import pytest
-from pytest_homeassistant_custom_component.common import (
-    RegistryEntryWithDefaults,
-    mock_registry,
-)
 
 from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
@@ -75,21 +71,19 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.errors import SensorConfigurationError
-from tests.common import set_states
+from tests.common import mock_device_with_entities, mock_entities_in_registry, set_states
 
 from .common import (
     assert_entity_state,
-    create_input_boolean,
     create_mock_config_entry,
     get_simple_fixed_config,
     run_powercalc_setup,
 )
 from .config_flow.common import fixed_value_choice, handle_options_flow_update
-from .conftest import MockEntityWithModel
 
 
 async def test_fixed_power_sensor_from_yaml(hass: HomeAssistant) -> None:
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -99,17 +93,26 @@ async def test_fixed_power_sensor_from_yaml(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "sensor.test_power", "0.00")
 
     await set_states(hass, [("input_boolean.test", STATE_ON)])
-    power_state = hass.states.get("sensor.test_power")
-    assert power_state
-    assert power_state.state == "50.00"
-    assert power_state.attributes.get(ATTR_CALCULATION_MODE) == CalculationStrategy.FIXED
-    assert power_state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
+    assert_entity_state(
+        hass,
+        "sensor.test_power",
+        "50.00",
+        attributes={
+            ATTR_CALCULATION_MODE: CalculationStrategy.FIXED,
+            ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
+        },
+    )
 
-    energy_state = hass.states.get("sensor.test_energy")
-    assert energy_state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
-    assert energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
-    assert energy_state.attributes.get(ATTR_SOURCE_ID) == "sensor.test_power"
-    assert energy_state.attributes.get(ATTR_SOURCE_ENTITY) == "input_boolean.test"
+    assert_entity_state(
+        hass,
+        "sensor.test_energy",
+        attributes={
+            ATTR_DEVICE_CLASS: SensorDeviceClass.ENERGY,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR,
+            ATTR_SOURCE_ID: "sensor.test_power",
+            ATTR_SOURCE_ENTITY: "input_boolean.test",
+        },
+    )
 
 
 async def test_legacy_yaml_platform_configuration(
@@ -180,19 +183,29 @@ async def test_create_nested_group_sensor(hass: HomeAssistant) -> None:
         block_count=3,
     )
 
-    group1 = hass.states.get("sensor.testgroup1_power")
-    assert group1.attributes[ATTR_ENTITIES] == {
-        "sensor.test_power",
-        "sensor.test1_power",
-        "sensor.test2_power",
-    }
-    assert group1.state == "150.00"
+    assert_entity_state(
+        hass,
+        "sensor.testgroup1_power",
+        "150.00",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test_power",
+                "sensor.test1_power",
+                "sensor.test2_power",
+            },
+        },
+    )
 
-    group2 = hass.states.get("sensor.testgroup2_power")
-    assert group2.attributes[ATTR_ENTITIES] == {
-        "sensor.test2_power",
-    }
-    assert group2.state == "50.00"
+    assert_entity_state(
+        hass,
+        "sensor.testgroup2_power",
+        "50.00",
+        attributes={
+            ATTR_ENTITIES: {
+                "sensor.test2_power",
+            },
+        },
+    )
 
     with patch(
         "homeassistant.util.utcnow",
@@ -246,10 +259,10 @@ async def test_create_nested_handles_exception(hass: HomeAssistant, caplog: pyte
 
 async def test_light_lut_strategy(
     hass: HomeAssistant,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     light_entity_id = "light.test1"
-    mock_entity_with_model_information(
+    mock_device_with_entities(
+        hass,
         light_entity_id,
         "signify",
         "LWB010",
@@ -270,12 +283,16 @@ async def test_light_lut_strategy(
         {CONF_ENTITY_ID: light_entity_id},
     )
 
-    state = hass.states.get("sensor.test1_power")
-    assert state
-    assert state.state == "2.67"
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
-    assert state.attributes.get(ATTR_CALCULATION_MODE) == CalculationStrategy.LUT
-    assert state.attributes.get(ATTR_SOURCE_ENTITY) == light_entity_id
+    assert_entity_state(
+        hass,
+        "sensor.test1_power",
+        "2.67",
+        attributes={
+            ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
+            ATTR_CALCULATION_MODE: CalculationStrategy.LUT,
+            ATTR_SOURCE_ENTITY: light_entity_id,
+        },
+    )
 
 
 async def test_error_when_configuring_same_entity_twice(
@@ -312,12 +329,8 @@ async def test_alternate_naming_strategy(hass: HomeAssistant) -> None:
         },
     )
 
-    power_state = hass.states.get("sensor.test_power_consumption")
-    assert power_state
-    assert power_state.attributes.get(ATTR_FRIENDLY_NAME) == "test Power friendly"
-    energy_state = hass.states.get("sensor.test_energy_kwh")
-    assert energy_state
-    assert energy_state.attributes.get(ATTR_FRIENDLY_NAME) == "test Energy friendly"
+    assert_entity_state(hass, "sensor.test_power_consumption", attributes={ATTR_FRIENDLY_NAME: "test Power friendly"})
+    assert_entity_state(hass, "sensor.test_energy_kwh", attributes={ATTR_FRIENDLY_NAME: "test Energy friendly"})
 
 
 async def test_can_create_same_entity_twice_with_unique_id(hass: HomeAssistant) -> None:
@@ -348,9 +361,8 @@ async def test_can_create_same_entity_twice_with_unique_id(hass: HomeAssistant) 
 async def test_unsupported_model_is_skipped_from_autodiscovery(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
-    mock_entity_with_model_information("light.test", "lidl", "non_existing_model")
+    mock_device_with_entities(hass, "light.test", "lidl", "non_existing_model")
 
     # Run powercalc setup with autodiscovery
     await run_powercalc_setup(hass)
@@ -361,13 +373,12 @@ async def test_unsupported_model_is_skipped_from_autodiscovery(
 async def test_can_include_autodiscovered_entity_in_group(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    mock_entity_with_model_information: MockEntityWithModel,
 ) -> None:
     """Test that models are automatically discovered and power sensors created"""
 
     caplog.set_level(logging.ERROR)
 
-    mock_entity_with_model_information("light.testa", "lidl", "HG06462A")
+    mock_device_with_entities(hass, "light.testa", "lidl", "HG06462A")
 
     await set_states(
         hass,
@@ -392,32 +403,23 @@ async def test_can_include_autodiscovered_entity_in_group(
     assert len(caplog.records) == 0
 
     assert hass.states.get("sensor.testa_power")
-    group_state = hass.states.get("sensor.groupa_power")
-    assert group_state.attributes.get(ATTR_ENTITIES) == {"sensor.testa_power"}
+    assert_entity_state(hass, "sensor.groupa_power", attributes={ATTR_ENTITIES: {"sensor.testa_power"}})
 
 
-async def test_user_can_rename_entity_id(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-) -> None:
+async def test_user_can_rename_entity_id(hass: HomeAssistant) -> None:
     """
     When the power/energy sensors exist already with an unique ID, don't change the entity ID
     This allows the users to change the entity ID's from the GUI
     """
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        "abcdef",
-        suggested_object_id="my_renamed_power",
-    )
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        "abcdef_energy",
-        suggested_object_id="my_renamed_energy",
+    mock_entities_in_registry(
+        hass,
+        {
+            "sensor.my_renamed_power": {"unique_id": "abcdef", "platform": DOMAIN},
+            "sensor.my_renamed_energy": {"unique_id": "abcdef_energy", "platform": DOMAIN},
+        },
     )
 
-    await create_input_boolean(hass)
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
 
     await run_powercalc_setup(
         hass,
@@ -432,9 +434,7 @@ async def test_user_can_rename_entity_id(
     assert hass.states.get("sensor.my_renamed_power")
     assert not hass.states.get("sensor.test_power")
 
-    energy_state = hass.states.get("sensor.my_renamed_energy")
-    assert energy_state
-    assert energy_state.attributes.get("source") == "sensor.my_renamed_power"
+    assert_entity_state(hass, "sensor.my_renamed_energy", attributes={"source": "sensor.my_renamed_power"})
     assert not hass.states.get("sensor.test_energy")
 
 
@@ -488,19 +488,11 @@ async def test_change_options_of_renamed_sensor(
     assert hass.states.get("sensor.test_energy_daily").name == "Renamed daily utility meter"
 
 
-async def test_renaming_sensor_is_retained_after_startup(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    entity_registry.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        "abcdef",
-        suggested_object_id="test_power",
+async def test_renaming_sensor_is_retained_after_startup(hass: HomeAssistant) -> None:
+    mock_entities_in_registry(
+        hass,
+        {"sensor.test_power": {"unique_id": "abcdef", "platform": DOMAIN, "name": "Renamed power"}},
     )
-    await hass.async_block_till_done()
-    entity_registry.async_update_entity(entity_id="sensor.test_power", name="Renamed power")
-    await hass.async_block_till_done()
     await create_mock_config_entry(
         hass,
         {
@@ -577,15 +569,10 @@ async def test_create_config_entry_without_energy_sensor(
 
 async def test_rename_source_entity_id(hass: HomeAssistant) -> None:
     light_id = "sensor.my_light"
-    entity_reg = mock_registry(
+    entity_reg = mock_entities_in_registry(
         hass,
         {
-            light_id: RegistryEntryWithDefaults(
-                entity_id=light_id,
-                disabled_by=er.RegistryEntryDisabler.DEVICE,
-                unique_id="1234",
-                platform="light",
-            ),
+            light_id: {"disabled_by": er.RegistryEntryDisabler.DEVICE, "platform": "light"},
         },
     )
 
@@ -609,10 +596,7 @@ async def test_rename_source_entity_id(hass: HomeAssistant) -> None:
     changed_entry = hass.config_entries.async_get_entry(entry.entry_id)
     assert changed_entry.data.get(CONF_ENTITY_ID) == new_light_id
     await set_states(hass, [(new_light_id, STATE_ON)])
-    power_state = hass.states.get("sensor.testentry_power")
-    assert power_state
-    assert power_state.state == "50.00"
-    assert power_state.attributes.get(ATTR_SOURCE_ENTITY) == new_light_id
+    assert_entity_state(hass, "sensor.testentry_power", "50.00", attributes={ATTR_SOURCE_ENTITY: new_light_id})
 
 
 async def test_change_config_entry_entity_id(hass: HomeAssistant) -> None:
@@ -622,19 +606,11 @@ async def test_change_config_entry_entity_id(hass: HomeAssistant) -> None:
     original_unique_id = "aaaa"
     new_light_id = "light.new"
     new_unique_id = "bbbb"
-    mock_registry(
+    mock_entities_in_registry(
         hass,
         {
-            original_light_id: RegistryEntryWithDefaults(
-                entity_id=original_light_id,
-                unique_id=original_unique_id,
-                platform="light",
-            ),
-            new_light_id: RegistryEntryWithDefaults(
-                entity_id=original_light_id,
-                unique_id=new_unique_id,
-                platform="light",
-            ),
+            original_light_id: {"unique_id": original_unique_id, "platform": "light"},
+            new_light_id: {"unique_id": new_unique_id, "platform": "light"},
         },
     )
 
@@ -657,9 +633,7 @@ async def test_change_config_entry_entity_id(hass: HomeAssistant) -> None:
     await run_powercalc_setup(hass)
 
     await set_states(hass, [(original_light_id, STATE_ON), (new_light_id, STATE_ON)])
-    power_state = hass.states.get("sensor.testentry_power")
-    assert power_state.attributes.get(ATTR_SOURCE_ENTITY) == original_light_id
-    assert power_state.state == "50.00"
+    assert_entity_state(hass, "sensor.testentry_power", "50.00", attributes={ATTR_SOURCE_ENTITY: original_light_id})
 
     # Change the entity_id and power using the options flow
     await handle_options_flow_update(hass, entry, Step.BASIC_OPTIONS, {CONF_ENTITY_ID: new_light_id})
@@ -668,9 +642,7 @@ async def test_change_config_entry_entity_id(hass: HomeAssistant) -> None:
     changed_entry = hass.config_entries.async_get_entry(entry.entry_id)
     assert changed_entry.data.get(CONF_ENTITY_ID) == new_light_id
     assert changed_entry.unique_id == original_unique_id
-    power_state = hass.states.get("sensor.testentry_power")
-    assert power_state.attributes.get(ATTR_SOURCE_ENTITY) == new_light_id
-    assert power_state.state == "100.00"
+    assert_entity_state(hass, "sensor.testentry_power", "100.00", attributes={ATTR_SOURCE_ENTITY: new_light_id})
 
 
 async def test_regression(hass: HomeAssistant) -> None:

--- a/utils/measure/tests/test_contribution_coordinator.py
+++ b/utils/measure/tests/test_contribution_coordinator.py
@@ -117,29 +117,50 @@ class FakePreparer(ProfilePreparer):
         return tuple((file.path, b"content") for file in preview.files)
 
 
-def test_coordinator_persists_preview_and_submits_idempotently(tmp_path: Path) -> None:
-    preview = ContributionPreview(
+def make_preview() -> ContributionPreview:
+    """The single-file signify/LCT999 preview every coordinator test builds on."""
+    return ContributionPreview(
         manufacturer_directory="signify",
         model_directory="LCT999",
         files=(ContributionPreparedFile(path="profile_library/signify/LCT999/model.json", size=20),),
     )
-    metadata = ContributionMetadata(
+
+
+def make_metadata(github: str = "test-user") -> ContributionMetadata:
+    return ContributionMetadata(
         manufacturer="Philips",
         model_id="LCT999",
-        author=ContributionAuthor(name="Test User", github="test-user"),
-    )
-    credential_store = CredentialStore(tmp_path / "credentials.json")
-    credential_value = "secret"
-    credential_store.save(StoredCredential(kind="pat", token=credential_value, github_username="octo"))
-    github = FakeGitHubClient()
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=credential_store,
-        job_store=ContributionJobStore(tmp_path / "jobs"),
-        github_client=github,
+        author=ContributionAuthor(name="Test User", github=github),
     )
 
-    job = coordinator.create_job(tmp_path / "artifacts", metadata, base_sha="base-sha")
+
+def make_credential_store(tmp_path: Path, kind: str = "pat") -> CredentialStore:
+    """A credential store already holding a token for GitHub user `octo`."""
+    store = CredentialStore(tmp_path / "credentials.json")
+    store.save(StoredCredential(kind=kind, token="secret", github_username="octo"))  # noqa: S106
+    return store
+
+
+def make_coordinator(
+    tmp_path: Path,
+    preview: ContributionPreview | None = None,
+    credential_store: CredentialStore | None = None,
+    github_client: GitHubClient | None = None,
+) -> ContributionJobCoordinator:
+    """A coordinator wired to fakes, storing its jobs under `tmp_path`."""
+    return ContributionJobCoordinator(
+        preparer=FakePreparer(preview or make_preview()),
+        credential_store=credential_store or CredentialStore(tmp_path / "missing.json"),
+        job_store=ContributionJobStore(tmp_path / "jobs"),
+        github_client=github_client,
+    )
+
+
+def test_coordinator_persists_preview_and_submits_idempotently(tmp_path: Path) -> None:
+    github = FakeGitHubClient()
+    coordinator = make_coordinator(tmp_path, credential_store=make_credential_store(tmp_path), github_client=github)
+
+    job = coordinator.create_job(tmp_path / "artifacts", make_metadata(), base_sha="base-sha")
     submitted = coordinator.submit(job.id, tmp_path / "artifacts")
     submitted_again = coordinator.submit(job.id, tmp_path / "artifacts")
 
@@ -157,29 +178,9 @@ def test_coordinator_persists_preview_and_submits_idempotently(tmp_path: Path) -
 
 
 def test_coordinator_targets_configured_repository_and_branch(tmp_path: Path) -> None:
-    preview = ContributionPreview(
-        manufacturer_directory="signify",
-        model_directory="LCT999",
-        files=(ContributionPreparedFile(path="profile_library/signify/LCT999/model.json", size=20),),
-    )
-    credential_store = CredentialStore(tmp_path / "credentials.json")
-    credential_store.save(StoredCredential(kind="pat", token="secret", github_username="octo"))  # noqa: S106
     github = FakeGitHubClient(GitHubRepository(owner="test-owner", name="powercalc-sandbox", branch="main"))
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=credential_store,
-        job_store=ContributionJobStore(tmp_path / "jobs"),
-        github_client=github,
-    )
-    job = coordinator.create_job(
-        tmp_path / "artifacts",
-        ContributionMetadata(
-            manufacturer="Philips",
-            model_id="LCT999",
-            author=ContributionAuthor(name="Test User", github="test-user"),
-        ),
-        base_sha="base-sha",
-    )
+    coordinator = make_coordinator(tmp_path, credential_store=make_credential_store(tmp_path), github_client=github)
+    job = coordinator.create_job(tmp_path / "artifacts", make_metadata(), base_sha="base-sha")
 
     submitted = coordinator.submit(job.id, tmp_path / "artifacts")
 
@@ -199,29 +200,9 @@ def test_coordinator_targets_configured_repository_and_branch(tmp_path: Path) ->
 
 
 def test_coordinator_uses_owned_target_without_trying_to_fork_it(tmp_path: Path) -> None:
-    preview = ContributionPreview(
-        manufacturer_directory="signify",
-        model_directory="LCT999",
-        files=(ContributionPreparedFile(path="profile_library/signify/LCT999/model.json", size=20),),
-    )
-    credential_store = CredentialStore(tmp_path / "credentials.json")
-    credential_store.save(StoredCredential(kind="pat", token="secret", github_username="octo"))  # noqa: S106
     github = FakeGitHubClient(GitHubRepository(owner="octo", name="powercalc-sandbox", branch="main"))
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=credential_store,
-        job_store=ContributionJobStore(tmp_path / "jobs"),
-        github_client=github,
-    )
-    job = coordinator.create_job(
-        tmp_path / "artifacts",
-        ContributionMetadata(
-            manufacturer="Philips",
-            model_id="LCT999",
-            author=ContributionAuthor(name="Test User", github="octo"),
-        ),
-        base_sha="base-sha",
-    )
+    coordinator = make_coordinator(tmp_path, credential_store=make_credential_store(tmp_path), github_client=github)
+    job = coordinator.create_job(tmp_path / "artifacts", make_metadata("octo"), base_sha="base-sha")
 
     submitted = coordinator.submit(job.id, tmp_path / "artifacts")
 
@@ -239,24 +220,8 @@ def test_coordinator_uses_owned_target_without_trying_to_fork_it(tmp_path: Path)
 
 
 def test_coordinator_records_missing_credentials_failure(tmp_path: Path) -> None:
-    preview = ContributionPreview(
-        manufacturer_directory="signify",
-        model_directory="LCT999",
-        files=(ContributionPreparedFile(path="profile_library/signify/LCT999/model.json", size=20),),
-    )
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=CredentialStore(tmp_path / "missing.json"),
-        job_store=ContributionJobStore(tmp_path / "jobs"),
-    )
-    job = coordinator.create_job(
-        tmp_path / "artifacts",
-        ContributionMetadata(
-            manufacturer="Philips",
-            model_id="LCT999",
-            author=ContributionAuthor(name="Test User", github="test-user"),
-        ),
-    )
+    coordinator = make_coordinator(tmp_path)
+    job = coordinator.create_job(tmp_path / "artifacts", make_metadata())
 
     failed = coordinator.submit(job.id, tmp_path / "artifacts")
 
@@ -266,29 +231,14 @@ def test_coordinator_records_missing_credentials_failure(tmp_path: Path) -> None
 
 
 def test_coordinator_reports_missing_workflow_scope_before_writing_fork(tmp_path: Path) -> None:
-    preview = ContributionPreview(
-        manufacturer_directory="signify",
-        model_directory="LCT999",
-        files=(ContributionPreparedFile(path="profile_library/signify/LCT999/model.json", size=20),),
-    )
-    credential_store = CredentialStore(tmp_path / "credentials.json")
-    credential_store.save(StoredCredential(kind="oauth", token="secret", github_username="octo"))  # noqa: S106
     github = FakeGitHubClient()
     github.user = GitHubUser(login="octo", scopes=("public_repo",), scopes_reported=True)
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=credential_store,
-        job_store=ContributionJobStore(tmp_path / "jobs"),
+    coordinator = make_coordinator(
+        tmp_path,
+        credential_store=make_credential_store(tmp_path, kind="oauth"),
         github_client=github,
     )
-    job = coordinator.create_job(
-        tmp_path / "artifacts",
-        ContributionMetadata(
-            manufacturer="Philips",
-            model_id="LCT999",
-            author=ContributionAuthor(name="Test User", github="test-user"),
-        ),
-    )
+    job = coordinator.create_job(tmp_path / "artifacts", make_metadata())
 
     failed = coordinator.submit(job.id, tmp_path / "artifacts")
 
@@ -300,30 +250,10 @@ def test_coordinator_reports_missing_workflow_scope_before_writing_fork(tmp_path
 
 
 def test_coordinator_accepts_classic_repo_scope_as_public_repo(tmp_path: Path) -> None:
-    preview = ContributionPreview(
-        manufacturer_directory="signify",
-        model_directory="LCT999",
-        files=(ContributionPreparedFile(path="profile_library/signify/LCT999/model.json", size=20),),
-    )
-    credential_store = CredentialStore(tmp_path / "credentials.json")
-    credential_store.save(StoredCredential(kind="pat", token="secret", github_username="octo"))  # noqa: S106
     github = FakeGitHubClient()
     github.user = GitHubUser(login="octo", scopes=("repo", "workflow"), scopes_reported=True)
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=credential_store,
-        job_store=ContributionJobStore(tmp_path / "jobs"),
-        github_client=github,
-    )
-    job = coordinator.create_job(
-        tmp_path / "artifacts",
-        ContributionMetadata(
-            manufacturer="Philips",
-            model_id="LCT999",
-            author=ContributionAuthor(name="Test User", github="test-user"),
-        ),
-        base_sha="base-sha",
-    )
+    coordinator = make_coordinator(tmp_path, credential_store=make_credential_store(tmp_path), github_client=github)
+    job = coordinator.create_job(tmp_path / "artifacts", make_metadata(), base_sha="base-sha")
 
     submitted = coordinator.submit(job.id, tmp_path / "artifacts")
 
@@ -337,29 +267,9 @@ def test_coordinator_refreshes_existing_pull_request_with_new_commit(tmp_path: P
             self.calls.append(f"find_pr:{head}:{base}")
             return {"html_url": "https://github.test/pr/7", "number": 7, "head": {"sha": "old-commit"}}
 
-    preview = ContributionPreview(
-        manufacturer_directory="signify",
-        model_directory="LCT999",
-        files=(ContributionPreparedFile(path="profile_library/signify/LCT999/model.json", size=20),),
-    )
-    credential_store = CredentialStore(tmp_path / "credentials.json")
-    credential_store.save(StoredCredential(kind="pat", token="secret", github_username="octo"))  # noqa: S106
     github = ExistingPullRequestClient()
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=credential_store,
-        job_store=ContributionJobStore(tmp_path / "jobs"),
-        github_client=github,
-    )
-    job = coordinator.create_job(
-        tmp_path / "artifacts",
-        ContributionMetadata(
-            manufacturer="Philips",
-            model_id="LCT999",
-            author=ContributionAuthor(name="Test User", github="test-user"),
-        ),
-        base_sha="base-sha",
-    )
+    coordinator = make_coordinator(tmp_path, credential_store=make_credential_store(tmp_path), github_client=github)
+    job = coordinator.create_job(tmp_path / "artifacts", make_metadata(), base_sha="base-sha")
 
     submitted = coordinator.submit(job.id, tmp_path / "artifacts")
 
@@ -374,12 +284,7 @@ def test_coordinator_refreshes_existing_pull_request_with_new_commit(tmp_path: P
 
 
 def test_coordinator_submit_of_unknown_job_reports_expired_preview(tmp_path: Path) -> None:
-    preview = ContributionPreview(manufacturer_directory="signify", model_directory="LCT999", files=())
-    coordinator = ContributionJobCoordinator(
-        preparer=FakePreparer(preview),
-        credential_store=CredentialStore(tmp_path / "missing.json"),
-        job_store=ContributionJobStore(tmp_path / "jobs"),
-    )
+    coordinator = make_coordinator(tmp_path)
 
     with pytest.raises(ContributionJobExpiredError, match="refresh the preview"):
         coordinator.submit("0badc0ffee", tmp_path / "artifacts")


### PR DESCRIPTION
Consolidates repeated setup and assertion code in the test suite behind a small set of helpers in `tests/common.py`.

**Test-only change** — no production code is touched, all 1094 integration tests and 491 measure tests pass, and coverage stays at 100%. Net **-1066 lines** across 55 files.

## Registry helpers

| Helper | Replaces | Sites |
|---|---|---|
| `mock_entities_in_registry(hass, {entity_id: kwargs})` | `mock_registry` + `RegistryEntryWithDefaults` literals | 135 entries |
| `mock_devices(hass, {device_id: kwargs})` | `mock_device_registry` + `DeviceEntry` literals | 13 blocks |
| `mock_device_with_entities(hass, entity_ids, manufacturer, model)` | the `mock_entity_with_model_information` fixture | 54 |

`platform` now defaults to the entity domain and `unique_id` is derived from the entity id, so a test only spells out the fields it cares about.

`mock_device` could only ever register **one** device — each call replaces the whole registry — so any test needing two fell back to raw `DeviceEntry` literals. It now delegates to `mock_devices`, which takes them all at once.

`mock_device_with_entities` composes the two primitives and replaces the old fixture, removing the `MockEntityWithModel` Protocol, a parameter from 54 test signatures and an import from 24 files. The ~43 tests that genuinely need several devices or per-entity kwargs keep using the primitives directly.

## Assertion and timing helpers

- `assert_entity_state()` gained an `attributes` argument and now covers **394** call sites (up from 295).
- `async_advance_time(hass, delta, block=True)` replaces `async_fire_time_changed(hass, dt.utcnow() + timedelta(...))` plus a manual block, at 24 sites.

## No more real entity creation in helpers

`create_input_boolean`/`create_input_booleans` and `create_mock_light_entity`/`create_discoverable_light` set up real Home Assistant components just to get a source entity. Both are gone; tests register the entity and set its state directly.

Checking each of the 19 `create_input_boolean` call sites: **8 needed nothing at all**, 9 needed only a state, and 2 a registry entry (for the unique id Powercalc derives its own from).

Dropping the light platform setup also removed two copies of this workaround:

```python
# Ugly hack, maybe I can figure out something better in the future.
# Light domain is already setup for platform test, remove the component so we can setup light group
if light.DOMAIN in hass.config.components:
    hass.config.components.remove(light.DOMAIN)
```

## Parametrized near-identical tests

Sibling tests differing in one value collapsed in `test_remote.py`, `test_power_meter.py`, `test_lut.py`, `test_local.py`, `test_cost.py`, `test_daily_energy.py` and `test_energy.py`.

## Bugs found on the way

- **Five registry entries whose dict key and `entity_id` disagreed.** `mock_registry` keys by the dict key, but production code iterates and reads `entry.entity_id` — so both values were live in different code paths. `test_include_by_label` and `test_domain_group_all` were asserting against entities that were never registered; both now test what they claim.
- **Two tests called `load_model()` without asserting the result.** It returns `None` on failure, so the local-profile fallback they exist to cover was never actually verified.
- **`test_regression` in `test_utility_meter.py`** had no assertion and a name that said nothing. It guards against duplicate utility meters when two power sensors share one energy sensor — renamed and given an assertion.
- Replaced an `asyncio.sleep(0.1)` (the only wall-clock sleep in the suite) with `async_block_till_done()`.
- Removed 11 unused or shadowed fixture parameters, and converted two side-effect-only fixtures to `@pytest.mark.usefixtures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
