### PR TITLE
Enable renovate automerge for non-major updates

### DIFF
--- a/.github/workflows/validate-lut-files.yml
+++ b/.github/workflows/validate-lut-files.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '**/*.csv.gz'
+      - '.github/scripts/lut_validator/**'
       - '.github/workflows/validate-lut-files.yml'
       - 'utils/library/scan_lut_quality.py'
 

--- a/renovate.json
+++ b/renovate.json
@@ -11,32 +11,51 @@
     "python"
   ],
   "dependencyDashboard": false,
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "automergeStrategy": "squash",
   "packageRules": [
     {
-      "groupName": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ]
-    },
-    {
+      "description": "All non-major updates: one PR, automerged when CI is green",
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "matchUpdateTypes": [
         "minor",
         "patch"
-      ]
+      ],
+      "automerge": true
     },
     {
+      "description": "GitHub Actions: digests and non-major automerged",
       "matchManagers": [
-        "pip_requirements"
+        "github-actions"
       ],
-      "matchFileNames": [
-        "pyproject.toml"
+      "matchUpdateTypes": [
+        "digest",
+        "pin",
+        "patch",
+        "minor"
       ],
-      "enabled": true
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "description": "HA test harness tracks upstream releases, no soak time",
+      "matchPackageNames": [
+        "pytest-homeassistant-custom-component",
+        "homeassistant-stubs"
+      ],
+      "minimumReleaseAge": "0"
+    },
+    {
+      "description": "Majors always get a human",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## What

Enables Renovate automerge for updates that are already covered by CI, and hardens the config against supply chain risk.

### `renovate.json`

- **Automerge all non-major updates.** The existing `all-minor-patch` group and GitHub Actions digest/minor/patch bumps now merge themselves once CI is green. Majors keep requiring a human — the last package rule enforces that unconditionally.
- **`minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"`**, so a compromised or immediately-yanked release is never automerged. Exempted for `pytest-homeassistant-custom-component` and `homeassistant-stubs`, which need to track upstream HA releases without delay.
- **`automergeStrategy: "squash"`** — the repo only allows squash merges.
- Package rules reordered so the catch-all comes first (later rules win), and the deprecated `matchPackagePatterns` replaced with `matchPackageNames`.
- Dropped the `pip_requirements` + `pyproject.toml` rule: it was a no-op, since `pyproject.toml` is handled by the `pep621` manager and `enabled: true` is the default anyway.

### `validate-lut-files.yml`

Added `.github/scripts/lut_validator/**` to the PR path filter. Its npm dependencies (chalk, csval, node-gzip, readdirp) were the only ones in the repo with zero test coverage — now a bump to them runs `npm ci` and the validator against the profile library before it can automerge.

## CI coverage behind the automerge

| Dependency | Gated by |
| --- | --- |
| Python / `uv.lock` | Test |
| `utils/measure/frontend` | Test measure |
| `.github/scripts/lut_validator` | Validate LUT files *(this PR)* |
| Everything, always | Lint (`pre-commit`) |

Note that Renovate waits for *all* checks on the branch to pass, not just the required ones.

## Repo settings (already applied, not in this diff)

- "Allow auto-merge" enabled.
- Ruleset on `master` requiring the `pre-commit` check, with a repository-admin bypass so direct pushes still work. Deliberately does **not** require `Test` / `Test measure` / `Validate LUT files` — they are path-filtered, and a required check that never reports would leave PRs pending forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)