### PR TITLE
ci: harden repository quality gates

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,31 @@
+# Dev container
+
+A ready-to-use development environment for the Powercalc integration. It saves you from setting up Home Assistant Core by hand.
+
+## Getting started
+
+- **VS Code**: install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, open this repository and choose **Reopen in Container**.
+- **GitHub Codespaces**: click **Code → Codespaces → Create codespace** on the repository page.
+
+The first build installs [uv](https://docs.astral.sh/uv/), which fetches the Python version pinned in `pyproject.toml`, syncs the locked dependencies and installs the git hooks. This takes a few minutes; later starts are quick.
+
+## Running Home Assistant
+
+```bash
+script/develop.sh
+```
+
+This creates a `config/` directory on first run, links `custom_components/powercalc` into it and starts Home Assistant on <http://localhost:8123> with debug logging for Powercalc. Port 8123 is forwarded automatically.
+
+Add Powercalc from **Settings → Devices & Services → Add Integration**. The `config/` directory is not tracked by git, so whatever you configure there stays between restarts and never ends up in a pull request.
+
+Restart Home Assistant to pick up code changes.
+
+## Running the checks
+
+```bash
+uv run pytest tests/                 # test suite
+uv run prek run --all-files          # everything CI lints
+```
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for what is expected before opening a pull request.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "name": "Powercalc",
+  "image": "mcr.microsoft.com/devcontainers/base:debian",
+  "postCreateCommand": "script/devcontainer-setup.sh",
+  "forwardPorts": [
+    8123
+  ],
+  "portsAttributes": {
+    "8123": {
+      "label": "Home Assistant",
+      "onAutoForward": "notify"
+    }
+  },
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "UV_LINK_MODE": "copy"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "EditorConfig.EditorConfig",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "tests"
+        ],
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": "explicit",
+            "source.organizeImports.ruff": "explicit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+max_line_length = 120
+
+[*.{md,markdown}]
+# Trailing whitespace is a hard line break in Markdown.
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: Question or help with your setup
+    url: https://github.com/bramstroker/homeassistant-powercalc/discussions/categories/questions
+    about: Ask in Discussions. The issue tracker is for bugs and feature requests.
+  - name: Frequently asked questions
+    url: https://docs.powercalc.nl/troubleshooting/faq/
+    about: Check the FAQ and troubleshooting guides first, your problem may already be solved there.
+  - name: Request support for a device
+    url: https://github.com/bramstroker/homeassistant-powercalc/discussions/categories/request-light-models
+    about: Ask for a device to be added to the profile library, or find out whether someone is already measuring it.
+  - name: Share a measurement
+    url: https://github.com/bramstroker/homeassistant-powercalc/discussions/categories/finished-measurements
+    about: Measured a device yourself? Share the results here or open a pull request with the profile.

--- a/.github/scripts/ha_version_matrix.py
+++ b/.github/scripts/ha_version_matrix.py
@@ -11,7 +11,6 @@ that did not exist yet when it was published.
 
 import json
 import re
-import sys
 import time
 import urllib.error
 import urllib.request
@@ -95,4 +94,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/.github/scripts/profile_library/__init__.py
+++ b/.github/scripts/profile_library/__init__.py
@@ -1,0 +1,1 @@
+"""Profile-library maintenance scripts."""

--- a/.github/scripts/profile_library/update_library.py
+++ b/.github/scripts/profile_library/update_library.py
@@ -13,7 +13,9 @@ import json
 import math
 import os
 from pathlib import Path
+import subprocess
 import sys
+from typing import Any
 
 import aiofiles
 import git
@@ -45,13 +47,13 @@ def create_model_hash(mapping: Mapping[str, object]) -> str:
     return hashlib.md5(json.dumps(mapping, sort_keys=True).encode(), usedforsecurity=False).hexdigest()
 
 
-async def generate_library_json(model_listing: list[dict]) -> None:
-    manufacturers: dict[str, dict] = {}
+async def generate_library_json(model_listing: list[dict[str, Any]]) -> None:
+    manufacturers: dict[str, dict[str, Any]] = {}
 
     # Process manufacturers concurrently
     tasks = []
     for model in model_listing:
-        manufacturer_name = model.get("manufacturer")
+        manufacturer_name = model["manufacturer"]
         if manufacturer_name not in manufacturers:
             task = get_manufacturer_json(manufacturer_name)
             tasks.append((manufacturer_name, task))
@@ -67,8 +69,7 @@ async def generate_library_json(model_listing: list[dict]) -> None:
 
     # Process models
     for model in model_listing:
-        manufacturer_name = model.get("manufacturer")
-        manufacturer = manufacturers.get(manufacturer_name)
+        manufacturer = manufacturers[model["manufacturer"]]
 
         device_type = model.get("device_type")
         if device_type not in manufacturer["device_types"]:
@@ -107,7 +108,7 @@ async def generate_library_json(model_listing: list[dict]) -> None:
     print("Generated library.json")
 
 
