### PR TITLE
Fix deprecation warning related to device binding

### DIFF
--- a/custom_components/powercalc/config_flow.py
+++ b/custom_components/powercalc/config_flow.py
@@ -47,7 +47,7 @@ from .const import (
     CalculationStrategy,
     SensorType,
 )
-from .device_binding import attach_configured_device_entry
+from .device_binding import resolve_source_device
 from .errors import ModelNotSupportedError, StrategyConfigurationError
 from .flow_helper.common import FlowType, PowercalcFormStep, Step, fill_schema_defaults, flatten_sections
 from .flow_helper.flows.cost import CostConfigFlow, CostOptionsFlow
@@ -510,7 +510,7 @@ class PowercalcOptionsFlow(PowercalcCommonFlow, OptionsFlow):
 
         self.sensor_config = dict(self.config_entry.data)
         if self.source_entity_id:
-            self.source_entity = attach_configured_device_entry(
+            self.source_entity = resolve_source_device(
                 self.hass,
                 self.sensor_config,
                 create_source_entity(

--- a/custom_components/powercalc/device_binding.py
+++ b/custom_components/powercalc/device_binding.py
@@ -126,7 +126,7 @@ def get_related_devices(hass: HomeAssistant, device_id: str) -> list[DeviceEntry
     return list(devices.values())
 
 
-def attach_configured_device_entry(
+def resolve_source_device(
     hass: HomeAssistant,
     sensor_config: ConfigType,
     source_entity: SourceEntity,
@@ -141,10 +141,10 @@ def attach_configured_device_entry(
     return source_entity
 
 
-def attach_entities_to_resolved_device(
+def assign_device_to_entities(
+    hass: HomeAssistant,
     config_entry: ConfigEntry | None,
     entities_to_add: list[Entity],
-    hass: HomeAssistant,
     source_entity: SourceEntity | None,
     sensor_config: ConfigType | None = None,
 ) -> None:
@@ -155,11 +155,12 @@ def attach_entities_to_resolved_device(
         return
 
     for entity in entities_to_add:
-        try:
+        # Home Assistant only accepts `device_entry` on entities belonging to a config entry.
+        # Setting it for YAML entities makes HA report a deprecation warning, so those rely
+        # solely on the registry update `bind_entity_to_device` does after they are added.
+        if config_entry:
             entity.device_entry = device_entry
-            setattr(entity, "_powercalc_device_entry", device_entry)  # noqa: B010
-        except AttributeError:  # pragma: no cover
-            _LOGGER.error("%s: Cannot set device id on entity", entity.entity_id)
+        setattr(entity, "_powercalc_device_entry", device_entry)  # noqa: B010
 
 
 def get_device_entry(

--- a/custom_components/powercalc/sensor.py
+++ b/custom_components/powercalc/sensor.py
@@ -86,8 +86,8 @@ from .const import (
     SensorType,
 )
 from .device_binding import (
-    attach_configured_device_entry,
-    attach_entities_to_resolved_device,
+    assign_device_to_entities,
+    resolve_source_device,
 )
 from .errors import (
     PowercalcSetupError,
@@ -217,7 +217,7 @@ async def _async_setup_entities(
         _LOGGER.error(err)
         return
 
-    attach_entities_to_resolved_device(config_entry, entities.new, hass, None, config)
+    assign_device_to_entities(hass, config_entry, entities.new, None, config)
 
     entities_to_add = [entity for entity in entities.new if isinstance(entity, SensorEntity)]
     for entity in entities_to_add:
@@ -661,7 +661,7 @@ async def create_individual_sensors(
     source_entity = create_source_entity(sensor_config[CONF_ENTITY_ID], hass)
 
     # For device-based profiles, attach the device entry to the source entity
-    source_entity = attach_configured_device_entry(hass, sensor_config, source_entity)
+    source_entity = resolve_source_device(hass, sensor_config, source_entity)
 
     used_unique_ids = hass.data[DOMAIN].get(DATA_USED_UNIQUE_IDS, [])
 
@@ -698,7 +698,7 @@ async def create_individual_sensors(
             create_energy_related_sensors(hass, sensor_config, energy_sensor, source_entity, config_entry),
         )
 
-    attach_entities_to_resolved_device(config_entry, entities_to_add, hass, source_entity, sensor_config)
+    assign_device_to_entities(hass, config_entry, entities_to_add, source_entity, sensor_config)
     hass.data[DOMAIN][DATA_CONFIGURED_ENTITIES].update(
         {source_entity.entity_id: [(entity, context.is_yaml) for entity in entities_to_add]},
     )

--- a/tests/common.py
+++ b/tests/common.py
@@ -244,7 +244,7 @@ def mock_device_with_entities(
     model: str = "LCT010",
     model_id: str | None = None,
     **entity_kwargs: Any,  # noqa: ANN401
-) -> None:
+) -> EntityRegistry:
     """Register entities on a single device carrying manufacturer/model info, so discovery can match a profile.
 
     Replaces both registries, so call it once per test and use `mock_devices` /
@@ -256,7 +256,7 @@ def mock_device_with_entities(
     if isinstance(entity_ids, str):
         entity_ids = [entity_ids]
     unique_id = entity_kwargs.pop("unique_id", None)
-    mock_entities_in_registry(
+    return mock_entities_in_registry(
         hass,
         {
             entity_id: {

--- a/tests/config_flow/test_virtual_power_library.py
+++ b/tests/config_flow/test_virtual_power_library.py
@@ -110,7 +110,7 @@ async def test_manual_setup_from_library_skips_to_manufacturer_step(
     assert result["step_id"] == Step.MANUFACTURER
 
 
-async def test_manufacturer_listing_is_filtered_by_entity_domain(
+async def test_manufacturer_listing_is_filtered_for_light_entity(
     hass: HomeAssistant,
 ) -> None:
     mock_entities_in_registry(hass, {"light.test": {"unique_id": DEFAULT_UNIQUE_ID}})
@@ -127,7 +127,7 @@ async def test_manufacturer_listing_is_filtered_by_entity_domain(
     assert {"value": "signify", "label": "Signify"} in manufacturer_options
 
 
-async def test_manufacturer_listing_is_filtered_by_entity_domain2(
+async def test_manufacturer_listing_is_filtered_for_switch_entity(
     hass: HomeAssistant,
 ) -> None:
     result = await goto_virtual_power_strategy_step(

--- a/tests/group_include/test_filter.py
+++ b/tests/group_include/test_filter.py
@@ -265,7 +265,7 @@ def test_create_filter(hass: HomeAssistant, filter_type: str, filter_config: dic
     assert isinstance(filter_instance, expected_type)
 
 
-def test_create_composite_filter(hass: HomeAssistant) -> None:
+def test_create_composite_filter_with_nested_and_or_conditions(hass: HomeAssistant) -> None:
     entity_filter = create_composite_filter(
         {
             CONF_DOMAIN: "switch",
@@ -288,7 +288,10 @@ def test_create_composite_filter(hass: HomeAssistant) -> None:
     assert not entity_filter.is_valid(_create_registry_entry("switch.some1"))
 
 
-def test_create_composite_filter2(hass: HomeAssistant, area_registry: AreaRegistry) -> None:
+def test_create_composite_filter_combines_area_and_nested_filter(
+    hass: HomeAssistant,
+    area_registry: AreaRegistry,
+) -> None:
     area_registry.async_get_or_create("kitchen")
     entity_filter = create_composite_filter(
         {

--- a/tests/strategy/test_composite.py
+++ b/tests/strategy/test_composite.py
@@ -267,7 +267,8 @@ async def test_playbook(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "sensor.dishwasher_power", "0.00")
 
 
-async def test_calculate_standby_power(hass: HomeAssistant) -> None:
+async def test_standby_power_is_ignored_when_strategy_handles_off_state(hass: HomeAssistant) -> None:
+    """Multi switch resolves the off state itself, so the configured standby power must not take over."""
     sensor_config = {
         CONF_ENTITY_ID: "switch.test",
         CONF_STANDBY_POWER: 1,
@@ -304,7 +305,8 @@ async def test_calculate_standby_power(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "sensor.test_power", "10.00")
 
 
-async def test_calculate_standby_power2(hass: HomeAssistant) -> None:
+async def test_standby_power_is_used_when_strategy_cannot_handle_off_state(hass: HomeAssistant) -> None:
+    """Fixed cannot resolve the off state, so the configured standby power applies instead."""
     sensor_config = {
         CONF_ENTITY_ID: "switch.test",
         CONF_STANDBY_POWER: 1,

--- a/tests/test_device_binding.py
+++ b/tests/test_device_binding.py
@@ -23,16 +23,17 @@ from custom_components.powercalc.const import (
     SensorType,
 )
 from custom_components.powercalc.device_binding import (
-    attach_configured_device_entry,
     get_config_entry_ids,
     get_first_device_for_config_entry,
     get_non_composite_devices,
     get_related_device_ids,
     is_composite_device_id,
+    resolve_source_device,
 )
 from tests.common import (
     create_mock_config_entry,
     mock_device,
+    mock_device_with_entities,
     mock_devices,
     mock_entities_in_registry,
     run_powercalc_setup,
@@ -83,11 +84,11 @@ def test_get_first_device_for_config_entry(hass: HomeAssistant) -> None:
     assert get_first_device_for_config_entry(hass, config_entry_id) == device_entry
 
 
-def test_attach_configured_device_entry_keeps_source_entity_when_device_is_missing(hass: HomeAssistant) -> None:
+def test_resolve_source_device_keeps_source_entity_when_device_is_missing(hass: HomeAssistant) -> None:
     mock_device_registry(hass)
     source_entity = SourceEntity(object_id="powercalc_dummy", entity_id=DUMMY_ENTITY_ID, domain="sensor")
 
-    result = attach_configured_device_entry(hass, {CONF_DEVICE: "missing-device-id"}, source_entity)
+    result = resolve_source_device(hass, {CONF_DEVICE: "missing-device-id"}, source_entity)
 
     assert result == source_entity
 
@@ -147,7 +148,7 @@ async def test_entities_are_bound_to_source_device(
     assert utility_entity_entry.device_id == device_entry.id
 
 
-async def test_entities_are_bound_to_source_device2(
+async def test_entities_are_bound_to_source_device_when_using_power_sensor_id(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -184,6 +185,20 @@ async def test_entities_are_bound_to_source_device2(
     assert len(caplog.records) == 0
 
 
+async def test_yaml_sensor_is_bound_to_source_device(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+    """YAML entities are bound with a registry update, which must not trigger the HA device attach warning."""
+    caplog.set_level(logging.WARNING)
+
+    entity_registry = mock_device_with_entities(hass, "light.test")
+    await run_powercalc_setup(hass, {CONF_ENTITY_ID: "light.test"})
+
+    power_sensor = entity_registry.async_get("sensor.test_power")
+    assert power_sensor
+    assert power_sensor.device_id == "model-device"
+
+    assert "attempts to attach a device to an entity without a config entry" not in caplog.text
+
+
 async def test_entities_are_bound_to_disabled_source_device(
     hass: HomeAssistant,
 ) -> None:
@@ -215,10 +230,11 @@ async def test_entities_are_bound_to_disabled_source_device(
     assert energy_entity_entry.device_id == device_id
 
 
-async def test_entities_are_bound_to_source_device3(
+async def test_entities_are_bound_to_configured_device_without_source_entity(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
+    """A device based profile has no source entity, so the sensors bind to the configured device."""
     device_id = "abc"
     mock_device(hass, device_id, "test", "test")
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -239,7 +239,7 @@ async def test_create_nested_handles_exception(hass: HomeAssistant, caplog: pyte
     caplog.set_level(logging.ERROR)
 
     with patch(
-        "custom_components.powercalc.sensor.attach_entities_to_resolved_device",
+        "custom_components.powercalc.sensor.assign_device_to_entities",
         new=MagicMock(side_effect=SensorConfigurationError("My custom error message")),
     ):
         await run_powercalc_setup(


### PR DESCRIPTION
Fixes:

Detected that custom integration 'powercalc' attempts to attach a device to an entity without a config entry. This will stop working in Home Assistant 2027.8.0, please create a bug report at https://github.com/bramstroker/homeassistant-powercalc/issues