### PR TITLE
Skip discovery when already setup for composite device

### DIFF
--- a/custom_components/powercalc/device_binding.py
+++ b/custom_components/powercalc/device_binding.py
@@ -31,6 +31,29 @@ def is_composite_device_id(hass: HomeAssistant, device_id: str) -> bool:
     return bool(is_composite(device_id))
 
 
+def get_composite_split_devices(hass: HomeAssistant, device_id: str) -> list[DeviceEntry]:
+    """
+    Return all devices split off from the same legacy composite device as the given device.
+    Accepts either the composite device ID itself, or the ID of one of the split devices.
+    Returns an empty list when the device is unrelated to a composite device, or when running on
+    HA <2026.8, which does not split composite devices at all.
+    """
+    device_reg = device_registry.async_get(hass)
+    get_split_devices = getattr(device_reg, "async_get_devices_for_composite_device_id", None)
+    if not callable(get_split_devices):
+        return []
+
+    if split_devices := list(get_split_devices(device_id)):
+        return split_devices
+
+    # Not a composite ID itself, so it may be one of the devices split off from a composite.
+    device = device_reg.async_get(device_id)
+    composite_device_id = getattr(device, "composite_device_id", None) if device else None
+    if not composite_device_id:
+        return []
+    return list(get_split_devices(composite_device_id))
+
+
 def get_config_entry_ids(device: DeviceEntry) -> set[str]:
     """
     Return the config entry IDs a device belongs to.

--- a/custom_components/powercalc/discovery.py
+++ b/custom_components/powercalc/discovery.py
@@ -8,7 +8,7 @@ from typing import Any, TypeVar
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, SOURCE_USER, ConfigEntry
-from homeassistant.const import CONF_ENTITY_ID, CONF_PLATFORM, CONF_UNIQUE_ID
+from homeassistant.const import CONF_DEVICE, CONF_ENTITY_ID, CONF_PLATFORM, CONF_UNIQUE_ID
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import discovery_flow
 import homeassistant.helpers.device_registry as dr
@@ -31,7 +31,12 @@ from .const import (
     MANUFACTURER_WLED,
     CalculationStrategy,
 )
-from .device_binding import get_config_entry_ids, get_first_device_for_config_entry, is_composite_device_id
+from .device_binding import (
+    get_composite_split_devices,
+    get_config_entry_ids,
+    get_first_device_for_config_entry,
+    is_composite_device_id,
+)
 from .group_include.filter import (
     CategoryFilter,
     CompositeFilter,
@@ -180,6 +185,8 @@ class DiscoveryManager:
                 continue  # pragma: no cover
 
             self.initialized_flows.add(entry.unique_id)
+            self._initialize_configured_device(entry)
+
             entity_id = entry.data.get(CONF_ENTITY_ID)
             if not entity_id or entity_id == DUMMY_ENTITY_ID:
                 continue
@@ -188,6 +195,23 @@ class DiscoveryManager:
             if entity and entity.device_entry:
                 self.initialized_flows.add(f"pc_{entity.device_entry.id}")
             self.initialized_flows.add(entity_id)
+
+    def _initialize_configured_device(self, entry: ConfigEntry) -> None:
+        """Mark the device a config entry was setup for as already setup.
+
+        HA >=2026.8 splits devices belonging to multiple config entries into one device per entry.
+        The entry may hold the composite device ID, which no longer resolves to a registered device,
+        or one of the split devices after the user resolved the composite device repair. Either way
+        all devices split off from that composite represent the same physical device the user already
+        configured, so none of them should be discovered again.
+        """
+        device_id = entry.data.get(CONF_DEVICE)
+        if not device_id:
+            return
+
+        self.initialized_flows.add(f"pc_{device_id}")
+        for device in get_composite_split_devices(self.hass, str(device_id)):
+            self.initialized_flows.add(f"pc_{device.id}")
 
     def remove_initialized_flow(self, entry: ConfigEntry) -> None:
         """Remove a flow from the initialized flows."""

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -11,7 +11,15 @@ from homeassistant.components.light import (
     ColorMode,
 )
 from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_INTEGRATION_DISCOVERY
-from homeassistant.const import CONF_ENABLED, CONF_ENTITY_ID, CONF_NAME, CONF_SOURCE, CONF_UNIQUE_ID, STATE_ON
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_ENABLED,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_SOURCE,
+    CONF_UNIQUE_ID,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
@@ -65,12 +73,14 @@ from .common import (
     mock_device_with_entities,
     mock_devices,
     mock_entities_in_registry,
+    requires_composite_devices,
     run_powercalc_setup,
     set_states,
 )
 from .config_flow.test_global_configuration import create_mock_global_config_entry
 
 DEFAULT_UNIQUE_ID = "7c009ef6829f"
+COMPOSITE_DEVICE_ID = "composite00000000000000000000ab"
 LIGHT_ATTRIBUTES = {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS], ATTR_COLOR_MODE: ColorMode.BRIGHTNESS}
 
 
@@ -836,6 +846,72 @@ async def test_composite_devices_are_ignored_for_device_discovery(
         devices = discovery_manager.get_devices()
 
     assert devices == [regular_device]
+
+
+def _mock_split_devices(hass: HomeAssistant) -> None:
+    """Mock two devices split off from the same pre-migration composite device."""
+    mock_devices(
+        hass,
+        {
+            f"split-device-{index}": {
+                "config_entry_id": f"source-entry-{index}",
+                "manufacturer": "test",
+                "model": "discovery_type_device",
+                "composite_device_id": COMPOSITE_DEVICE_ID,
+            }
+            for index in range(2)
+        },
+    )
+
+
+@requires_composite_devices
+@pytest.mark.parametrize(
+    "configured_device_id",
+    [COMPOSITE_DEVICE_ID, "split-device-0"],
+    ids=["composite_device", "repaired_split_device"],
+)
+async def test_no_discovery_for_devices_split_from_configured_composite_device(
+    hass: HomeAssistant,
+    mock_flow_init: AsyncMock,
+    configured_device_id: str,
+) -> None:
+    """Devices split from a composite device must not be discovered when it is already setup.
+
+    The entry either still references the composite device ID, or one of the split devices after the
+    user resolved the composite device repair. Both represent the same physical device.
+    """
+    _mock_split_devices(hass)
+
+    await create_mock_config_entry(
+        hass,
+        {
+            CONF_SENSOR_TYPE: SensorType.VIRTUAL_POWER,
+            CONF_ENTITY_ID: DUMMY_ENTITY_ID,
+            CONF_NAME: "Composite device",
+            CONF_MANUFACTURER: "test",
+            CONF_MODEL: "discovery_type_device",
+            CONF_DEVICE: configured_device_id,
+        },
+        unique_id=f"pc_{COMPOSITE_DEVICE_ID}",
+    )
+
+    await run_powercalc_setup(hass)
+
+    assert not mock_flow_init.mock_calls
+
+
+@requires_composite_devices
+async def test_discovery_for_devices_split_from_unconfigured_composite_device(
+    hass: HomeAssistant,
+    mock_flow_init: AsyncMock,
+) -> None:
+    """Split devices must still be discovered when no Powercalc entry exists for the composite."""
+    _mock_split_devices(hass)
+
+    await run_powercalc_setup(hass)
+
+    unique_ids = {call[2]["data"][CONF_UNIQUE_ID] for call in mock_flow_init.mock_calls}
+    assert unique_ids == {"pc_split-device-0", "pc_split-device-1"}
 
 
 async def test_powercalc_sensors_are_ignored_for_discovery(


### PR DESCRIPTION
When user has already setup powercalc for a device which is split and part of a composite device, prevent another discovery.
Trying to circumvent issues with duplicate discoveries after devices are split in HA 2026.8 