-async def update_authors(_model_listing: list[dict]) -> None:
+async def update_authors(_model_listing: list[dict[str, Any]]) -> None:
     model_json_paths = sorted(
         glob.glob(f"{DATA_DIR}/**/model.json", recursive=True),
         key=lambda model_json_path: (len(Path(model_json_path).parts), model_json_path),
@@ -143,7 +144,7 @@ async def process_author_update(model_json_path: str) -> None:
     print(f"Updated author metadata in {model_json_path}")
 
 
-def has_author_info(model_data: dict) -> bool:
+def has_author_info(model_data: dict[str, Any]) -> bool:
     author_info = model_data.get("author_info")
     return isinstance(author_info, dict) and bool(author_info.get("name")) and bool(author_info.get("github"))
 
@@ -153,7 +154,7 @@ def is_main_model_json(model_json_path: str) -> bool:
     return len(relative_path.parts) == 3
 
 
-def author_to_json(author: Author) -> dict:
+def author_to_json(author: Author) -> dict[str, str]:
     author_json = {
         "name": author.name,
         "github": author.github_username,
@@ -163,7 +164,7 @@ def author_to_json(author: Author) -> dict:
     return author_json
 
 
-async def update_translations(model_listing: list[dict]) -> None:
+async def update_translations(model_listing: list[dict[str, Any]]) -> None:
     data_translations: dict[str, str] = {}
     description_translations: dict[str, str] = {}
     for model in model_listing:
@@ -196,7 +197,7 @@ async def update_translations(model_listing: list[dict]) -> None:
         await file.write(json.dumps(json_data, indent=2) + "\n")
 
 
-def deep_update(target: dict, updates: dict) -> None:
+def deep_update(target: dict[str, Any], updates: dict[str, Any]) -> None:
     """
     Recursively updates a dictionary with another dictionary,
     only adding keys that are missing.
@@ -208,7 +209,7 @@ def deep_update(target: dict, updates: dict) -> None:
             target[key] = value
 
 
-async def get_manufacturer_json(manufacturer: str) -> dict:
+async def get_manufacturer_json(manufacturer: str) -> dict[str, Any]:
     json_path = os.path.join(DATA_DIR, manufacturer, "manufacturer.json")
     try:
         async with aiofiles.open(json_path) as json_file:
@@ -231,7 +232,7 @@ async def get_manufacturer_json(manufacturer: str) -> dict:
         return default_json
 
 
-async def get_model_list() -> list[dict]:
+async def get_model_list() -> list[dict[str, Any]]:
     """Get a listing of all available powercalc models"""
     json_paths = glob.glob(
         f"{DATA_DIR}/*/*/model.json",
@@ -240,7 +241,7 @@ async def get_model_list() -> list[dict]:
 
     semaphore = asyncio.Semaphore(MAX_CONCURRENT_FILE_TASKS)
 
-    async def process_with_limit(json_path: str) -> dict:
+    async def process_with_limit(json_path: str) -> dict[str, Any]:
         async with semaphore:
             return await process_model_file(json_path)
 
@@ -250,11 +251,11 @@ async def get_model_list() -> list[dict]:
     return [model for model in models if model]
 
 
-async def process_model_file(json_path: str) -> dict:
+async def process_model_file(json_path: str) -> dict[str, Any]:
     """Process a single model file asynchronously"""
     async with aiofiles.open(json_path) as json_file:
         content = await json_file.read()
-        model_data: dict = json.loads(content)
+        model_data: dict[str, Any] = json.loads(content)
         model_data.pop("author", None)
         model_directory = os.path.dirname(json_path)
         model_data["id"] = os.path.basename(model_directory)
@@ -288,8 +289,8 @@ async def process_model_file(json_path: str) -> dict:
         return model_data
 
 
-async def get_color_modes(model_directory: str) -> set:
-    color_modes = set()
+async def get_color_modes(model_directory: str) -> set[str]:
+    color_modes: set[str] = set()
     paths = glob.glob(f"{model_directory}/**/*.csv.gz", recursive=True)
     for path in paths:
         filename = os.path.basename(path)
@@ -307,7 +308,7 @@ def get_sub_profile_count(model_directory: str) -> int:
     return sum(1 for p in path.iterdir() if p.is_dir())
 
 
-async def get_max_power(model_directory: str, model_data: dict) -> float | None:
+async def get_max_power(model_directory: str, model_data: dict[str, Any]) -> float | None:
     calculation_strategy = model_data.get("calculation_strategy", "lut")
     if calculation_strategy == "lut":
         max_power = 0
@@ -316,9 +317,9 @@ async def get_max_power(model_directory: str, model_data: dict) -> float | None:
         # Process CSV files concurrently
         if paths:
             tasks = [process_csv_file(path) for path in paths]
-            power_values = await asyncio.gather(*tasks)
+            csv_powers = await asyncio.gather(*tasks)
             # Filter out None values and find max
-            valid_powers = [p for p in power_values if p is not None]
+            valid_powers = [p for p in csv_powers if p is not None]
             if valid_powers:
                 return max(valid_powers)
             return max_power
@@ -327,23 +328,22 @@ async def get_max_power(model_directory: str, model_data: dict) -> float | None:
     if calculation_strategy == "linear":
         linear_config = model_data.get("linear_config", {})
         if "calibrate" in linear_config:
-            power_values = [
+            calibrate_powers = [
                 float(line.split("->")[1].strip()) for line in linear_config.get("calibrate", []) if "->" in line
             ]
-            return max(power_values) if power_values else 0
-        return max(linear_config.get("max_power", 0), model_data.get("standby_power_on", 0))
+            return max(calibrate_powers) if calibrate_powers else 0
+        return float(max(linear_config.get("max_power", 0), model_data.get("standby_power_on", 0)))
 
     if calculation_strategy == "fixed":
         fixed_config = model_data.get("fixed_config", {})
-        power_values = [
+        candidates = [
             fixed_config.get("power", 0),
             model_data.get("standby_power_on", 0),
+            *fixed_config.get("states_power", {}).values(),
         ]
-        states_power = fixed_config.get("states_power", {})
-        power_values.extend(states_power.values())
-        power_values = filter(lambda p: is_number(p), power_values)
+        fixed_powers = [float(value) for value in candidates if is_number(value)]
 
-        return max(power_values) if power_values else 0
+        return max(fixed_powers) if fixed_powers else 0
 
     return None
 
@@ -354,7 +354,7 @@ async def process_csv_file(path: str) -> float | None:
         with gzip.open(path, "rt") as f:
             reader = csv.reader(f)
             next(reader, None)  # skip header row
-            max_power = 0
+            max_power = 0.0
             for row in reader:
                 if not row:
                     continue
@@ -394,7 +394,7 @@ async def get_last_commit_time(directory: str) -> datetime:
             return datetime.fromtimestamp(0)
         timestamp = int(out)
         return datetime.fromtimestamp(timestamp)
-    except asyncio.SubprocessError, ValueError:
+    except subprocess.SubprocessError, ValueError:
         # Handle case where there are no commits or Git command fails
         return datetime.fromtimestamp(0)
 
@@ -407,12 +407,12 @@ async def run_git_command(command: str) -> str:
     stdout, stderr = await proc.communicate()
 
     if proc.returncode != 0:
-        raise asyncio.SubprocessError(f"Command failed: {command}, error: {stderr.decode()}")
+        raise subprocess.SubprocessError(f"Command failed: {command}, error: {stderr.decode()}")
 
     return stdout.decode().strip()
 
 
-async def get_commits_affected_directory(directory: str) -> list:
+async def get_commits_affected_directory(directory: str) -> list[str]:
     """Get a list of commits that affected the given directory, including renames."""
     command = f"git log --follow --format='%H' -- '{directory}'"
     commits = await run_git_command(command)
@@ -458,7 +458,7 @@ async def get_commit_author(commit_hash: str) -> Author | None:
     )
 
 
-async def get_pull_request_author(client: httpx.AsyncClient, commit_hash: str, headers: dict) -> str | None:
+async def get_pull_request_author(client: httpx.AsyncClient, commit_hash: str, headers: dict[str, str]) -> str | None:
     """Get the author of the pull request that contains the given commit."""
     r = await client.get(
         f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/commits/{commit_hash}/pulls",
@@ -533,9 +533,11 @@ async def main_async() -> None:
 
 def is_number(value: float | str | None) -> bool:
     """Try to convert value to a float."""
+    if value is None:
+        return False
     try:
         fvalue = float(value)
-    except ValueError, TypeError:
+    except ValueError:
         return False
     return math.isfinite(fvalue)
 

--- a/.github/scripts/profile_library/update_library.py
+++ b/.github/scripts/profile_library/update_library.py
@@ -2,22 +2,22 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from collections.abc import Mapping
 import csv
+from dataclasses import dataclass
+from datetime import datetime
 import glob
 import gzip
 import hashlib
 import json
+import math
 import os
-import sys
-from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from typing import Mapping
+import sys
 
 import aiofiles
 import git
 import httpx
-import math
 
 sys.path.insert(
     1,
@@ -33,14 +33,17 @@ REPO_NAME = "homeassistant-powercalc"
 MAX_CONCURRENT_FILE_TASKS = 50
 DISCOVERY_IGNORED_DOMAINS: list[str] = ["unifi"]
 
+
 @dataclass
 class Author:
     name: str
     email: str | None
     github_username: str
 
-def create_model_hash(mapping: Mapping) -> str:
-    return hashlib.md5(json.dumps(mapping, sort_keys=True).encode()).hexdigest()
+
+def create_model_hash(mapping: Mapping[str, object]) -> str:
+    return hashlib.md5(json.dumps(mapping, sort_keys=True).encode(), usedforsecurity=False).hexdigest()
+
 
 async def generate_library_json(model_listing: list[dict]) -> None:
     manufacturers: dict[str, dict] = {}
@@ -85,9 +88,7 @@ async def generate_library_json(model_listing: list[dict]) -> None:
             "sensor_config",
             "sub_profile_select",
         ]
-        mapped_dict = {
-            key: value for key, value in model.items() if key not in skipped_fields
-        }
+        mapped_dict = {key: value for key, value in model.items() if key not in skipped_fields}
         hash_dict = {key: value for key, value in mapped_dict.items() if key != "sub_profile_count"}
         mapped_dict["hash"] = create_model_hash(hash_dict)
         manufacturer["models"].append(mapped_dict)
@@ -114,9 +115,10 @@ async def update_authors(_model_listing: list[dict]) -> None:
     for model_json_path in model_json_paths:
         await process_author_update(model_json_path)
 
+
 async def process_author_update(model_json_path: str) -> None:
     """Process a single author update asynchronously"""
-    async with aiofiles.open(model_json_path, mode="r") as file:
+    async with aiofiles.open(model_json_path) as file:
         content = await file.read()
         json_data = json.loads(content)
 
@@ -162,7 +164,7 @@ def author_to_json(author: Author) -> dict:
 
 
 async def update_translations(model_listing: list[dict]) -> None:
-    data_translations: dict[str, str] =  {}
+    data_translations: dict[str, str] = {}
     description_translations: dict[str, str] = {}
     for model in model_listing:
         custom_fields = model.get("fields")
@@ -174,15 +176,15 @@ async def update_translations(model_listing: list[dict]) -> None:
             description_translations[key] = field_data.get("description")
 
     if not data_translations:
-        print(f"No translations found")
+        print("No translations found")
         return
 
     translation_file = os.path.join(PROJECT_ROOT, "custom_components/powercalc/translations/en.json")
-    async with aiofiles.open(translation_file, mode='r') as file:
+    async with aiofiles.open(translation_file) as file:
         content = await file.read()
         json_data = json.loads(content)
         step = "library_custom_fields"
-        if not step in json_data["config"]["step"]:
+        if step not in json_data["config"]["step"]:
             json_data["config"]["step"][step] = {
                 "data": {},
                 "data_description": {},
@@ -190,7 +192,7 @@ async def update_translations(model_listing: list[dict]) -> None:
         deep_update(json_data["config"]["step"][step]["data"], data_translations)
         deep_update(json_data["config"]["step"][step]["data_description"], description_translations)
 
-    async with aiofiles.open(translation_file, mode='w') as file:
+    async with aiofiles.open(translation_file, mode="w") as file:
         await file.write(json.dumps(json_data, indent=2) + "\n")
 
 
@@ -209,23 +211,20 @@ def deep_update(target: dict, updates: dict) -> None:
 async def get_manufacturer_json(manufacturer: str) -> dict:
     json_path = os.path.join(DATA_DIR, manufacturer, "manufacturer.json")
     try:
-        async with aiofiles.open(json_path, mode='r') as json_file:
+        async with aiofiles.open(json_path) as json_file:
             content = await json_file.read()
             manufacturer_data = json.loads(content)
             return {
                 "aliases": manufacturer_data.get("aliases", []),
                 "name": manufacturer,
                 "full_name": manufacturer_data.get("name"),
-                "dir_name": manufacturer
+                "dir_name": manufacturer,
             }
     except FileNotFoundError:
-        default_json = {
-            "name": manufacturer.capitalize(),
-            "aliases": []
-        }
+        default_json = {"name": manufacturer.capitalize(), "aliases": []}
         # Create directory if it doesn't exist
         os.makedirs(os.path.dirname(json_path), exist_ok=True)
-        async with aiofiles.open(json_path, mode='w', encoding="utf-8") as json_file:
+        async with aiofiles.open(json_path, mode="w", encoding="utf-8") as json_file:
             await json_file.write(json.dumps(default_json, ensure_ascii=False, indent=4) + "\n")
         git.Repo(PROJECT_ROOT).git.add(json_path)
         print(f"Added {json_path}")
@@ -250,14 +249,15 @@ async def get_model_list() -> list[dict]:
     # Filter out None values (if any)
     return [model for model in models if model]
 
+
 async def process_model_file(json_path: str) -> dict:
     """Process a single model file asynchronously"""
-    async with aiofiles.open(json_path, mode='r') as json_file:
+    async with aiofiles.open(json_path) as json_file:
         content = await json_file.read()
         model_data: dict = json.loads(content)
         model_data.pop("author", None)
         model_directory = os.path.dirname(json_path)
-        model_data['id'] = os.path.basename(model_directory)
+        model_data["id"] = os.path.basename(model_directory)
         if "linked_profile" in model_data:
             model_directory = os.path.join(DATA_DIR, model_data["linked_profile"])
 
@@ -265,8 +265,8 @@ async def process_model_file(json_path: str) -> dict:
         updated_at, max_power, sub_profile_count, color_modes = await asyncio.gather(
             get_last_commit_time(model_directory),
             get_max_power(model_directory, model_data),
-            get_sub_profile_count(model_directory),
-            get_color_modes(model_directory)
+            asyncio.to_thread(get_sub_profile_count, model_directory),
+            get_color_modes(model_directory),
         )
 
         model_data.update(
@@ -302,9 +302,10 @@ async def get_color_modes(model_directory: str) -> set:
     return color_modes
 
 
-async def get_sub_profile_count(model_directory: str) -> int:
+def get_sub_profile_count(model_directory: str) -> int:
     path = Path(model_directory)
     return sum(1 for p in path.iterdir() if p.is_dir())
+
 
 async def get_max_power(model_directory: str, model_data: dict) -> float | None:
     calculation_strategy = model_data.get("calculation_strategy", "lut")
@@ -326,7 +327,9 @@ async def get_max_power(model_directory: str, model_data: dict) -> float | None:
     if calculation_strategy == "linear":
         linear_config = model_data.get("linear_config", {})
         if "calibrate" in linear_config:
-            power_values = [float(line.split("->")[1].strip()) for line in linear_config.get("calibrate", []) if "->" in line]
+            power_values = [
+                float(line.split("->")[1].strip()) for line in linear_config.get("calibrate", []) if "->" in line
+            ]
             return max(power_values) if power_values else 0
         return max(linear_config.get("max_power", 0), model_data.get("standby_power_on", 0))
 
@@ -344,10 +347,11 @@ async def get_max_power(model_directory: str, model_data: dict) -> float | None:
 
     return None
 
+
 async def process_csv_file(path: str) -> float | None:
     """Process a single CSV file to find the maximum power value"""
     try:
-        with gzip.open(path, 'rt') as f:
+        with gzip.open(path, "rt") as f:
             reader = csv.reader(f)
             next(reader, None)  # skip header row
             max_power = 0
@@ -358,10 +362,10 @@ async def process_csv_file(path: str) -> float | None:
                     watt = float(row[-1])
                     if watt > max_power:
                         max_power = watt
-                except (ValueError, IndexError):
+                except ValueError, IndexError:
                     continue
             return max_power if max_power > 0 else None
-    except Exception as e:
+    except (OSError, EOFError, UnicodeDecodeError, csv.Error) as e:
         print(f"Error processing {path}: {e}")
         return None
 
@@ -370,12 +374,17 @@ async def get_last_commit_time(directory: str) -> datetime:
     try:
         # Use asyncio to run the git command
         proc = await asyncio.create_subprocess_exec(
-            "git", "log", "-1", "--format=%ct", "--", directory,
+            "git",
+            "log",
+            "-1",
+            "--format=%ct",
+            "--",
+            directory,
             cwd=directory,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
+            stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await proc.communicate()
+        stdout, _stderr = await proc.communicate()
 
         if proc.returncode != 0:
             return datetime.fromtimestamp(0)
@@ -385,16 +394,15 @@ async def get_last_commit_time(directory: str) -> datetime:
             return datetime.fromtimestamp(0)
         timestamp = int(out)
         return datetime.fromtimestamp(timestamp)
-    except (asyncio.SubprocessError, ValueError):
+    except asyncio.SubprocessError, ValueError:
         # Handle case where there are no commits or Git command fails
         return datetime.fromtimestamp(0)
 
-async def run_git_command(command):
+
+async def run_git_command(command: str) -> str:
     """Run a git command asynchronously and return the output."""
     proc = await asyncio.create_subprocess_shell(
-        command,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE
+        command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
     )
     stdout, stderr = await proc.communicate()
 
@@ -426,7 +434,7 @@ async def get_commit_author(commit_hash: str) -> Author | None:
         r.raise_for_status()
         data = r.json()
 
-        if not "commit" in data and not "author" in data:
+        if "commit" not in data and "author" not in data:
             return None
 
         commit = data.get("commit")
@@ -449,6 +457,7 @@ async def get_commit_author(commit_hash: str) -> Author | None:
         github_username=github_username,
     )
 
+
 async def get_pull_request_author(client: httpx.AsyncClient, commit_hash: str, headers: dict) -> str | None:
     """Get the author of the pull request that contains the given commit."""
     r = await client.get(
@@ -462,6 +471,7 @@ async def get_pull_request_author(client: httpx.AsyncClient, commit_hash: str, h
     user = pulls[0].get("user")
     return user.get("login") if user else None
 
+
 async def find_first_commit_author(file: str, check_paths: bool = True) -> Author | None:
     """Find the first commit that affected the directory and return the author's name."""
     commits = await get_commits_affected_directory(file)
@@ -472,13 +482,17 @@ async def find_first_commit_author(file: str, check_paths: bool = True) -> Autho
 
         affected_files = await run_git_command(command)
         file = file.replace(PROJECT_ROOT, "").lstrip("/")
-        paths = [file.replace("profile_library", "custom_components/powercalc/data"), file.replace("profile_library", "data"), file]
+        paths = [
+            file.replace("profile_library", "custom_components/powercalc/data"),
+            file.replace("profile_library", "data"),
+            file,
+        ]
         if any(path in affected_files.splitlines() for path in paths):
-            author = await get_commit_author(commit)
-            return author
+            return await get_commit_author(commit)
     return None
 
-async def main_async():
+
+async def main_async() -> None:
     parser = argparse.ArgumentParser(description="Process profiles JSON files and perform updates.")
     parser.add_argument("--authors", action="store_true", help="Update authors")
     parser.add_argument("--library-json", action="store_true", help="Generate library.json")
@@ -516,19 +530,20 @@ async def main_async():
     total_time = (datetime.now() - start_time).total_seconds()
     print(f"All operations completed in {total_time:.2f} seconds")
 
-def is_number(value):
+
+def is_number(value: float | str | None) -> bool:
     """Try to convert value to a float."""
     try:
         fvalue = float(value)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return False
-    if not math.isfinite(fvalue):
-        return False
-    return True
+    return math.isfinite(fvalue)
 
-def main():
+
+def main() -> None:
     """Entry point that runs the async main function"""
     asyncio.run(main_async())
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/release_draft/__init__.py
+++ b/.github/scripts/release_draft/__init__.py
@@ -1,0 +1,1 @@
+"""Release-draft generation scripts."""

--- a/.github/scripts/release_draft/github_client.py
+++ b/.github/scripts/release_draft/github_client.py
@@ -12,6 +12,8 @@ import urllib.request
 
 API_ROOT = "https://api.github.com"
 PAGE_SIZE = 100
+type JsonObject = dict[str, Any]
+type JsonResponse = JsonObject | list[JsonObject] | None
 
 
 class GitHubClient:
@@ -19,7 +21,7 @@ class GitHubClient:
         self._token = token
         self.repository = repository
 
-    def _request(self, method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+    def _request(self, method: str, url: str, payload: JsonObject | None = None) -> JsonResponse:
         if url.startswith("/"):
             url = f"{API_ROOT}{url}"
         data = json.dumps(payload).encode("utf-8") if payload is not None else None

--- a/.github/scripts/release_draft/github_client.py
+++ b/.github/scripts/release_draft/github_client.py
@@ -39,12 +39,17 @@ class GitHubClient:
             body = response.read()
         return json.loads(body) if body else None
 
+    def _request_list(self, method: str, url: str) -> list[JsonObject]:
+        """Request an endpoint that is documented to return an array."""
+        response = self._request(method, url)
+        return cast(list[JsonObject], response) if response is not None else []
+
     def _paginate(self, path: str) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
         page = 1
         while True:
             separator = "&" if "?" in path else "?"
-            chunk = self._request("GET", f"{path}{separator}per_page={PAGE_SIZE}&page={page}")
+            chunk = self._request_list("GET", f"{path}{separator}per_page={PAGE_SIZE}&page={page}")
             items.extend(chunk)
             if len(chunk) < PAGE_SIZE:
                 return items
@@ -54,9 +59,9 @@ class GitHubClient:
         """Resolve pushed commits to the merged pull requests they belong to."""
         pull_requests: dict[int, dict[str, Any]] = {}
         for sha in commit_shas:
-            for pull_request in self._request("GET", f"/repos/{self.repository}/commits/{sha}/pulls"):
+            for pull_request in self._request_list("GET", f"/repos/{self.repository}/commits/{sha}/pulls"):
                 if pull_request.get("merged_at") is not None:
-                    pull_requests.setdefault(pull_request["number"], pull_request)
+                    pull_requests.setdefault(int(pull_request["number"]), pull_request)
         return [pull_requests[number] for number in sorted(pull_requests)]
 
     def pull_request_files(self, number: int) -> list[str]:
@@ -65,7 +70,7 @@ class GitHubClient:
 
     def commit_sha(self, ref: str) -> str:
         """Resolve a tag, branch or sha to its commit sha."""
-        commit = self._request("GET", f"/repos/{self.repository}/commits/{ref}")
+        commit = cast(JsonObject, self._request("GET", f"/repos/{self.repository}/commits/{ref}"))
         return str(commit["sha"])
 
     def commit_shas_since(self, base_sha: str | None, head_ref: str) -> list[str]:
@@ -78,7 +83,7 @@ class GitHubClient:
         shas: list[str] = []
         page = 1
         while True:
-            chunk = self._request(
+            chunk = self._request_list(
                 "GET",
                 f"/repos/{self.repository}/commits?sha={head_ref}&per_page={PAGE_SIZE}&page={page}",
             )
@@ -87,7 +92,7 @@ class GitHubClient:
             for commit in chunk:
                 if commit["sha"] == base_sha:
                     return shas
-                shas.append(commit["sha"])
+                shas.append(str(commit["sha"]))
             page += 1
 
     def releases(self) -> list[dict[str, Any]]:

--- a/.github/scripts/release_draft/supporters.py
+++ b/.github/scripts/release_draft/supporters.py
@@ -112,7 +112,7 @@ def group_supporters_by_tier(
             continue
 
         # BMC returns most recent first, so slicing keeps that order
-        names = [item.get("name") for item in matches[:max_names_per_tier]]
+        names = [str(name) for item in matches[:max_names_per_tier] if (name := item.get("name"))]
         more = len(matches) > max_names_per_tier
 
         tiered[label] = {"names": names, "more": more}
@@ -132,7 +132,10 @@ def build_monthly_supporters_block(
 
     names: list[str] = []
     for item in subs:
-        names.append(item.get("name"))
+        name = item.get("name")
+        if not name:
+            continue
+        names.append(str(name))
         if len(names) >= max_names:
             break
 

--- a/.github/scripts/release_draft/supporters.py
+++ b/.github/scripts/release_draft/supporters.py
@@ -35,6 +35,7 @@ MAX_MONTHLY_NAMES = 5
 
 # ---------- HTTP / pagination helpers ----------
 
+
 def _get(url: str) -> list[dict[str, Any]]:
     """
     Simple GET request helper.
@@ -47,10 +48,11 @@ def _get(url: str) -> list[dict[str, Any]]:
 
     return data
 
+
 # ---------- Data fetchers ----------
 
-def fetch_supporters(
-) -> list[dict[str, Any]]:
+
+def fetch_supporters() -> list[dict[str, Any]]:
     """
     Fetch supporters from Buy Me a Coffee across pages.
 
@@ -59,8 +61,7 @@ def fetch_supporters(
     return [s for s in _get(SUPPORTERS_API) if s.get("name") != "Someone"]
 
 
-def fetch_active_subscriptions(
-) -> list[dict[str, Any]]:
+def fetch_active_subscriptions() -> list[dict[str, Any]]:
     """
     Fetch active subscriptions (memberships)
     """
@@ -71,6 +72,7 @@ def fetch_active_subscriptions(
 
 
 # ---------- grouping helpers ----------
+
 
 def group_supporters_by_tier(
     supporters: list[dict[str, Any]],
@@ -92,7 +94,7 @@ def group_supporters_by_tier(
         coffees_raw = s.get("coffees", 0)
         try:
             coffees = int(coffees_raw)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             continue
         if coffees <= 0:
             continue
@@ -146,6 +148,7 @@ def build_monthly_supporters_block(
 
 # ---------- main assembly ----------
 
+
 def build_supporters_section() -> str:
     """
     Build the final markdown section.
@@ -174,7 +177,7 @@ def build_supporters_section() -> str:
         return (
             "Supporters powering this project ⚡ 👇\n\n"
             "_No public supporters found yet._\n"
-            f"Support the project at https://buymeacoffee.com/bramski"
+            "Support the project at https://buymeacoffee.com/bramski"
         )
 
     tiered = group_supporters_by_tier(supporters)
@@ -206,7 +209,7 @@ def build_supporters_section() -> str:
         lines.append("")
 
     lines.append("")
-    lines.append(f"Support the project at https://buymeacoffee.com/bramski")
+    lines.append("Support the project at https://buymeacoffee.com/bramski")
 
     return "\n".join(lines)
 

--- a/.github/scripts/release_draft/tests/__init__.py
+++ b/.github/scripts/release_draft/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the release-draft generation scripts."""

--- a/.github/scripts/release_draft/tests/test_changelog.py
+++ b/.github/scripts/release_draft/tests/test_changelog.py
@@ -44,7 +44,10 @@ def pr(number: int = 1, title: str = "chore: tidy", labels: list[str] | None = N
 
 def test_label_beats_conventional_type_and_respects_order() -> None:
     # powerprofile is declared before Features, so it wins even with a feat title.
-    assert category_title(pr(title="feat: new bulb", labels=["powerprofile", "feature"]), CATEGORIES) == "💡 Power profiles"
+    assert (
+        category_title(pr(title="feat: new bulb", labels=["powerprofile", "feature"]), CATEGORIES)
+        == "💡 Power profiles"
+    )
 
 
 def test_conventional_type_used_when_no_label_matches() -> None:
@@ -59,12 +62,14 @@ def test_unknown_type_is_uncategorised() -> None:
 
 
 def test_breaking_wins_over_everything() -> None:
-    assert resolve_category(pr(title="feat!: drop legacy", labels=["feature"]), CATEGORIES).title == "💥 Breaking Changes"
+    assert (
+        resolve_category(pr(title="feat!: drop legacy", labels=["feature"]), CATEGORIES).title == "💥 Breaking Changes"
+    )
     assert resolve_category(pr(title="fix: x", labels=["breaking"]), CATEGORIES).title == "💥 Breaking Changes"
 
 
 @pytest.mark.parametrize(
-    ("title", "labels", "breaking"),
+    "title,labels,breaking",
     [
         ("feat!: x", [], True),
         ("fix(core)!: x", [], True),
@@ -82,7 +87,7 @@ def test_is_breaking(title: str, labels: list[str], breaking: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    ("title", "labels", "level"),
+    "title,labels,level",
     [
         ("feat!: x", [], MAJOR),
         ("feat: x", ["breaking"], MAJOR),
@@ -103,7 +108,7 @@ def test_powerprofile_does_not_bump_minor_by_itself() -> None:
 
 
 @pytest.mark.parametrize(
-    ("version", "level", "expected"),
+    "version,level,expected",
     [
         ((1, 2, 3), PATCH, (1, 2, 4)),
         ((1, 2, 3), MINOR, (1, 3, 0)),

--- a/.github/scripts/release_draft/tests/test_integration_draft.py
+++ b/.github/scripts/release_draft/tests/test_integration_draft.py
@@ -25,10 +25,10 @@ class FakeClient:
     def commit_sha(self, ref: str) -> str:
         return f"sha-of-{ref}"
 
-    def commit_shas_since(self, base_sha: str | None, head_ref: str) -> list[str]:  # noqa: ARG002
+    def commit_shas_since(self, base_sha: str | None, head_ref: str) -> list[str]:
         return ["sha1", "sha2"]
 
-    def merged_pull_requests(self, commit_shas: list[str]) -> list[dict[str, Any]]:  # noqa: ARG002
+    def merged_pull_requests(self, commit_shas: list[str]) -> list[dict[str, Any]]:
         return self._pull_requests
 
     def create_release(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -177,4 +177,5 @@ def test_supporters_failure_does_not_block_drafting(monkeypatch: pytest.MonkeyPa
 def test_no_stable_release_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     client = FakeClient(releases=[release("v1.0.0-beta.0", prerelease=True)], pull_requests=[pr(10, "fix: x")])
     run(monkeypatch, client, channel="stable", head_ref="master")
-    assert not client.created and not client.updated
+    assert not client.created
+    assert not client.updated

--- a/.github/scripts/release_draft/tests/test_measure_draft.py
+++ b/.github/scripts/release_draft/tests/test_measure_draft.py
@@ -287,7 +287,7 @@ def test_release_verification_accepts_explicit_previous_tag() -> None:
 
 
 @pytest.mark.parametrize(
-    ("changelog", "message"),
+    "changelog,message",
     [
         ("# Changelog\n\n## Unreleased\n", "no section for target version 0.1.0"),
         (

--- a/.github/scripts/release_draft/update_integration_draft.py
+++ b/.github/scripts/release_draft/update_integration_draft.py
@@ -48,8 +48,8 @@ from changelog import (
     parse_core,
     render_sections,
 )
-from supporters import build_supporters_section
 from github_client import GitHubClient
+from supporters import build_supporters_section
 
 NAME_TEMPLATE = "v{version} 🌈"
 EXCLUDE_LABELS = frozenset({"skip-changelog", "dependencies", "measure-tool"})
@@ -100,11 +100,11 @@ def _latest_stable_release(client: GitHubClient) -> dict[str, Any] | None:
 def _next_beta_number(client: GitHubClient, core: tuple[int, int, int]) -> int:
     prefix = f"v{format_version(core)}-beta."
     numbers = [
-        int(release["tag_name"][len(prefix):])
+        int(release["tag_name"][len(prefix) :])
         for release in client.releases()
         if not release["draft"]
         and release["tag_name"].startswith(prefix)
-        and release["tag_name"][len(prefix):].isdigit()
+        and release["tag_name"][len(prefix) :].isdigit()
     ]
     return max(numbers) + 1 if numbers else 0
 
@@ -119,9 +119,7 @@ def _find_draft(client: GitHubClient, *, prerelease: bool) -> dict[str, Any] | N
         (
             release
             for release in client.releases()
-            if release["draft"]
-            and bool(release["prerelease"]) == prerelease
-            and release["tag_name"].startswith("v")
+            if release["draft"] and bool(release["prerelease"]) == prerelease and release["tag_name"].startswith("v")
         ),
         None,
     )

--- a/.github/scripts/release_draft/update_measure_draft.py
+++ b/.github/scripts/release_draft/update_measure_draft.py
@@ -96,10 +96,7 @@ class ReleaseDraftDriftError(ValueError):
 
 
 def _touches_measure(files: list[str]) -> bool:
-    return any(
-        filename.startswith(MEASURE_DIRECTORIES) or filename in MEASURE_FILES
-        for filename in files
-    )
+    return any(filename.startswith(MEASURE_DIRECTORIES) or filename in MEASURE_FILES for filename in files)
 
 
 def _only_touches_release_infrastructure(files: list[str]) -> bool:
@@ -130,9 +127,7 @@ def _qualified_pull_requests_since(
         raise ReleaseDraftDriftError(f"could not resolve previous tag {previous_tag}: {error}") from error
     commit_shas = client.commit_shas_since(base_sha, head_ref)
     return [
-        pull_request
-        for pull_request in client.merged_pull_requests(commit_shas)
-        if _qualifies(client, pull_request)
+        pull_request for pull_request in client.merged_pull_requests(commit_shas) if _qualifies(client, pull_request)
     ]
 
 
@@ -148,9 +143,7 @@ def _changelog_release(changelog: str, target_version: str) -> tuple[str, str]:
     headings = list(re.finditer(r"^## (?P<title>.+?)[ \t]*$", normalized, re.MULTILINE))
     target_pattern = re.compile(rf"{re.escape(target_version)}(?:\s+-\s+.+)?")
     target_indexes = [
-        index
-        for index, heading in enumerate(headings)
-        if target_pattern.fullmatch(heading.group("title"))
+        index for index, heading in enumerate(headings) if target_pattern.fullmatch(heading.group("title"))
     ]
     if not target_indexes:
         raise ReleaseDraftDriftError(f"Changelog has no section for target version {target_version}")

--- a/.github/scripts/update_hacs_manifest.py
+++ b/.github/scripts/update_hacs_manifest.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 
-def update_manifest():
+def update_manifest() -> None:
     """Update the manifest file."""
     version = "0.0.0"
     for index, value in enumerate(sys.argv):

--- a/.github/scripts/validate_translations.py
+++ b/.github/scripts/validate_translations.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
 import json
-import os
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
-from typing import Dict, List, Set, Tuple
+
 
 def extract_placeholders(text: str) -> set[str]:
     """
@@ -21,8 +20,9 @@ def extract_placeholders(text: str) -> set[str]:
         return set()
 
     # Find all occurrences of {name}
-    placeholders = re.findall(r'\{([^{}]+)\}', text)
+    placeholders = re.findall(r"\{([^{}]+)\}", text)
     return set(placeholders)
+
 
 def extract_all_placeholders(data: dict, path: str = "") -> dict[str, set[str]]:
     """
@@ -52,6 +52,17 @@ def extract_all_placeholders(data: dict, path: str = "") -> dict[str, set[str]]:
 
     return result
 
+
+def get_path_value(data: dict, path: str) -> tuple[bool, object]:
+    """Return whether a dotted path exists and its value when it does."""
+    current: object = data
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False, None
+        current = current[part]
+    return True, current
+
+
 def validate_translations(translations_dir: Path) -> list[str]:
     """
     Validate that all placeholders in en.json exist in all other translation files.
@@ -67,7 +78,7 @@ def validate_translations(translations_dir: Path) -> list[str]:
     if not en_file.exists():
         return ["Error: en.json not found in the translations directory"]
 
-    with open(en_file, 'r', encoding='utf-8') as f:
+    with open(en_file, encoding="utf-8") as f:
         en_data = json.load(f)
 
     en_placeholders = extract_all_placeholders(en_data)
@@ -80,7 +91,7 @@ def validate_translations(translations_dir: Path) -> list[str]:
         lang_code = translation_file.stem
 
         try:
-            with open(translation_file, 'r', encoding='utf-8') as f:
+            with open(translation_file, encoding="utf-8") as f:
                 lang_data = json.load(f)
         except json.JSONDecodeError:
             errors.append(f"Error: {lang_code}.json is not a valid JSON file")
@@ -89,19 +100,9 @@ def validate_translations(translations_dir: Path) -> list[str]:
         lang_placeholders = extract_all_placeholders(lang_data)
 
         for path, en_path_placeholders in en_placeholders.items():
-            path_parts = path.split('.')
-
-            current = lang_data
-            path_exists = True
-
-            for part in path_parts:
-                if part not in current:
-                    path_exists = False
-                    errors.append(f"Missing path in {lang_code}.json: {path}")
-                    break
-                current = current[part]
-
+            path_exists, current = get_path_value(lang_data, path)
             if not path_exists:
+                errors.append(f"Missing path in {lang_code}.json: {path}")
                 continue
 
             if path in lang_placeholders:
@@ -111,14 +112,14 @@ def validate_translations(translations_dir: Path) -> list[str]:
                 if missing_placeholders:
                     placeholders_str = ", ".join([f"{{{p}}}" for p in missing_placeholders])
                     errors.append(f"Missing placeholders in {lang_code}.json at path {path}: {placeholders_str}")
-            else:
-                if isinstance(current, str):
-                    placeholders_str = ", ".join([f"{{{p}}}" for p in en_path_placeholders])
-                    errors.append(f"Missing placeholders in {lang_code}.json at path {path}: {placeholders_str}")
+            elif isinstance(current, str):
+                placeholders_str = ", ".join([f"{{{p}}}" for p in en_path_placeholders])
+                errors.append(f"Missing placeholders in {lang_code}.json at path {path}: {placeholders_str}")
 
     return errors
 
-def main():
+
+def main() -> None:
     repo_root = Path(__file__).parent.parent.parent
 
     translations_dir = repo_root / "custom_components" / "powercalc" / "translations"
@@ -139,6 +140,7 @@ def main():
     else:
         print("\nAll translations are valid! No missing placeholders found.")
         sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/validate_translations.py
+++ b/.github/scripts/validate_translations.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 import re
 import sys
+from typing import Any
 
 
 def extract_placeholders(text: str) -> set[str]:
@@ -16,15 +17,12 @@ def extract_placeholders(text: str) -> set[str]:
     Returns:
         A set of placeholder names without the braces
     """
-    if not isinstance(text, str):
-        return set()
-
     # Find all occurrences of {name}
     placeholders = re.findall(r"\{([^{}]+)\}", text)
     return set(placeholders)
 
 
-def extract_all_placeholders(data: dict, path: str = "") -> dict[str, set[str]]:
+def extract_all_placeholders(data: dict[str, Any], path: str = "") -> dict[str, set[str]]:
     """
     Recursively extract all placeholders from a nested dictionary.
 
@@ -53,7 +51,7 @@ def extract_all_placeholders(data: dict, path: str = "") -> dict[str, set[str]]:
     return result
 
 
-def get_path_value(data: dict, path: str) -> tuple[bool, object]:
+def get_path_value(data: dict[str, Any], path: str) -> tuple[bool, object]:
     """Return whether a dotted path exists and its value when it does."""
     current: object = data
     for part in path.split("."):

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   assign:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,42 @@
+name: Dependency review
+
+# Renovate automerges every minor and patch update without a human in the loop,
+# so this is the gate that inspects what a pull request actually adds to the
+# dependency graph before it lands.
+on:
+  pull_request:
+    paths:
+      - '**/package-lock.json'
+      - '**/pyproject.toml'
+      - '**/uv.lock'
+      - '.github/workflows/dependency-review.yml'
+
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Leave the findings as a pull request comment instead of only in the log.
+      pull-requests: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Only newly introduced vulnerabilities fail the run. Pre-existing ones
+          # in the tree are tracked by the OSV scan, not by every unrelated PR.
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,6 +20,7 @@ jobs:
   deploy:
     name: Deploy website
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout website
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -13,12 +13,18 @@ jobs:
   release_zip_file:
     name: Prepare development release asset
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
 
       - name: Set manifest version number
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,26 @@
 name: Docs build and deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/docs.yml'
+      - 'docs/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  pull_request:
+    paths:
+      - '.github/workflows/docs.yml'
+      - 'docs/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 permissions:
   contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -20,6 +33,7 @@ jobs:
       - run: uv run --locked --only-group docs --no-build zensical build --clean
         working-directory: docs
       - name: Deploy to Cloudflare Pages
+        if: github.event_name != 'pull_request'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,13 @@ on:
       - 'docs/**'
       - 'pyproject.toml'
       - 'uv.lock'
+
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/generate-plots.yml
+++ b/.github/workflows/generate-plots.yml
@@ -12,10 +12,15 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: profile-library-writes
+  cancel-in-progress: false
+
 jobs:
   format:
     name: Generate plots
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -37,4 +42,4 @@ jobs:
         with:
           message: 'chore(profile): generate plots'
           pull: '--rebase --autostash'
-          push: 'origin HEAD:master --force'
+          push: 'origin HEAD:master'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,11 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+concurrency:
+  # Only the labels from the latest push to a pull request are interesting.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,5 +8,6 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
   workflow_dispatch:
 
@@ -12,12 +12,15 @@ permissions:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           activate-environment: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,9 @@ jobs:
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --locked
+        # The type checkers now cover utils/library and .github/scripts, so the
+        # groups holding their third-party imports have to be installed too.
+      - run: uv sync --locked --group library --group profile-library
       - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
         with:
           cache: true

--- a/.github/workflows/measure-release.yml
+++ b/.github/workflows/measure-release.yml
@@ -25,6 +25,7 @@ jobs:
     name: Update rolling draft
     needs: tag-release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: read
@@ -33,6 +34,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - name: Rebuild draft from merged Measure pull requests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +47,7 @@ jobs:
   tag-release:
     name: Tag and publish merged release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       actions: write
@@ -51,6 +57,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - name: Detect merged release
         id: release
         run: |

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,30 @@
+name: OSV scan
+
+# Scans every lockfile in the repository (root uv.lock, the measure and visualize
+# projects, and the npm lockfiles) against the OSV database. Findings land in
+# Security > Code scanning so they can be triaged and dismissed there, rather
+# than turning into a recurring red cross on an unfixable upstream advisory.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches:
+      - master
+    paths:
+      - '**/package-lock.json'
+      - '**/uv.lock'
+      - '.github/workflows/osv-scanner.yml'
+
+permissions: {}
+
+jobs:
+  scan:
+    permissions:
+      # Required by the reusable workflow to upload its SARIF report.
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+    with:
+      fail-on-vuln: false

--- a/.github/workflows/pr-comment-generate-plots.yml
+++ b/.github/workflows/pr-comment-generate-plots.yml
@@ -6,6 +6,12 @@ on:
       - 'profile_library/**/*.csv.gz'
       - 'profile_library/**/model.json'
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-comment-generate-plots.yml
+++ b/.github/workflows/pr-comment-generate-plots.yml
@@ -13,6 +13,7 @@ jobs:
   generate-plots:
     name: Generate plots
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/pr-comment-upload-and-comment.yml
+++ b/.github/workflows/pr-comment-upload-and-comment.yml
@@ -25,6 +25,7 @@ jobs:
     name: Upload plots to Imgur
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout comment action
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/prepare-measure-release.yml
+++ b/.github/workflows/prepare-measure-release.yml
@@ -27,6 +27,7 @@ jobs:
   prepare:
     name: Prepare release pull request
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/publish-measure-image.yml
+++ b/.github/workflows/publish-measure-image.yml
@@ -26,6 +26,7 @@ jobs:
     name: Build and push CLI Docker image
     if: github.event_name == 'push' || inputs.release_tag != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -83,6 +84,7 @@ jobs:
     name: Initialize Home Assistant app build
     if: inputs.release_tag != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     outputs:
@@ -129,6 +131,7 @@ jobs:
     name: Build Home Assistant app (${{ matrix.arch }})
     needs: home-assistant-app-init
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write
@@ -171,6 +174,7 @@ jobs:
       - home-assistant-app-init
       - home-assistant-app-build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       packages: write
@@ -196,6 +200,7 @@ jobs:
       - home-assistant-app-init
       - home-assistant-app-manifest
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -246,6 +251,7 @@ jobs:
       - home-assistant-app-init
       - publish-app-repository
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,7 @@ jobs:
   update_release_draft:
     name: Update release draft
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,7 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release_zip_file:
@@ -13,6 +12,12 @@ jobs:
     name: Prepare release asset
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      # Upload the zip as a release asset.
+      contents: write
+      # Sign the provenance statement and record it against the repository.
+      id-token: write
+      attestations: write
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -29,6 +34,10 @@ jobs:
         run: |
           cd custom_components/powercalc
           zip powercalc.zip -r ./
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ./custom_components/powercalc/powercalc.zip
       - name: Upload zip to release
         run: gh release upload "${GITHUB_REF_NAME}" ./custom_components/powercalc/powercalc.zip#powercalc.zip --clobber
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,16 @@ jobs:
     if: startsWith(github.event.release.tag_name, 'v')
     name: Prepare release asset
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - name: "Set manifest version number"
         run: |
           python3 "${{ github.workspace }}/.github/scripts/update_hacs_manifest.py" --version "${GITHUB_REF_NAME}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Run stale
         uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11

--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -15,6 +15,12 @@ on:
       - '.github/actions/build-measure-docker/**'
       - '.github/workflows/test-measure.yml'
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   tests:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     name: Run tests
     steps:
       - name: Check out code
@@ -58,6 +59,7 @@ jobs:
 
   docker:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 60
     name: Build Docker image
     steps:
       - name: Check out code
@@ -69,6 +71,7 @@ jobs:
 
   home-assistant-app:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 60
     name: Validate Home Assistant app
     steps:
       - name: Check out code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,23 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - '**.py'
+      - '.github/scripts/ha_version_matrix.py'
+      - '.github/scripts/release_draft/**'
+      - '.github/workflows/test.yml'
+      - 'custom_components/powercalc/**'
+      - 'pyproject.toml'
+      - 'tests/**'
+      - 'utils/library/**'
+      - 'uv.lock'
   pull_request:
     paths:
-      - '**.py'
+      - '.github/scripts/ha_version_matrix.py'
+      - '.github/scripts/release_draft/**'
+      - '.github/workflows/test.yml'
+      - 'custom_components/powercalc/**'
+      - 'pyproject.toml'
+      - 'tests/**'
+      - 'utils/library/**'
       - 'uv.lock'
 
 permissions:
@@ -16,6 +29,7 @@ permissions:
 jobs:
   tests:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     name: Run tests
     steps:
       - name: Check out code
@@ -43,8 +57,7 @@ jobs:
             --cov custom_components.powercalc \
             --cov-report xml \
             -o console_output_style=count \
-            -p no:sugar \
-            tests
+            -p no:sugar
           uv run --locked coverage lcov
       - name: Upload Coverage Results
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2
@@ -54,6 +67,7 @@ jobs:
 
   ha-versions:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 10
     name: Determine supported HA versions
     outputs:
       versions: ${{ steps.matrix.outputs.versions }}
@@ -62,12 +76,17 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
       - name: Build version matrix
         id: matrix
         run: python3 .github/scripts/ha_version_matrix.py >> "$GITHUB_OUTPUT"
 
   tests-ha-compat:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     needs: ha-versions
     if: needs.ha-versions.outputs.versions != '[]'
     name: Run tests (HA ${{ matrix.target.ha_version }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,12 @@ on:
       - 'utils/library/**'
       - 'uv.lock'
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/update-profile-library.yml
+++ b/.github/workflows/update-profile-library.yml
@@ -19,11 +19,16 @@ permissions:
   contents: write
   pull-requests: read
 
+concurrency:
+  group: profile-library-writes
+  cancel-in-progress: false
+
 jobs:
   format:
     name: Update profile library
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -37,8 +42,6 @@ jobs:
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - name: Pull again
-        run: git pull || true
       - name: Update library.json, authors and translations
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +53,8 @@ jobs:
         with:
           add: 'profile_library'
           message: 'chore(profile): update generated library'
-          push: 'origin HEAD:master --force'
+          pull: '--rebase --autostash'
+          push: 'origin HEAD:master'
       - name: Wait 5 seconds
         run: sleep 5
       - name: Purge cloudflare cache

--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -13,6 +13,7 @@ jobs:
   validate-hassfest:
     name: Hassfest validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -24,6 +25,7 @@ jobs:
   validate-hacs:
     name: HACS validation
     runs-on: "ubuntu-latest"
+    timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/validate-lut-files.yml
+++ b/.github/workflows/validate-lut-files.yml
@@ -8,6 +8,12 @@ on:
       - '.github/workflows/validate-lut-files.yml'
       - 'utils/library/scan_lut_quality.py'
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/validate-model-json-comment.yml
+++ b/.github/workflows/validate-model-json-comment.yml
@@ -23,6 +23,7 @@ jobs:
   comment:
     name: Comment on model.json validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout comment action
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/validate-model-json.yml
+++ b/.github/workflows/validate-model-json.yml
@@ -8,6 +8,12 @@ on:
       - '.github/scripts/profile_library/validate_model_json.py'
       - '.github/workflows/validate-model-json.yml'
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/validate-model-json.yml
+++ b/.github/workflows/validate-model-json.yml
@@ -15,6 +15,7 @@ jobs:
   validate_model_json:
     name: Validate model.json
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout trusted validation code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -13,6 +13,7 @@ jobs:
   validate_translations:
     name: Validate translation files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -6,6 +6,12 @@ on:
       - custom_components/powercalc/translations/*.json
   workflow_dispatch:
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  # Supersede in-flight runs for the same pull request; every other event gets a
+  # unique group so pushes, schedules and dispatches never cancel or queue each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   pull_request:
     branches: ["**"]
 
@@ -12,6 +12,7 @@ jobs:
   zizmor:
     name: Run zizmor 🌈
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       security-events: write
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ cov.xml
 
 custom_components/test
 
+# Home Assistant config created by script/develop.sh
+/config
+
 *.egg-info/
 
 # PyEnv Version File

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,13 +43,15 @@ repos:
         language: script
         types: [python]
         require_serial: true
-        files: ^custom_components/powercalc
+        files: ^(custom_components/powercalc|\.github/scripts|utils/library)/
+        exclude: /tests/
       - id: ty
         name: ty
-        entry: uv run ty check custom_components/powercalc
+        entry: uv run ty check custom_components/powercalc .github/scripts utils/library
         language: system
         pass_filenames: false
-        files: ^custom_components/powercalc/.*\.py$
+        files: ^(custom_components/powercalc|\.github/scripts|utils/library)/.*\.py$
+        exclude: /tests/
       - id: uv-lock
         name: uv lock --check
         entry: uv lock --check

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+`bgerritsen@gmail.com`.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/inclusion
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Powercalc
+
+Thanks for helping out. Powercalc is community driven, and there is more than one way to contribute.
+
+The full guides live at **[docs.powercalc.nl/contributing](https://docs.powercalc.nl/contributing/)**. This page is the short version.
+
+## Ways to contribute
+
+| I want to... | Start here |
+| --- | --- |
+| Add a device to the profile library | [Measuring and submitting power profiles](https://docs.powercalc.nl/contributing/measure/) |
+| Fix a bug or build a feature | [Integration development](https://docs.powercalc.nl/contributing/integration-development/) |
+| Translate Powercalc | [Translating](https://docs.powercalc.nl/contributing/translating/) |
+| Report a bug | [Open an issue](https://github.com/bramstroker/homeassistant-powercalc/issues/new/choose) |
+| Ask a question | [Discussions](https://github.com/bramstroker/homeassistant-powercalc/discussions) |
+
+New device profiles are the most valuable contribution of all: they are what makes Powercalc accurate for everyone.
+
+## Development setup
+
+Powercalc uses [uv](https://docs.astral.sh/uv/) and targets the Python version pinned in `pyproject.toml`.
+
+```bash
+uv sync --locked --group dev
+tests/setup.sh
+uv run pytest tests/
+```
+
+A ready-made [dev container](.devcontainer/README.md) is available if you would rather not set up Home Assistant by hand — open the repository in VS Code or a Codespace and it starts a Home Assistant instance with Powercalc already loaded.
+
+Full instructions, including running Powercalc against a local Home Assistant, are in [Integration development](https://docs.powercalc.nl/contributing/integration-development/).
+
+## Before you open a pull request
+
+- **Write tests.** Powercalc follows a test-driven approach and enforces **100% coverage** on `custom_components/powercalc`. CI will fail below that.
+- **Run the checks.** `uv run prek run --all-files` runs the same lint, format, type and schema checks CI does.
+- **Use [Conventional Commits](https://docs.powercalc.nl/contributing/commits/)** for commit messages, for example `fix(discovery): prevent duplicate device proposals`. Pull request titles do not need a prefix.
+- **Keep it focused.** One concern per pull request is much easier to review than a mixed bag.
+- **Do not hand-edit generated files.** `profile_library/library.json` is produced by CI.
+
+## Reporting security issues
+
+Please do not open a public issue. See [SECURITY.md](SECURITY.md) for how to report privately.
+
+## Code of conduct
+
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ PowerCalc is powered by a growing community:
 - [Share measurements](https://docs.powercalc.nl/contributing/measure/)
 - Improve accuracy for everyone
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) to get started, and the [Code of Conduct](CODE_OF_CONDUCT.md) for how we work together.
+
 ---
 
 ## ⭐ Support the project

--- a/docs/source/contributing/integration-development.md
+++ b/docs/source/contributing/integration-development.md
@@ -8,6 +8,24 @@ So it's highly recommended to use the tests to verify your changes. See the [Run
 
 ## Setting up the development environment
 
+### Using the dev container (recommended)
+
+The repository ships a dev container that installs everything and runs Home Assistant with Powercalc already loaded, so you don't have to set up Home Assistant Core yourself.
+
+1. Fork the repository, then open your fork either in VS Code with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension (**Reopen in Container**) or in a [GitHub Codespace](https://github.com/features/codespaces).
+2. Wait for the container to build. It installs [uv](https://docs.astral.sh/uv/), the pinned Python version, all dependencies and the git hooks.
+3. Start Home Assistant:
+
+    ```bash
+    script/develop.sh
+    ```
+
+    Home Assistant becomes available on [http://localhost:8123](http://localhost:8123) with debug logging enabled for Powercalc. The configuration lives in a `config/` directory that is not tracked by git. Restart Home Assistant to pick up code changes.
+
+See [.devcontainer/README.md](https://github.com/bramstroker/homeassistant-powercalc/blob/master/.devcontainer/README.md) for more details.
+
+### Manual setup
+
 1. Setup a development environment for Home Assistant Core. Follow the instructions on the [Home Assistant Developer Documentation](https://developers.home-assistant.io/docs/development_environment).
 2. Fork and clone the Powercalc repository:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,14 @@ known-third-party = ["homeassistant"]
 force-sort-within-sections = true
 combine-as-imports = true
 
+[tool.ty.environment]
+# The release-draft entry points run as plain scripts and import their siblings flat.
+extra-paths = [".github/scripts/release_draft"]
+
+[tool.ty.src]
+# Test suites are exercised by pytest, not by the type checker.
+exclude = ["**/tests/"]
+
 [tool.ty.analysis]
 allowed-unresolved-imports = [
     "homeassistant.components.**",
@@ -56,6 +64,13 @@ local_partial_types = true
 warn_incomplete_stub = true
 warn_unused_configs = true
 warn_unreachable = true
+# The release-draft entry points are executed as plain scripts, so their sibling
+# modules are imported flat. Put that directory on the search path and make mypy
+# derive module names from an explicit base instead of walking up to __init__.py.
+mypy_path = ".github/scripts/release_draft"
+explicit_package_bases = true
+# Test suites are exercised by pytest, not by the type checker.
+exclude = ["/tests/"]
 
 [[tool.mypy.overrides]]
 module = "homeassistant.components.*"
@@ -126,6 +141,8 @@ dev = [
     "aioresponses>=0.7.6",
     "pyturbojpeg>=1.8.2",
     "ty>=0.0.39",
+    "types-jsonschema>=4.26.0.20260518",
+    "types-aiofiles>=25.1.0.20260518",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,15 @@ ignore_missing_imports = true
 [tool.coverage.paths]
 source = ["custom_components/powercalc", "utils", "tests"]
 
+[tool.coverage.report]
+fail_under = 100
+precision = 2
+show_missing = true
+
 [tool.ruff]
 line-length = 120
 target-version = "py314"
-exclude = ["utils/measure/playground", ".github", "docs"]
+exclude = ["utils/measure/playground", "docs"]
 
 [tool.ruff.lint]
 select = ["A", "ANN", "ASYNC", "B", "BLE", "C", "C4", "COM", "E", "F", "FAST", "FIX", "FLY", "FURB", "G", "ICN", "I", "INP", "ISC", "LOG", "N", "NPY", "PERF", "PIE", "PLE", "PT", "PYI", "Q", "RET", "RSE", "RUF", "S", "SIM", "SLF", "SLOT", "T10", "T20", "TID", "UP", "W", "YTT"]
@@ -76,6 +81,7 @@ select = ["A", "ANN", "ASYNC", "B", "BLE", "C", "C4", "COM", "E", "F", "FAST", "
 ignore = ["S101", "COM812"]
 
 [tool.ruff.lint.per-file-ignores]
+".github/scripts/**.py" = ["T201"]
 "utils/measure/**.py" = ["T201"]
 "tests/**.py" = ["ASYNC230"]
 

--- a/script/devcontainer-setup.sh
+++ b/script/devcontainer-setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Provision the dev container. Run automatically as the postCreateCommand.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPTPATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 && pwd -P)"
+cd "$SCRIPTPATH/.."
+
+# uv installs itself into ~/.local/bin, which is already on PATH in the base image.
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# uv resolves and downloads the Python version pinned in pyproject.toml itself,
+# so the base image does not need to ship a matching interpreter.
+echo "Installing dependencies..."
+uv sync --locked --group dev
+
+echo "Linking test integration..."
+tests/setup.sh
+
+echo "Installing git hooks..."
+uv run prek install
+
+echo
+echo "Ready. Run 'script/develop.sh' to start Home Assistant with Powercalc loaded."

--- a/script/develop.sh
+++ b/script/develop.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Start Home Assistant with Powercalc loaded from the working tree.
+# The config directory is created on first run and is not tracked by git,
+# so anything you configure in the UI survives restarts.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPTPATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 && pwd -P)"
+cd "$SCRIPTPATH/.."
+
+CONFIG_DIR="config"
+
+mkdir -p "$CONFIG_DIR/custom_components"
+ln -sfn ../../custom_components/powercalc "$CONFIG_DIR/custom_components/powercalc"
+
+if [ ! -f "$CONFIG_DIR/configuration.yaml" ]; then
+  echo "Creating $CONFIG_DIR/configuration.yaml"
+  cat >"$CONFIG_DIR/configuration.yaml" <<'YAML'
+default_config:
+
+logger:
+  default: info
+  logs:
+    custom_components.powercalc: debug
+YAML
+fi
+
+echo "Starting Home Assistant on http://localhost:8123"
+exec uv run hass --config "$CONFIG_DIR" --debug

--- a/script/run-mypy.sh
+++ b/script/run-mypy.sh
@@ -2,4 +2,4 @@
 
 set -o errexit
 
-uv run mypy custom_components/powercalc
+uv run mypy custom_components/powercalc .github/scripts utils/library

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import shutil
+from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp import ClientError
@@ -18,7 +19,12 @@ from custom_components.powercalc.const import LIBRARY_DISCOVERY_IGNORED_DOMAINS
 from custom_components.powercalc.helpers import get_library_json_path, get_library_path
 from custom_components.powercalc.power_profile.error import LibraryLoadingError, ProfileDownloadError
 from custom_components.powercalc.power_profile.library import ModelInfo, ProfileLibrary
-from custom_components.powercalc.power_profile.loader.remote import ENDPOINT_DOWNLOAD, ENDPOINT_LIBRARY, RemoteLoader
+from custom_components.powercalc.power_profile.loader.remote import (
+    ENDPOINT_DOWNLOAD,
+    ENDPOINT_LIBRARY,
+    LibraryModel,
+    RemoteLoader,
+)
 from custom_components.powercalc.power_profile.power_profile import DeviceType, DiscoveryBy
 from tests.common import get_test_config_dir, get_test_profile_dir
 
@@ -159,6 +165,15 @@ async def test_get_model_listing(remote_loader: RemoteLoader) -> None:
     device_models = await remote_loader.get_model_listing("signify", None, DiscoveryBy.DEVICE)
     assert ("BSB002", "Hue Bridge V2") in device_models
     assert ("LCT010", "Hue White and Color Ambiance A19 E26 (Gen 3)") not in device_models
+
+
+async def test_get_model_metadata_rejects_invalid_device_type(remote_loader: RemoteLoader) -> None:
+    remote_loader.model_infos["test/invalid"] = cast(
+        "LibraryModel",
+        {"id": "invalid", "hash": "hash", "device_type": "invalid"},
+    )
+
+    assert await remote_loader.get_model_metadata("test", "invalid") is None
 
 
 async def test_find_model_migration(hass: HomeAssistant, mock_aioresponse: aioresponses) -> None:

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -3,4 +3,4 @@
 SCRIPTPATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit; pwd -P)"
 
 cd "$SCRIPTPATH/../custom_components" || exit
-ln -sf ../tests/testing_config/custom_components/test test
+ln -sfn ../tests/testing_config/custom_components/test test

--- a/tests/test_device_binding.py
+++ b/tests/test_device_binding.py
@@ -24,6 +24,7 @@ from custom_components.powercalc.const import (
 )
 from custom_components.powercalc.device_binding import (
     attach_configured_device_entry,
+    get_config_entry_ids,
     get_first_device_for_config_entry,
     get_non_composite_devices,
     get_related_device_ids,
@@ -77,7 +78,9 @@ def test_get_related_device_ids_for_unknown_device(hass: HomeAssistant) -> None:
 def test_get_first_device_for_config_entry(hass: HomeAssistant) -> None:
     device_entry = mock_device(hass, "regular-device", manufacturer=None, model=None)
 
-    assert get_first_device_for_config_entry(hass, device_entry.config_entry_id) == device_entry
+    config_entry_id = next(iter(get_config_entry_ids(device_entry)))
+
+    assert get_first_device_for_config_entry(hass, config_entry_id) == device_entry
 
 
 def test_attach_configured_device_entry_keeps_source_entity_when_device_is_missing(hass: HomeAssistant) -> None:

--- a/tests/test_device_binding.py
+++ b/tests/test_device_binding.py
@@ -22,7 +22,13 @@ from custom_components.powercalc.const import (
     DUMMY_ENTITY_ID,
     SensorType,
 )
-from custom_components.powercalc.device_binding import attach_configured_device_entry, is_composite_device_id
+from custom_components.powercalc.device_binding import (
+    attach_configured_device_entry,
+    get_first_device_for_config_entry,
+    get_non_composite_devices,
+    get_related_device_ids,
+    is_composite_device_id,
+)
 from tests.common import (
     create_mock_config_entry,
     mock_device,
@@ -50,6 +56,28 @@ def test_device_is_not_composite_when_detection_is_unavailable(
     monkeypatch.setattr(DeviceRegistry, "async_is_composite_device_id", None, raising=False)
 
     assert not is_composite_device_id(hass, device_entry.id)
+
+
+def test_get_non_composite_devices_when_detection_is_unavailable(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device_entry = mock_device(hass, "regular-device", manufacturer=None, model=None)
+    monkeypatch.setattr(DeviceRegistry, "async_is_composite_device_id", None, raising=False)
+
+    assert get_non_composite_devices(hass) == [device_entry]
+
+
+def test_get_related_device_ids_for_unknown_device(hass: HomeAssistant) -> None:
+    mock_device_registry(hass)
+
+    assert get_related_device_ids(hass, "missing-device") == {"missing-device"}
+
+
+def test_get_first_device_for_config_entry(hass: HomeAssistant) -> None:
+    device_entry = mock_device(hass, "regular-device", manufacturer=None, model=None)
+
+    assert get_first_device_for_config_entry(hass, device_entry.config_entry_id) == device_entry
 
 
 def test_attach_configured_device_entry_keeps_source_entity_when_device_is_missing(hass: HomeAssistant) -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
@@ -1258,6 +1259,36 @@ async def test_initial_discovery_is_delayed(
     await async_advance_time(hass, DISCOVERY_DELAY)
 
     assert len(mock_flow_init.mock_calls) == 1
+
+
+async def test_initial_discovery_propagates_cancellation_while_running(hass: HomeAssistant) -> None:
+    discovery_manager = DiscoveryManager(hass, {})
+
+    with (
+        patch.object(discovery_manager, "start_discovery", side_effect=asyncio.CancelledError),
+        patch("custom_components.powercalc.discovery.async_call_later") as mock_call_later,
+    ):
+        discovery_manager._schedule_initial_discovery()  # noqa: SLF001
+        scheduled_job = mock_call_later.call_args.args[2]
+        with pytest.raises(asyncio.CancelledError):
+            await scheduled_job.target(None)
+
+
+async def test_initial_discovery_logs_unexpected_failure(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    discovery_manager = DiscoveryManager(hass, {})
+
+    with (
+        patch.object(discovery_manager, "start_discovery", side_effect=RuntimeError("boom")),
+        patch("custom_components.powercalc.discovery.async_call_later") as mock_call_later,
+    ):
+        discovery_manager._schedule_initial_discovery()  # noqa: SLF001
+        scheduled_job = mock_call_later.call_args.args[2]
+        await scheduled_job.target(None)
+
+    assert "Error during initial discovery" in caplog.text
 
 
 async def test_pending_initial_discovery_is_cancelled_when_disabled(

--- a/utils/library/build_info_table.py
+++ b/utils/library/build_info_table.py
@@ -1,13 +1,14 @@
 from collections.abc import Callable, Mapping
+from typing import Any
 
 import pytablewriter
 
 from utils.library.common import find_model_json_files
 
 
-def build_list(filter_callback: Callable | None, fields: list[str]) -> list[Mapping[str, str]]:
+def build_list(filter_callback: Callable[[dict[str, Any]], bool] | None, fields: list[str]) -> list[Mapping[str, str]]:
     """Count occurrences of each measure_device in all model.json files."""
-    listing = []
+    listing: list[Mapping[str, str]] = []
     for model_data in find_model_json_files():
         json_data = model_data["data"]
         if filter_callback and not filter_callback(json_data):
@@ -26,7 +27,7 @@ def write_md_table(data: list[Mapping[str, str]], output_file: str) -> None:
     """Write the listing data to a Markdown table using pytablewriter."""
     writer = pytablewriter.MarkdownTableWriter()
     writer.table_name = "Device Power Data"
-    fields = data[0].keys()
+    fields = list(data[0].keys())
     writer.headers = fields
     writer.value_matrix = [[row.get(field, "") for field in fields] for row in data]
 

--- a/utils/library/common.py
+++ b/utils/library/common.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 import json
 import os
+from typing import Any
 
 PROFILE_DIRECTORY = os.path.join(os.path.dirname(__file__), "../../profile_library")
 
@@ -10,7 +11,7 @@ def _path_part(path_parts: list[str], index: int) -> str | None:
     return path_parts[index] if len(path_parts) > index else None
 
 
-def _read_model_json(directory: str, root: str, file_name: str) -> dict:
+def _read_model_json(directory: str, root: str, file_name: str) -> dict[str, Any]:
     """Read a single model.json file and enrich it with the profile identifiers from its path."""
     full_path = os.path.join(root, file_name)
     path_parts = os.path.relpath(root, directory).split(os.sep)
@@ -27,7 +28,7 @@ def _read_model_json(directory: str, root: str, file_name: str) -> dict:
     }
 
 
-def find_model_json_files(directory: str | None = None) -> Generator:
+def find_model_json_files(directory: str | None = None) -> Generator[dict[str, Any]]:
     """Recursively find all model.json files in a directory."""
     if directory is None:
         directory = PROFILE_DIRECTORY

--- a/utils/library/field_counts.py
+++ b/utils/library/field_counts.py
@@ -4,9 +4,9 @@ from collections import Counter
 from utils.library.common import find_model_json_files
 
 
-def count_field(field_name: str) -> Counter:
+def count_field(field_name: str) -> Counter[str]:
     """Count occurrences of each value for the given field in all model.json files."""
-    counter = Counter()
+    counter: Counter[str] = Counter()
 
     for model_data in find_model_json_files():
         value = model_data["data"].get(field_name)

--- a/utils/library/validate_model_json.py
+++ b/utils/library/validate_model_json.py
@@ -1,19 +1,20 @@
 import glob
 import json
 import os
+from typing import Any, cast
 
 from jsonschema import ValidationError, validate
 
 from utils.library.common import PROFILE_DIRECTORY
 
 
-def load_json(file_path: str) -> dict:
+def load_json(file_path: str) -> dict[str, Any]:
     """Load a JSON file from the given file path."""
     with open(file_path) as file:
-        return json.load(file)
+        return cast(dict[str, Any], json.load(file))
 
 
-def validate_model(model_path: str, schema: dict) -> None:
+def validate_model(model_path: str, schema: dict[str, Any]) -> None:
     """Validate a JSON model against the schema."""
     try:
         model = load_json(model_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1663,7 +1663,9 @@ dev = [
     { name = "pyturbojpeg" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "types-aiofiles" },
     { name = "types-croniter" },
+    { name = "types-jsonschema" },
     { name = "types-pytz" },
     { name = "voluptuous-stubs" },
 ]
@@ -1694,7 +1696,9 @@ dev = [
     { name = "pyturbojpeg", specifier = ">=1.8.2" },
     { name = "ruff", specifier = ">=0.15.0" },
     { name = "ty", specifier = ">=0.0.39" },
+    { name = "types-aiofiles", specifier = ">=25.1.0.20260518" },
     { name = "types-croniter", specifier = ">=2.0" },
+    { name = "types-jsonschema", specifier = ">=4.26.0.20260518" },
     { name = "types-pytz", specifier = ">=2024.1" },
     { name = "voluptuous-stubs", specifier = ">=0.1" },
 ]
@@ -2744,12 +2748,33 @@ datetime = [
 ]
 
 [[package]]
+name = "types-aiofiles"
+version = "25.1.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/42/f5b9b90162d2196f016b87228d6bf43f2c2c0c6501bfd5415001b3eb68bb/types_aiofiles-25.1.0.20260518.tar.gz", hash = "sha256:c0c95eb78755d4fa7b397d4f0332c632714dd7cd0d17f49b96e31d4d7a8d8c76", size = 14891, upload-time = "2026-05-18T06:05:27.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/3d/7a9ed9faafeae3aa3b5bc22fa5b979ff9cf3c83ecbe919b58eae07795b8c/types_aiofiles-25.1.0.20260518-py3-none-any.whl", hash = "sha256:f776bdfb4bec17f743d9ef042e61edf03bdcc7821fc08556fba9b63d873fdea9", size = 14377, upload-time = "2026-05-18T06:05:26.871Z" },
+]
+
+[[package]]
 name = "types-croniter"
 version = "6.0.0.20250626"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/7e/2bb235f73d545fe3b77658a63b71e8d68b4fcabfbedd7956661bc31e6303/types_croniter-6.0.0.20250626.tar.gz", hash = "sha256:c32243b16d4dfa7c9989a5eadc6762459d093dded023f3c363fdee6b96578a77", size = 11745, upload-time = "2025-06-26T03:12:04.28Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/84/d51e29ccfe9ae23bb0cd0a4c91741ef03c923f7385eeac4b00411e20988c/types_croniter-6.0.0.20250626-py3-none-any.whl", hash = "sha256:3e8c37b54b541f323b2c487f3a1c9dcb27a7092333a2d5c09fff0c4d41c68380", size = 9757, upload-time = "2025-06-26T03:12:03.241Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- enforce a 100% coverage floor and add tests for the previously uncovered branches
- lint GitHub Python tooling with Ruff under Python 3.14 and fix all findings
- correct CI path and default-branch triggers, and validate documentation on pull requests
- serialize generated profile-library writes and remove force pushes
- add explicit timeouts to every runner-backed GitHub Actions job
- make the test setup symlink creation idempotent
- add devcontainer
- add code of conduct and contribution.MD
- add dependency and vulnarability scanner in github actions

## Why

The repository already had strong automation, but several quality gates could be skipped or silently regress. Generated-content workflows could also race and overwrite one another. These changes make those checks explicit and keep automated writes safe.

## Impact

Contributors get earlier feedback for documentation, library utility, workflow, and coverage regressions. Release and maintenance tooling now runs consistently on Python 3.14.

## Validation

- 1,144 tests passed with 100.00% integration coverage
- 51 release-draft tooling tests passed
- full `prek run --all-files` passed, including Ruff, mypy, ty, workflow schema validation, actionlint, Zizmor, codespell, and shellcheck
- Zensical documentation build passed
- translation validation passed
- profile-library script entry point verified
