### PR TITLE
Implement discovery ignore list to prevent duplicate discoveries

### DIFF
--- a/.github/scripts/profile_library/update_library.py
+++ b/.github/scripts/profile_library/update_library.py
@@ -31,6 +31,7 @@ DATA_DIR = f"{PROJECT_ROOT}/profile_library"
 REPO_OWNER = "bramstroker"
 REPO_NAME = "homeassistant-powercalc"
 MAX_CONCURRENT_FILE_TASKS = 50
+DISCOVERY_IGNORED_DOMAINS: list[str] = []
 
 @dataclass
 class Author:
@@ -92,6 +93,7 @@ async def generate_library_json(model_listing: list[dict]) -> None:
         manufacturer["models"].append(mapped_dict)
 
     json_data = {
+        "discovery_ignored_domains": DISCOVERY_IGNORED_DOMAINS,
         "manufacturers": list(manufacturers.values()),
     }
 

--- a/custom_components/powercalc/const.py
+++ b/custom_components/powercalc/const.py
@@ -241,6 +241,7 @@ DEFAULT_UTILITY_METER_TYPES = [DAILY, WEEKLY, MONTHLY]
 DISCOVERY_SOURCE_ENTITY = "source_entity"
 DISCOVERY_POWER_PROFILES = "power_profiles"
 DISCOVERY_TYPE = "discovery_type"
+LIBRARY_DISCOVERY_IGNORED_DOMAINS = "discovery_ignored_domains"
 
 LIBRARY_URL = "https://library.powercalc.nl"
 API_URL = "https://api.powercalc.nl"

--- a/custom_components/powercalc/discovery.py
+++ b/custom_components/powercalc/discovery.py
@@ -204,11 +204,16 @@ class DiscoveryManager:
         discovery_type: DiscoveryBy,
     ) -> None:
         """Generalized discovery procedure for entities and devices."""
+        library = await self._get_library()
+        ignored_domains = library.discovery_ignored_domains
         for source in source_provider():
             log_identifier = str(
                 getattr(source, "entity_id", getattr(source, "id", getattr(source, "entry_id", "unknown"))),
             )
             try:
