### PR TITLE
Add a bug report template just for measurement bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-measure.yml
+++ b/.github/ISSUE_TEMPLATE/bug-measure.yml
@@ -17,7 +17,7 @@ body:
     options:
       - label: I have read the [FAQ](https://docs.powercalc.nl/contributing/measure/troubleshooting/) to see if there is a known solution to my problem.
         required: true
-      - label: I have used the latest version. 
+      - label: I have used the latest version.
         required: true
       - label: I have filled out the issue template to the best of my ability.
         required: true
@@ -45,7 +45,7 @@ body:
 - type: textarea
   attributes:
     label: "Measurement logs"
-    description: "Get them via a click on the Measurement UI or paste the CLI output." 
+    description: "Get them via a click on the Measurement UI or paste the CLI output."
 
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/bug-measure.yml
+++ b/.github/ISSUE_TEMPLATE/bug-measure.yml
@@ -46,6 +46,6 @@ body:
   id: "Measurement logs and diagnostics"
   attributes:
     label: Upload measurement logs and diagnostics
-    description: Please upload your measurement data. You can downoad that from the GUI or write the CLI output into a file.
+    description: Please upload your measurement data. You can download that from the GUI or write the CLI output into a file.
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/bug-measure.yml
+++ b/.github/ISSUE_TEMPLATE/bug-measure.yml
@@ -42,10 +42,10 @@ body:
       ...
   validations:
     required: true
-- type: textarea
+- type: upload
+  id: "Measurement logs and diagnostics"
   attributes:
-    label: "Measurement logs"
-    description: "Get them via a click on the Measurement UI or paste the CLI output."
-
+    label: Upload measurement logs and diagnostics
+    description: Please upload your measurement data. You can downoad that from the GUI or write the CLI output into a file.
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/bug-measure.yml
+++ b/.github/ISSUE_TEMPLATE/bug-measure.yml
@@ -1,0 +1,51 @@
+---
+name: "Bug report about measurements"
+description: "Report a measurement bug with Powercalc Measure (CLI or HomeAssistant app)"
+labels: "bug"
+body:
+- type: markdown
+  attributes:
+    value: Before you open a new issue, search through the existing issues to see if others have had the same problem.
+- type: textarea
+  attributes:
+    label: "System information"
+    description: "Paste the data from the measurement app here or manually write your used versions"
+    required: true
+- type: checkboxes
+  attributes:
+    label: Checklist
+    options:
+      - label: I have read the [FAQ](https://docs.powercalc.nl/troubleshooting/faq/) to see if there is a known solution to my problem.
+        required: true
+      - label: I have used the latest version. 
+        required: true
+      - label: I have filled out the issue template to the best of my ability.
+        required: true
+      - label: This issue only contains 1 issue (if you have multiple issues, open one issue for each issue).
+        required: true
+      - label: This issue is not a duplicate issue of currently [previous issues](https://github.com/bramstroker/homeassistant-powercalc/issues?q=is%3Aissue+label%3A%22bug%22+)..
+        required: true
+- type: textarea
+  attributes:
+    label: "Describe the issue"
+    description: "A clear and concise description of what the issue is."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Reproduction steps
+    description: "Without steps to reproduce, it will be hard to fix, it is very important that you fill out this part, issues without it will be closed"
+    value: |
+      1.
+      2.
+      3.
+      ...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Measurement logs"
+    description: "Get them via a click on the Measurement UI or paste the CLI output." 
+
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/bug-measure.yml
+++ b/.github/ISSUE_TEMPLATE/bug-measure.yml
@@ -15,7 +15,7 @@ body:
   attributes:
     label: Checklist
     options:
-      - label: I have read the [FAQ](https://docs.powercalc.nl/troubleshooting/faq/) to see if there is a known solution to my problem.
+      - label: I have read the [FAQ](https://docs.powercalc.nl/contributing/measure/troubleshooting/) to see if there is a known solution to my problem.
         required: true
       - label: I have used the latest version. 
         required: true


### PR DESCRIPTION
I noticed the "normal" bug report template does not really fit the new measurement app bugs e.g. here.

So what do you think of this? Still a draft, I need to adjust more things.

