### PR TITLE
Add model.json for Netgear GS110MX network switch

### DIFF
--- a/profile_library/netgear/GS110MX/model.json
+++ b/profile_library/netgear/GS110MX/model.json
@@ -3,8 +3,9 @@
   "measure_device": "Prise Athom",
   "measure_method": "manual",
   "device_type": "network",
+  "created_at": "2026-08-07T07:43:20+02:00",
   "calculation_strategy": "fixed",
-  "standby_power": 0.0,
+  "standby_power": 0.05,
   "supported_modes": [
     "fixed"
   ],

--- a/profile_library/netgear/GS110MX/model.json
+++ b/profile_library/netgear/GS110MX/model.json
@@ -1,0 +1,14 @@
+{
+  "name": "Netgear GS110MX",
+  "measure_device": "Prise Athom",
+  "measure_method": "manual",
+  "device_type": "network_switch",
+  "calculation_strategy": "fixed",
+  "standby_power": 0.0,
+  "supported_modes": [
+    "fixed"
+  ],
+  "fixed_config": {
+    "power": 8.0
+  }
+}

--- a/profile_library/netgear/GS110MX/model.json
+++ b/profile_library/netgear/GS110MX/model.json
@@ -2,7 +2,7 @@
   "name": "Netgear GS110MX",
   "measure_device": "Prise Athom",
   "measure_method": "manual",
-  "device_type": "network_switch",
+  "device_type": "network",
   "calculation_strategy": "fixed",
   "standby_power": 0.0,
   "supported_modes": [


### PR DESCRIPTION
Add Netgear GS110MX

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
Netgear GS110MX
8-Port Gigabit Ethernet Unmanaged Switch with 2-Port 10G/Multi-Gig.
Link: https://www.netgear.com/business/wired/switches/unmanaged/gs110mx/

## Home Assistant Device information
N/A - This is an unmanaged network switch, so there is no native device integration in Home Assistant. It is typically tracked via a Ping `binary_sensor` or configured as an always-on virtual powercalc sensor.

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
Measurements were taken continuously over a 30-day period using a calibrated Athom smart plug. 
- Absolute minimum observed (idle): ~3.6 W
- Maximum observed (heavy 10G link activity): ~10.16 W
- 30-day mathematical average: 7.99 W

Given the unmanaged nature of the switch, the calculation strategy is set to `fixed` at `8.0` W to accurately smooth out the daily energy consumption in the HA Energy Dashboard. `standby_power` is set to `0.0` as turning the entity `off` in HA implies the switch is physically unpowered.