+                if self._is_domain_ignored(source, ignored_domains):
+                    _LOGGER.debug("%s: Integration domain is ignored, skipping discovery", log_identifier)
+                    continue
                 source_entity = source_creator(source)
                 model_info = await self.extract_model_info_from_device_info(
                     source_entity.entity_entry or source_entity.device_entry,
@@ -339,6 +344,23 @@ class DiscoveryManager:
             power_profiles.append(profile)
 
         return power_profiles
+
+    def _is_domain_ignored(self, source: _DiscoverySourceT, ignored_domains: set[str]) -> bool:
+        """Return whether a discovery source belongs to a globally ignored integration domain."""
+        if not ignored_domains:
+            return False
+
+        if isinstance(source, er.RegistryEntry):
+            return source.platform in ignored_domains
+        if isinstance(source, ConfigEntry):
+            return source.domain in ignored_domains
+
+        config_entry_id = next(iter(source.config_entries), None)
+        if config_entry_id is None:  # pragma: no cover
+            return False
+
+        config_entry = self.hass.config_entries.async_get_entry(config_entry_id)
+        return config_entry is not None and config_entry.domain in ignored_domains
 
     async def init_wled_flow(self, model_info: ModelInfo, source_entity: SourceEntity) -> None:
         """Initialize the discovery flow for a WLED light."""

--- a/custom_components/powercalc/power_profile/library.py
+++ b/custom_components/powercalc/power_profile/library.py
@@ -52,6 +52,11 @@ class ProfileLibrary:
     async def initialize(self) -> None:
         await self._loader.initialize()
 
+    @property
+    def discovery_ignored_domains(self) -> set[str]:
+        """Get integration domains globally excluded from discovery."""
+        return self._loader.get_discovery_ignored_domains()
+
     @staticmethod
     @singleton("powercalc_library")
     async def factory(hass: HomeAssistant) -> ProfileLibrary:

--- a/custom_components/powercalc/power_profile/loader/composite.py
+++ b/custom_components/powercalc/power_profile/loader/composite.py
@@ -15,6 +15,10 @@ class CompositeLoader(Loader):
         for loader in self.loaders:
             await loader.initialize()
 
+    def get_discovery_ignored_domains(self) -> set[str]:
+        """Get all integration domains excluded by the combined libraries."""
+        return {domain for loader in self.loaders for domain in loader.get_discovery_ignored_domains()}
+
     async def get_manufacturer_listing(
         self,
         device_types: set[DeviceType] | None,

--- a/custom_components/powercalc/power_profile/loader/local.py
+++ b/custom_components/powercalc/power_profile/loader/local.py
@@ -25,6 +25,10 @@ class LocalLoader(Loader):
         if not self._is_custom_directory:
             await self._hass.async_add_executor_job(self._load_custom_library)
 
+    def get_discovery_ignored_domains(self) -> set[str]:
+        """Local profile directories do not provide global library metadata."""
+        return set()
+
     async def get_manufacturer_listing(
         self,
         device_types: set[DeviceType] | None,

--- a/custom_components/powercalc/power_profile/loader/protocol.py
+++ b/custom_components/powercalc/power_profile/loader/protocol.py
@@ -7,6 +7,9 @@ class Loader(Protocol):
     async def initialize(self) -> None:
         """Initialize the loader."""
 
+    def get_discovery_ignored_domains(self) -> set[str]:
+        """Get integration domains excluded from discovery."""
+
     async def get_manufacturer_listing(
         self,
         device_types: set[DeviceType] | None,

--- a/custom_components/powercalc/power_profile/loader/remote.py
+++ b/custom_components/powercalc/power_profile/loader/remote.py
@@ -16,7 +16,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.loader import async_get_integration
 
-from custom_components.powercalc.const import API_URL, BUILT_IN_LIBRARY_DIR, DOMAIN
+from custom_components.powercalc.const import (
+    API_URL,
+    BUILT_IN_LIBRARY_DIR,
+    DOMAIN,
+    LIBRARY_DISCOVERY_IGNORED_DOMAINS,
+)
 from custom_components.powercalc.helpers import async_cache, clear_async_cache
 from custom_components.powercalc.power_profile.error import LibraryLoadingError, ProfileDownloadError
 from custom_components.powercalc.power_profile.loader.protocol import Loader
@@ -79,6 +84,10 @@ class RemoteLoader(Loader):
 
         for manufacturer in manufacturers:
             self._index_manufacturer(manufacturer, powercalc_version)
+
+    def get_discovery_ignored_domains(self) -> set[str]:
+        """Get integration domains excluded from discovery by library metadata."""
+        return set(self.library_contents.get(LIBRARY_DISCOVERY_IGNORED_DOMAINS, []))
 
     def _index_manufacturer(self, manufacturer: LibraryManufacturer, powercalc_version: AwesomeVersion) -> None:
         """Register a manufacturer, its aliases and all of its supported models in the lookup tables."""

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
 import pytest
 
+from custom_components.powercalc.const import LIBRARY_DISCOVERY_IGNORED_DOMAINS
 from custom_components.powercalc.helpers import get_library_json_path, get_library_path
 from custom_components.powercalc.power_profile.error import LibraryLoadingError, ProfileDownloadError
 from custom_components.powercalc.power_profile.library import ModelInfo, ProfileLibrary
@@ -143,6 +144,12 @@ async def test_get_manufacturer_listing(remote_loader: RemoteLoader) -> None:
     assert ("signify", "Signify") in manufacturers
     assert len(manufacturers) > 40
     assert ("signify", "Signify") in await remote_loader.get_manufacturer_listing(None, DiscoveryBy.DEVICE)
+
+
+async def test_get_discovery_ignored_domains(remote_loader: RemoteLoader) -> None:
+    remote_loader.library_contents[LIBRARY_DISCOVERY_IGNORED_DOMAINS] = ["ignored", "other"]
+
+    assert remote_loader.get_discovery_ignored_domains() == {"ignored", "other"}
 
 
 async def test_get_model_listing(remote_loader: RemoteLoader) -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1060,3 +1060,68 @@ async def test_discovery_compatible_integrations(
     assert len(mock_calls) == 1
     assert mock_calls[0][2]["context"] == {"source": SOURCE_INTEGRATION_DISCOVERY}
     assert mock_calls[0][2]["data"][CONF_ENTITY_ID] == "light.hue_light"
+
+
+async def test_discovery_ignored_domain_filters_entities(
+    hass: HomeAssistant,
+    mock_flow_init: AsyncMock,
+) -> None:
+    """Entities provided by a globally ignored integration must not be discovered."""
+    mock_entities_in_registry(
+        hass,
+        {
+            "light.ignored": {"platform": "ignored", "device_id": "ignored-device"},
+            "light.allowed": {"platform": "hue", "device_id": "allowed-device"},
+        },
+    )
+    mock_devices(
+        hass,
+        {
+            "ignored-device": {"manufacturer": "test", "model": "compatible_integrations"},
+            "allowed-device": {"manufacturer": "test", "model": "compatible_integrations"},
+        },
+    )
+
+    with patch(
+        "custom_components.powercalc.power_profile.loader.remote.RemoteLoader.get_discovery_ignored_domains",
+        return_value={"ignored"},
+    ):
+        await run_powercalc_setup(hass)
+
+    assert len(mock_flow_init.mock_calls) == 1
+    assert mock_flow_init.mock_calls[0][2]["data"][CONF_ENTITY_ID] == "light.allowed"
+
+
+async def test_discovery_ignored_domain_filters_devices(
+    hass: HomeAssistant,
+    mock_flow_init: AsyncMock,
+) -> None:
+    """Devices belonging to a globally ignored integration must not be discovered."""
+    ignored_entry = MockConfigEntry(domain="ignored")
+    ignored_entry.add_to_hass(hass)
+    allowed_entry = MockConfigEntry(domain="allowed")
+    allowed_entry.add_to_hass(hass)
+    mock_devices(
+        hass,
+        {
+            "ignored-device": {
+                "config_entry_id": ignored_entry.entry_id,
+                "manufacturer": "test",
+                "model": "discovery_type_device",
+            },
+            "allowed-device": {
+                "config_entry_id": allowed_entry.entry_id,
+                "manufacturer": "test",
+                "model": "discovery_type_device",
+            },
+        },
+    )
+
+    with patch(
+        "custom_components.powercalc.power_profile.loader.remote.RemoteLoader.get_discovery_ignored_domains",
+        return_value={"ignored"},
+    ):
+        await run_powercalc_setup(hass)
+
+    assert len(mock_flow_init.mock_calls) == 1
+    assert mock_flow_init.mock_calls[0][2]["data"][CONF_UNIQUE_ID] == "pc_allowed-device"


### PR DESCRIPTION
Because of device split introduced in HA 2026.8 Powercalc unfortunately can provide multiple discoveries for the same device, because they are supplied by multiple integrations now.

This PR adds an ignore list where certain integrations can be ignored from discovery. For example Unifi.
