### PR TITLE
perf(group_include): resolve nested light groups with O(1) entity lookup

### DIFF
--- a/custom_components/powercalc/group_include/filter.py
+++ b/custom_components/powercalc/group_include/filter.py
@@ -170,13 +170,7 @@ class LightGroupFilter(EntityFilter):
     @staticmethod
     def _find_light_group(hass: HomeAssistant, group_entity_id: str) -> Entity | None:
         light_component = cast(EntityComponent, hass.data.get(LIGHT_DOMAIN))
-        return next(
-            filter(
-                lambda entity: entity.entity_id == group_entity_id,
-                light_component.entities,
-            ),
-            None,
-        )
+        return light_component.get_entity(group_entity_id)
 
     def find_all_entity_ids_recursively(
         self,

--- a/tests/group_include/test_include.py
+++ b/tests/group_include/test_include.py
@@ -158,6 +158,58 @@ async def test_include_light_group(hass: HomeAssistant) -> None:
     )
 
 
+async def test_include_deeply_nested_light_group(hass: HomeAssistant) -> None:
+    """Light groups nested several levels deep should still resolve to the underlying light entities."""
+    await _create_powercalc_config_entry(hass, "light.deep_light")
+
+    mock_entities_in_registry(hass, {"light.deep_light": {}})
+    await set_states(hass, [("light.deep_light", STATE_ON)])
+
+    await async_setup_component(
+        hass,
+        light.DOMAIN,
+        {
+            light.DOMAIN: [
+                {
+                    "platform": "group",
+                    "name": "Level 1",
+                    "unique_id": "level1",
+                    "entities": ["light.deep_light"],
+                },
+                {
+                    "platform": "group",
+                    "name": "Level 2",
+                    "unique_id": "level2",
+                    "entities": ["light.level_1"],
+                },
+                {
+                    "platform": "group",
+                    "name": "Level 3",
+                    "unique_id": "level3",
+                    "entities": ["light.level_2"],
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_CREATE_GROUP: "Test deeply nested lightgroup",
+            CONF_INCLUDE: {CONF_GROUP: "light.level_3"},
+        },
+    )
+
+    await hass.async_start()
+
+    assert_entity_state(
+        hass,
+        "sensor.test_deeply_nested_lightgroup_power",
+        attributes={ATTR_ENTITIES: {"sensor.deep_light_power"}},
+    )
+
+
 async def test_error_is_logged_when_light_group_not_exists(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
LightGroupFilter._find_light_group did an $`\mathcal{O}(n)`$ linear scan over light_component.entities via next(filter(...)) to find one entity by entity_id. This was called once per recursion level in find_all_entity_ids_recursively, making deeply nested light group resolution $`\mathcal{O}(\text{depth} \times \text{total\_light\_entities})`$. Use EntityComponent's built-in get_entity(entity_id), which does an $`\mathcal{O}(1)`$ dict lookup, instead.

Added a regression test covering 3 levels of nested light groups to confirm resolution still works end-to-end.
