### PR TITLE
add Levoit Core 400S power profile

### DIFF
--- a/profile_library/vesync/Core400S/model.json
+++ b/profile_library/vesync/Core400S/model.json
@@ -1,0 +1,23 @@
+{
+  "calculation_strategy": "fixed",
+  "created_at": "2026-08-09T00:00:00Z",
+  "device_type": "fan",
+  "measure_device": "P3 International Kill A Watt EZ (Model P4460)",
+  "measure_method": "manual",
+  "name": "Core 400S Series Air Purifier",
+  "standby_power": 1.2,
+  "fixed_config": {
+    "states_power": {
+      "preset_mode|sleep": 3.3,
+      "preset_mode|auto": 37.0,
+      "percentage|25": 4.9,
+      "percentage|50": 7.8,
+      "percentage|75": 15.1,
+      "percentage|100": 37.0
+    }
+  },
+  "author_info": {
+    "name": "nathanzm",
+    "github": "nathanzm"
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
https://us.vesync.com/product-detail/levoit-core-400s-p-smart-air-purifier-314
## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
<img width="841" height="565" alt="image" src="https://github.com/user-attachments/assets/0fd406ab-5a82-4232-aa93-611ed5fe2a46" />

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [ ] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
I measured every setting manually with a P3 International Kill A Watt EZ (Model P4460) and verified that this profile is working with Powercalc's auto-discovery.