### PR TITLE
Measure multiple lights directly in measure app

### DIFF
--- a/docs/source/contributing/measure/lights.md
+++ b/docs/source/contributing/measure/lights.md
@@ -92,9 +92,11 @@ Notes:
 
 ## Multiple identical lights
 
-When standby power is too low for your meter, measuring multiple identical lights in parallel can make the total load measurable. The wizard asks whether you are measuring multiple lights and how many lights are connected.
+When standby power is too low for your meter, measuring multiple identical lights in parallel can make the total load measurable. In the Home Assistant app, enable **Measure multiple lights**, then use **Add another light** to select two or three individual light entities directly. The app sends each operating point to all selected entities and divides the measured power by **Number of lights**.
 
-Only use this when every connected light is the same model and receives the same commands. See [Standby power shows 0 W](troubleshooting.md#standby-power-shows-0-w) for details.
+For larger sets, prefer a native Zigbee or Hue group: it sends one command over the lighting network. A Home Assistant light group also works, but Home Assistant may fan the command out to every member. The app automatically counts the entities you select directly. When selecting a group as one entity, enter its total number of physical lights manually.
+
+Only use this when every connected light is the same model and receives the same commands. The app rejects different known model IDs and warns when Home Assistant does not provide enough model metadata to verify this. See [Standby power shows 0 W](troubleshooting.md#standby-power-shows-0-w) for details.
 
 ## Effect measurements
 

--- a/docs/source/contributing/measure/troubleshooting.md
+++ b/docs/source/contributing/measure/troubleshooting.md
@@ -35,7 +35,7 @@ Example:
 - Expected standby: ~0.2 W per bulb
 - With 4 bulbs: ~0.8 W total, which is usually measurable
 
-Make sure to have a group in Home Assistant that turns all bulbs on and off simultaneously during measurement. In the measure tool wizard select `yes` when asked `Are you measuring multiple lights?`, then enter the number of bulbs you are measuring.
+In the Home Assistant app, select a few individual light entities with **Add another light**, or select one native Zigbee/Hue group. Native groups are preferred for larger sets because they use one lighting-network command. A Home Assistant light group also works, but may send a separate command to every member. Enter the total number of physical bulbs in **Number of lights**; the app divides every measured value by this number.
 
 ### Add a dummy load
 

--- a/utils/measure/frontend/src/components/app-shell.ts
+++ b/utils/measure/frontend/src/components/app-shell.ts
@@ -250,7 +250,8 @@ export class AppShell extends LitElement implements MeasureAppState {
     const controller = definition?.fields.find((field) => field.role === "controller");
     const entity = controller && requestFieldValue(request, controller);
     if (controller) {
-      rows.push({ label: controller.label, value: typeof entity === "string" && entity ? entity : "Virtual device" });
+      const value = Array.isArray(entity) ? entity.join(", ") : entity;
+      rows.push({ label: controller.label, value: typeof value === "string" && value ? value : "Virtual device" });
     }
     rows.push({
       label: "Power",

--- a/utils/measure/frontend/src/components/setup-view.ts
+++ b/utils/measure/frontend/src/components/setup-view.ts
@@ -35,6 +35,7 @@ function formText(form: FormData, name: string): string {
 }
 
 const FULL_PRODUCT_NAME_HINT = "Enter the complete marketed name, including the series and variant shown on the product or packaging.";
+const MULTIPLE_LIGHTS_GUIDE_URL = "https://docs.powercalc.nl/contributing/measure/lights/#multiple-identical-lights";
 
 export class SetupView extends LitElement {
   static readonly properties = {
@@ -120,6 +121,8 @@ export class SetupView extends LitElement {
     .entity-list { display: grid; gap: 0.4rem; }
     .entity-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.5rem; align-items: center; }
     .entity-row button, .add-entity { min-height: 40px; }
+    .remove-entity { display: grid; place-items: center; width: 44px; padding: 0; }
+    .remove-entity svg { width: 20px; height: 20px; }
     .check { display: flex; grid-template-columns: none; align-items: center; gap: 0.5rem; min-height: 42px; padding: 0 0.75rem; border: 1px solid var(--line); border-radius: 999px; color: var(--ink); }
     .check input { min-height: auto; width: auto; accent-color: var(--signal); }
     /* A checkbox pill has no caption above it, so pin it to the input line of its row. */
@@ -159,6 +162,8 @@ export class SetupView extends LitElement {
     .dummy-controller p { margin: 0; }
     .multiple-lights { display: grid; justify-items: start; gap: 0.4rem; }
     .multiple-lights p { margin: 0; }
+    .help-link { display: inline-flex; align-items: center; margin-left: 0.25rem; color: var(--signal-strong); vertical-align: 0.15em; }
+    .help-link svg { width: 16px; height: 16px; }
     .dummy-load-options { display: grid; gap: 0.8rem; padding: 0.9rem; border: 1px solid var(--line); border-radius: 10px; background: var(--field); }
     .dummy-load-options p { margin: 0; }
     .calibration-card { display: grid; gap: 0.2rem; }
@@ -372,7 +377,22 @@ export class SetupView extends LitElement {
           />
           Measure multiple lights
         </label>
-        <p class="muted">Measuring multiple identical lights together increases the load, making very low power use easier to measure accurately.</p>
+        <p class="muted">
+          Measuring multiple identical lights together increases the load, making very low power use easier to measure accurately.
+          <a
+            class="help-link"
+            href=${MULTIPLE_LIGHTS_GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Learn more about measuring multiple identical lights"
+            title="Learn more"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="9"></circle>
+              <path d="M9.75 9a2.4 2.4 0 0 1 4.57 1c0 1.75-2.32 2.1-2.32 3.5M12 17h.01"></path>
+            </svg>
+          </a>
+        </p>
       </div>
     `;
   }
@@ -611,7 +631,19 @@ export class SetupView extends LitElement {
             ?disabled=${entity.entity_id !== value && values.includes(entity.entity_id)}
           >${entity.name} · ${entity.entity_id}</option>`)}
         </select>
-        ${values.length > 1 ? html`<button type="button" data-field=${field.name} data-index=${index} @click=${this.removeEntity}>Remove</button>` : nothing}
+        ${values.length > 1 ? html`<button
+          class="remove-entity danger"
+          type="button"
+          data-field=${field.name}
+          data-index=${index}
+          aria-label="Remove ${field.label}"
+          title="Remove ${field.label}"
+          @click=${this.removeEntity}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6M10 10v6M14 10v6"></path>
+          </svg>
+        </button>` : nothing}
       </div>`)}
       <button class="add-entity" type="button" data-field=${field.name} @click=${this.addEntity}>Add another ${field.label.toLowerCase()}</button>
       ${field.hint ? html`<small class="field-hint">${field.hint}</small>` : nothing}

--- a/utils/measure/frontend/src/components/setup-view.ts
+++ b/utils/measure/frontend/src/components/setup-view.ts
@@ -58,12 +58,14 @@ export class SetupView extends LitElement {
     errorMessage: { type: String },
     selectedType: { state: true },
     selectedEntities: { state: true },
+    selectedEntityLists: { state: true },
     selectValues: { state: true },
     multiSelection: { state: true },
     parameterValues: { state: true },
     dummyLoadEnabled: { state: true },
     dummyLoadMode: { state: true },
     dummyController: { state: true },
+    multipleLights: { state: true },
   };
 
   capabilities?: Capabilities;
@@ -87,20 +89,24 @@ export class SetupView extends LitElement {
   errorMessage = "";
   selectedType?: MeasureType;
   selectedEntities: Record<string, string> = {};
+  selectedEntityLists: Record<string, string[]> = {};
   selectValues: Record<string, string> = {};
   multiSelection: Record<string, string[]> = {};
   parameterValues: Record<string, string> = {};
   dummyLoadEnabled = false;
   dummyLoadMode: DummyLoadSpec["mode"] = "calibrate";
   dummyController = false;
+  multipleLights = false;
+  lightCountOverride?: string;
 
   static readonly styles = [sharedStyles, css`
     :host { display: block; min-width: 0; max-width: 100%; }
     form { display: grid; gap: 1rem; }
     .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
     .profile-grid { align-items: start; }
+    .profile-fields { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start; gap: 1rem; }
     label, fieldset { display: grid; gap: 0.4rem; }
-    label > span, legend { color: var(--muted); font-size: 0.82rem; font-weight: 650; }
+    label > span, legend, .field-label { color: var(--muted); font-size: 0.82rem; font-weight: 650; }
     .field-hint { color: var(--muted); font-size: 0.74rem; line-height: 1.4; }
     input, select {
       width: 100%; min-height: 44px; border: 1px solid var(--line); border-radius: 9px;
@@ -110,6 +116,9 @@ export class SetupView extends LitElement {
     fieldset.section { border: 1px solid var(--line); border-radius: 12px; padding: 1rem 1.1rem 1.2rem; margin: 0; display: grid; gap: 1rem; }
     fieldset.section > legend { padding: 0 0.4rem; color: var(--signal-strong); font-size: 0.85rem; font-weight: 700; }
     .checks { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+    .entity-list { display: grid; gap: 0.4rem; }
+    .entity-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.5rem; align-items: center; }
+    .entity-row button, .add-entity { min-height: 40px; }
     .check { display: flex; grid-template-columns: none; align-items: center; gap: 0.5rem; min-height: 42px; padding: 0 0.75rem; border: 1px solid var(--line); border-radius: 999px; color: var(--ink); }
     .check input { min-height: auto; width: auto; accent-color: var(--signal); }
     /* A checkbox pill has no caption above it, so pin it to the input line of its row. */
@@ -146,6 +155,8 @@ export class SetupView extends LitElement {
     .dummy-controller { display: grid; gap: 0.4rem; }
     .dummy-controller-toggle { width: fit-content; }
     .dummy-controller p { margin: 0; }
+    .multiple-lights { display: grid; justify-items: start; gap: 0.4rem; }
+    .multiple-lights p { margin: 0; }
     .dummy-load-options { display: grid; gap: 0.8rem; padding: 0.9rem; border: 1px solid var(--line); border-radius: 10px; background: var(--field); }
     .dummy-load-options p { margin: 0; }
     .calibration-card { display: grid; gap: 0.2rem; }
@@ -178,6 +189,10 @@ export class SetupView extends LitElement {
       this.dummyLoadMode = this.initialRequest?.dummy_load?.mode ?? (this.dummyLoadCalibration ? "reuse" : "calibrate");
       this.dummyController = Boolean(
         this.initialRequest && "controller" in this.initialRequest && this.initialRequest.controller.type === "dummy",
+      );
+      this.multipleLights = Boolean(
+        this.initialRequest?.measure_type === "light"
+        && (this.initialRequest.controller.type === "hass_multi" || this.initialRequest.multiple_light_count > 1),
       );
     } else if (changed.has("dummyLoadCalibration") && !this.dummyLoadEnabled) {
       this.dummyLoadMode = this.dummyLoadCalibration ? "reuse" : "calibrate";
@@ -255,6 +270,7 @@ export class SetupView extends LitElement {
     if (!definition || !this.capabilities) return html`<p class="muted">Loading measurement capabilities…</p>`;
     const run = this.initialRequest?.measure_type === type ? this.initialRequest : undefined;
     const fields = deviceFields(definition);
+    const multipleController = fields.find((field) => field.role === "controller" && field.multiple);
     // A multi-select needs the room of its own fieldset; the rest are grid cells.
     const blocks = fields.filter((field) => field.control === "multi_select");
     return html`
@@ -268,14 +284,13 @@ export class SetupView extends LitElement {
         <fieldset class="section">
           <legend>${definition.label}</legend>
           ${definition.fields.some((field) => field.role === "controller") ? this.renderDummyControllerToggle() : nothing}
+          ${multipleController && !this.dummyController ? this.renderMultipleLightsToggle(multipleController) : nothing}
           <div class="grid profile-grid">
             ${fields.filter((field) => field.control !== "multi_select").map((field) => this.genericField(field, run))}
-            ${definition.supports_profile
-              ? this.textField("model_id", "Model ID", this.modelId(run), definition.model_id_example && `e.g. ${definition.model_id_example}`, true)
-              : nothing}
-            ${definition.supports_profile
-              ? this.textField("product_name", "Full product name", run?.product_name ?? "", definition.product_name_example || definition.label, true, FULL_PRODUCT_NAME_HINT)
-              : nothing}
+            ${definition.supports_profile ? html`<div class="profile-fields">
+              ${this.textField("model_id", "Model ID", this.modelId(run), definition.model_id_example && `e.g. ${definition.model_id_example}`, true)}
+              ${this.textField("product_name", "Full product name", run?.product_name ?? "", definition.product_name_example || definition.label, true, FULL_PRODUCT_NAME_HINT)}
+            </div>` : nothing}
           </div>
           ${blocks.map((field) => this.multiSelectField(field, run))}
         </fieldset>
@@ -338,6 +353,24 @@ export class SetupView extends LitElement {
         ${this.dummyController
           ? html`<p class="muted">No real device is controlled during this measurement. Use it only to test the app itself.</p>`
           : nothing}
+      </div>
+    `;
+  }
+
+  private renderMultipleLightsToggle(field: FormField) {
+    return html`
+      <div class="multiple-lights">
+        <label class="check dummy-controller-toggle">
+          <input
+            type="checkbox"
+            name="measure_multiple_lights"
+            .checked=${this.multipleLights}
+            data-field=${field.name}
+            @change=${this.multipleLightsChanged}
+          />
+          Measure multiple lights
+        </label>
+        <p class="muted">Measuring multiple identical lights together increases the load, making very low power use easier to measure accurately.</p>
       </div>
     `;
   }
@@ -497,6 +530,9 @@ export class SetupView extends LitElement {
     if (!definition) return nothing;
     const name = field.name;
     if (this.dummyController && field.role === "controller") return nothing;
+    if (name === "multiple_light_count" && !this.multipleLights) {
+      return html`<input type="hidden" name=${name} value="1" />`;
+    }
     const stored = run && requestFieldValue(run, field);
     if (field.control === "boolean") {
       return html`<label class="check"><input type="checkbox" name=${name} .checked=${Boolean(stored ?? field.default)} />${field.label}</label>`;
@@ -512,6 +548,11 @@ export class SetupView extends LitElement {
         return html`<div class="notice error" role="alert">Could not load ${field.label.toLowerCase()} entities: ${this.deviceEntityErrors[failed]}</div>`;
       }
       const entities = this.entitiesIn(domains);
+      if (field.multiple) {
+        if (this.multipleLights) return this.multiEntityField(field, entities, stored);
+        const selected = this.selectedEntityIds(field, run)[0] ?? value;
+        return this.entitySelect(name, field.label.replace(/s$/, ""), entities, selected, field.required);
+      }
       return this.entitySelect(name, field.label, entities, value, field.required);
     }
     if (field.control === "select") {
@@ -523,7 +564,10 @@ export class SetupView extends LitElement {
       </select></label>`;
     }
     const type = field.control === "number" ? "number" : "text";
-    const value = (stored ?? field.default ?? "").toString();
+    const inferredCount = name === "multiple_light_count" ? this.selectedLightCount(run) : undefined;
+    const value = name === "multiple_light_count"
+      ? (this.lightCountOverride ?? (inferredCount && inferredCount > 1 ? String(inferredCount) : (stored ?? field.default ?? "").toString()))
+      : (stored ?? field.default ?? "").toString();
     return html`<label><span>${field.label}</span><input
       type=${type}
       name=${name}
@@ -532,7 +576,29 @@ export class SetupView extends LitElement {
       max=${field.maximum ?? nothing}
       ?required=${field.required}
       autocomplete="off"
-    /></label>`;
+      @input=${name === "multiple_light_count" ? this.lightCountChanged : null}
+    />${field.hint ? html`<small class="field-hint">${field.hint}</small>` : nothing}</label>`;
+  }
+
+  private multiEntityField(field: FormField, entities: EntityDescriptor[], stored: unknown) {
+    const storedValues = Array.isArray(stored) ? stored.map(String) : typeof stored === "string" && stored ? [stored] : [];
+    const values = this.selectedEntityLists[field.name] ?? (storedValues.length ? storedValues : [""]);
+    return html`<div class="entity-list">
+      <span class="field-label">${field.label}</span>
+      ${values.map((value, index) => html`<div class="entity-row">
+        <select name=${field.name} required data-index=${index} @change=${this.multiEntityChanged}>
+          <option value="">Select an entity</option>
+          ${entities.map((entity) => html`<option
+            value=${entity.entity_id}
+            ?selected=${entity.entity_id === value}
+            ?disabled=${entity.entity_id !== value && values.includes(entity.entity_id)}
+          >${entity.name} · ${entity.entity_id}</option>`)}
+        </select>
+        ${values.length > 1 ? html`<button type="button" data-field=${field.name} data-index=${index} @click=${this.removeEntity}>Remove</button>` : nothing}
+      </div>`)}
+      <button class="add-entity" type="button" data-field=${field.name} @click=${this.addEntity}>Add another light</button>
+      ${field.hint ? html`<small class="field-hint">${field.hint}</small>` : nothing}
+    </div>`;
   }
 
   private fieldDomains(field: MeasureDefinition["fields"][number]): string[] {
@@ -582,6 +648,26 @@ export class SetupView extends LitElement {
     this.dummyController = (event.currentTarget as HTMLInputElement).checked;
   }
 
+  private multipleLightsChanged(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement;
+    const field = input.dataset.field ?? "";
+    this.multipleLights = input.checked;
+    if (this.multipleLights) {
+      const selected = this.selectedEntities[field];
+      if (!this.selectedEntityLists[field] && selected) {
+        this.selectedEntityLists = { ...this.selectedEntityLists, [field]: [selected] };
+      }
+      return;
+    }
+    const first = this.selectedEntityLists[field]?.find(Boolean)
+      ?? this.selectedEntities[field]
+      ?? this.initialControllerEntities(field).find(Boolean)
+      ?? "";
+    this.selectedEntities = { ...this.selectedEntities, [field]: first };
+    this.selectedEntityLists = { ...this.selectedEntityLists, [field]: first ? [first] : [""] };
+    this.lightCountOverride = undefined;
+  }
+
   /** Options a field offers right now, narrowed by the capabilities of the entity it names. */
   private availableOptions(field: FormField, request?: MeasurementRequest): FormFieldOption[] {
     // A virtual device stands in for any real one, so it supports everything on offer.
@@ -610,6 +696,18 @@ export class SetupView extends LitElement {
     const definition = this.selectedType ? this.definition(this.selectedType) : undefined;
     const source = field.narrowed_by ? definition?.fields.find((candidate) => candidate.name === field.narrowed_by) : undefined;
     if (!source) return undefined;
+    if (source.multiple) {
+      const selected = this.selectedEntityIds(source, request)
+        .map((entityId) => this.entityChoices(source).find((entity) => entity.entity_id === entityId))
+        .filter((entity): entity is EntityDescriptor => Boolean(entity));
+      if (!selected.length) return undefined;
+      const first = selected[0];
+      if (!first) return undefined;
+      const supported = selected
+        .map((entity) => new Set(entity.supported_modes ?? []))
+        .reduce((common, modes) => new Set([...common].filter((mode) => modes.has(mode))));
+      return { ...first, supported_modes: [...supported] };
+    }
     const selected = this.selectedEntityId(source, request);
     return this.entityChoices(source).find((entity) => entity.entity_id === selected);
   }
@@ -628,10 +726,20 @@ export class SetupView extends LitElement {
     return this.selectedEntities[field.name] || (typeof stored === "string" ? stored : "");
   }
 
+  private selectedEntityIds(field: FormField, request?: MeasurementRequest): string[] {
+    const stored = request && requestFieldValue(request, field);
+    const selected = this.selectedEntities[field.name];
+    const values = this.selectedEntityLists[field.name]
+      ?? (selected ? [selected] : undefined)
+      ?? (Array.isArray(stored) ? stored : typeof stored === "string" && stored ? [stored] : []);
+    return values.filter(Boolean);
+  }
+
   private selectType(type: MeasureType): void {
     this.errorMessage = "";
     this.selectedType = type;
     this.dummyController = false;
+    this.multipleLights = false;
     this.dispatchEvent(new CustomEvent("measure-type-selected", { detail: type, bubbles: true, composed: true }));
   }
 
@@ -645,6 +753,48 @@ export class SetupView extends LitElement {
   private entityChanged(event: Event): void {
     const select = event.currentTarget as HTMLSelectElement;
     this.selectedEntities = { ...this.selectedEntities, [select.name]: select.value };
+  }
+
+  private multiEntityChanged(event: Event): void {
+    const select = event.currentTarget as HTMLSelectElement;
+    const index = Number(select.dataset.index);
+    const values = [...(this.selectedEntityLists[select.name] ?? [""])];
+    values[index] = select.value;
+    this.selectedEntityLists = { ...this.selectedEntityLists, [select.name]: values };
+  }
+
+  private addEntity(event: Event): void {
+    const field = (event.currentTarget as HTMLElement).dataset.field ?? "";
+    const values = this.selectedEntityLists[field] ?? this.initialControllerEntities(field);
+    this.selectedEntityLists = { ...this.selectedEntityLists, [field]: [...values, ""] };
+  }
+
+  private removeEntity(event: Event): void {
+    const button = event.currentTarget as HTMLElement;
+    const field = button.dataset.field ?? "";
+    const index = Number(button.dataset.index);
+    const values = [...(this.selectedEntityLists[field] ?? this.initialControllerEntities(field))];
+    values.splice(index, 1);
+    this.selectedEntityLists = { ...this.selectedEntityLists, [field]: values.length ? values : [""] };
+  }
+
+  private initialControllerEntities(field: string): string[] {
+    const definition = this.selectedType ? this.definition(this.selectedType) : undefined;
+    const descriptor = definition?.fields.find((candidate) => candidate.name === field);
+    const stored = descriptor && this.initialRequest ? requestFieldValue(this.initialRequest, descriptor) : undefined;
+    if (Array.isArray(stored)) return stored;
+    return typeof stored === "string" && stored ? [stored] : [""];
+  }
+
+  private lightCountChanged(event: Event): void {
+    this.lightCountOverride = (event.currentTarget as HTMLInputElement).value;
+  }
+
+  private selectedLightCount(request?: MeasurementRequest): number {
+    const definition = this.selectedType ? this.definition(this.selectedType) : undefined;
+    const field = definition?.fields.find((candidate) => candidate.role === "controller" && candidate.multiple);
+    if (!field) return 1;
+    return Math.max(1, new Set(this.selectedEntityIds(field, request)).size);
   }
 
 
@@ -695,10 +845,15 @@ export class SetupView extends LitElement {
 
   private modelId(request?: MeasurementRequest): string {
     if (request?.model_id) return request.model_id;
-    const requestEntityId = request && "controller" in request && request.controller.type === "hass" ? request.controller.entity_id : "";
-    const entityId = Object.values(this.selectedEntities).find(Boolean) || requestEntityId;
     const entities = [...this.lights, ...Object.values(this.deviceEntities).flat()];
-    return entities.find((entity) => entity.entity_id === entityId)?.model_id ?? "";
+    const multiField = this.selectedType ? this.definition(this.selectedType)?.fields.find((field) => field.multiple) : undefined;
+    const multiIds = multiField ? this.selectedEntityIds(multiField, request) : [];
+    const requestEntityId = request && "controller" in request && request.controller.type === "hass" ? request.controller.entity_id : "";
+    const ids = multiIds.length ? multiIds : [Object.values(this.selectedEntities).find(Boolean) || requestEntityId].filter(Boolean);
+    const modelIds = ids.map((id) => entities.find((entity) => entity.entity_id === id)?.model_id);
+    if (!modelIds.length || modelIds.some((modelId) => !modelId)) return "";
+    const models = new Set(modelIds);
+    return models.size === 1 ? [...models][0] ?? "" : "";
   }
 
   private submitMeasurement(event: SubmitEvent): void {

--- a/utils/measure/frontend/src/components/setup-view.ts
+++ b/utils/measure/frontend/src/components/setup-view.ts
@@ -7,6 +7,7 @@ import type {
   EntityDescriptor,
   FormField,
   FormFieldOption,
+  LutMode,
   MeasureDefaults,
   MeasureDefinition,
   MeasureParameter,
@@ -58,7 +59,6 @@ export class SetupView extends LitElement {
     errorMessage: { type: String },
     selectedType: { state: true },
     selectedEntities: { state: true },
-    selectedEntityLists: { state: true },
     selectValues: { state: true },
     multiSelection: { state: true },
     parameterValues: { state: true },
@@ -88,8 +88,8 @@ export class SetupView extends LitElement {
   busy = false;
   errorMessage = "";
   selectedType?: MeasureType;
-  selectedEntities: Record<string, string> = {};
-  selectedEntityLists: Record<string, string[]> = {};
+  /** Entities picked per field. A single-entity field simply holds a one-entry list. */
+  selectedEntities: Record<string, string[]> = {};
   selectValues: Record<string, string> = {};
   multiSelection: Record<string, string[]> = {};
   parameterValues: Record<string, string> = {};
@@ -97,7 +97,8 @@ export class SetupView extends LitElement {
   dummyLoadMode: DummyLoadSpec["mode"] = "calibrate";
   dummyController = false;
   multipleLights = false;
-  lightCountOverride?: string;
+  /** Deliberately not reactive: it exists so a typed count survives re-renders instead of being recomputed. */
+  private derivedCountOverride?: string;
 
   static readonly styles = [sharedStyles, css`
     :host { display: block; min-width: 0; max-width: 100%; }
@@ -152,8 +153,9 @@ export class SetupView extends LitElement {
     .power-meter-summary button { flex: 0 0 auto; min-height: 38px; padding: 0.4rem 0.9rem; }
     .dummy-load { display: grid; gap: 0.9rem; }
     .dummy-load-toggle { width: fit-content; }
+    /* A checkbox that reveals or hides a block of the form, rather than submitting a value. */
+    .toggle-pill { width: fit-content; }
     .dummy-controller { display: grid; gap: 0.4rem; }
-    .dummy-controller-toggle { width: fit-content; }
     .dummy-controller p { margin: 0; }
     .multiple-lights { display: grid; justify-items: start; gap: 0.4rem; }
     .multiple-lights p { margin: 0; }
@@ -270,7 +272,7 @@ export class SetupView extends LitElement {
     if (!definition || !this.capabilities) return html`<p class="muted">Loading measurement capabilities…</p>`;
     const run = this.initialRequest?.measure_type === type ? this.initialRequest : undefined;
     const fields = deviceFields(definition);
-    const multipleController = fields.find((field) => field.role === "controller" && field.multiple);
+    const multipleController = this.multiControllerField();
     // A multi-select needs the room of its own fieldset; the rest are grid cells.
     const blocks = fields.filter((field) => field.control === "multi_select");
     return html`
@@ -341,7 +343,7 @@ export class SetupView extends LitElement {
     if (!this.capabilities?.developer_mode) return nothing;
     return html`
       <div class="dummy-controller">
-        <label class="check dummy-controller-toggle">
+        <label class="check toggle-pill">
           <input
             type="checkbox"
             name="use_dummy_controller"
@@ -360,7 +362,7 @@ export class SetupView extends LitElement {
   private renderMultipleLightsToggle(field: FormField) {
     return html`
       <div class="multiple-lights">
-        <label class="check dummy-controller-toggle">
+        <label class="check toggle-pill">
           <input
             type="checkbox"
             name="measure_multiple_lights"
@@ -530,9 +532,7 @@ export class SetupView extends LitElement {
     if (!definition) return nothing;
     const name = field.name;
     if (this.dummyController && field.role === "controller") return nothing;
-    if (name === "multiple_light_count" && !this.multipleLights) {
-      return html`<input type="hidden" name=${name} value="1" />`;
-    }
+    if (field.derived_from) return this.derivedCountField(field, run);
     const stored = run && requestFieldValue(run, field);
     if (field.control === "boolean") {
       return html`<label class="check"><input type="checkbox" name=${name} .checked=${Boolean(stored ?? field.default)} />${field.label}</label>`;
@@ -548,12 +548,9 @@ export class SetupView extends LitElement {
         return html`<div class="notice error" role="alert">Could not load ${field.label.toLowerCase()} entities: ${this.deviceEntityErrors[failed]}</div>`;
       }
       const entities = this.entitiesIn(domains);
-      if (field.multiple) {
-        if (this.multipleLights) return this.multiEntityField(field, entities, stored);
-        const selected = this.selectedEntityIds(field, run)[0] ?? value;
-        return this.entitySelect(name, field.label.replace(/s$/, ""), entities, selected, field.required);
-      }
-      return this.entitySelect(name, field.label, entities, value, field.required);
+      if (field.multiple && this.multipleLights) return this.multiEntityField(field, entities, run);
+      const selected = field.multiple ? this.selectedEntityId(field, run) || value : value;
+      return this.entitySelect(name, field.label, entities, selected, field.required);
     }
     if (field.control === "select") {
       const value = (stored ?? field.default ?? "").toString();
@@ -563,28 +560,48 @@ export class SetupView extends LitElement {
         ${field.options.map((option) => html`<option value=${option.value} ?selected=${option.value === value}>${option.label}</option>`)}
       </select></label>`;
     }
-    const type = field.control === "number" ? "number" : "text";
-    const inferredCount = name === "multiple_light_count" ? this.selectedLightCount(run) : undefined;
-    const value = name === "multiple_light_count"
-      ? (this.lightCountOverride ?? (inferredCount && inferredCount > 1 ? String(inferredCount) : (stored ?? field.default ?? "").toString()))
-      : (stored ?? field.default ?? "").toString();
+    return this.valueField(field, (stored ?? field.default ?? "").toString());
+  }
+
+  /** A plain text or number input, rendered from what the field declares about itself. */
+  private valueField(field: FormField, value: string, onInput: ((event: Event) => void) | null = null) {
     return html`<label><span>${field.label}</span><input
-      type=${type}
-      name=${name}
+      type=${field.control === "number" ? "number" : "text"}
+      name=${field.name}
       .value=${value}
       min=${field.minimum ?? nothing}
       max=${field.maximum ?? nothing}
       ?required=${field.required}
       autocomplete="off"
-      @input=${name === "multiple_light_count" ? this.lightCountChanged : null}
+      @input=${onInput}
     />${field.hint ? html`<small class="field-hint">${field.hint}</small>` : nothing}</label>`;
   }
 
-  private multiEntityField(field: FormField, entities: EntityDescriptor[], stored: unknown) {
-    const storedValues = Array.isArray(stored) ? stored.map(String) : typeof stored === "string" && stored ? [stored] : [];
-    const values = this.selectedEntityLists[field.name] ?? (storedValues.length ? storedValues : [""]);
+  /**
+   * A count that follows how many entities its source field selects. It only means anything
+   * while several devices are measured together, so until then it submits a fixed 1 out of sight.
+   */
+  private derivedCountField(field: FormField, run?: MeasurementRequest) {
+    if (!this.multipleLights) return html`<input type="hidden" name=${field.name} value="1" />`;
+    const source = this.selectedType
+      ? this.definition(this.selectedType)?.fields.find((candidate) => candidate.name === field.derived_from)
+      : undefined;
+    const derived = source ? this.selectedEntityIds(source, run).length : 0;
+    const stored = run && requestFieldValue(run, field);
+    const value = this.derivedCountOverride
+      ?? (derived > 1 ? String(derived) : (stored ?? field.default ?? "").toString());
+    return this.valueField(field, value, this.derivedCountChanged);
+  }
+
+  private derivedCountChanged(event: Event): void {
+    this.derivedCountOverride = (event.currentTarget as HTMLInputElement).value;
+  }
+
+  private multiEntityField(field: FormField, entities: EntityDescriptor[], run?: MeasurementRequest) {
+    const rows = this.entityRows(field, run);
+    const values = rows.length ? rows : [""];
     return html`<div class="entity-list">
-      <span class="field-label">${field.label}</span>
+      <span class="field-label">${field.plural_label || field.label}</span>
       ${values.map((value, index) => html`<div class="entity-row">
         <select name=${field.name} required data-index=${index} @change=${this.multiEntityChanged}>
           <option value="">Select an entity</option>
@@ -596,7 +613,7 @@ export class SetupView extends LitElement {
         </select>
         ${values.length > 1 ? html`<button type="button" data-field=${field.name} data-index=${index} @click=${this.removeEntity}>Remove</button>` : nothing}
       </div>`)}
-      <button class="add-entity" type="button" data-field=${field.name} @click=${this.addEntity}>Add another light</button>
+      <button class="add-entity" type="button" data-field=${field.name} @click=${this.addEntity}>Add another ${field.label.toLowerCase()}</button>
       ${field.hint ? html`<small class="field-hint">${field.hint}</small>` : nothing}
     </div>`;
   }
@@ -650,29 +667,19 @@ export class SetupView extends LitElement {
 
   private multipleLightsChanged(event: Event): void {
     const input = event.currentTarget as HTMLInputElement;
-    const field = input.dataset.field ?? "";
     this.multipleLights = input.checked;
-    if (this.multipleLights) {
-      const selected = this.selectedEntities[field];
-      if (!this.selectedEntityLists[field] && selected) {
-        this.selectedEntityLists = { ...this.selectedEntityLists, [field]: [selected] };
-      }
-      return;
-    }
-    const first = this.selectedEntityLists[field]?.find(Boolean)
-      ?? this.selectedEntities[field]
-      ?? this.initialControllerEntities(field).find(Boolean)
-      ?? "";
-    this.selectedEntities = { ...this.selectedEntities, [field]: first };
-    this.selectedEntityLists = { ...this.selectedEntityLists, [field]: first ? [first] : [""] };
-    this.lightCountOverride = undefined;
+    if (this.multipleLights) return;
+    // Back to one light: keep the first pick so the single selector stays populated, and let the count be derived again.
+    const field = input.dataset.field ?? "";
+    this.selectEntities(field, this.currentRows(field).filter(Boolean).slice(0, 1));
+    this.derivedCountOverride = undefined;
   }
 
-  /** Options a field offers right now, narrowed by the capabilities of the entity it names. */
+  /** Options a field offers right now, narrowed by the capabilities of the entities it names. */
   private availableOptions(field: FormField, request?: MeasurementRequest): FormFieldOption[] {
     // A virtual device stands in for any real one, so it supports everything on offer.
     if (this.dummyController) return field.options;
-    return fieldOptions(field, this.narrowingEntity(field, request));
+    return fieldOptions(field, this.narrowedModes(field, request));
   }
 
   /** Currently selected values: what the user picked, else the previous run's, else everything offered. */
@@ -692,24 +699,18 @@ export class SetupView extends LitElement {
     return active;
   }
 
-  private narrowingEntity(field: FormField, request?: MeasurementRequest): EntityDescriptor | undefined {
+  /** Modes every entity named by this field's narrowing source supports; undefined when none is selected. */
+  private narrowedModes(field: FormField, request?: MeasurementRequest): LutMode[] | undefined {
     const definition = this.selectedType ? this.definition(this.selectedType) : undefined;
     const source = field.narrowed_by ? definition?.fields.find((candidate) => candidate.name === field.narrowed_by) : undefined;
     if (!source) return undefined;
-    if (source.multiple) {
-      const selected = this.selectedEntityIds(source, request)
-        .map((entityId) => this.entityChoices(source).find((entity) => entity.entity_id === entityId))
-        .filter((entity): entity is EntityDescriptor => Boolean(entity));
-      if (!selected.length) return undefined;
-      const first = selected[0];
-      if (!first) return undefined;
-      const supported = selected
-        .map((entity) => new Set(entity.supported_modes ?? []))
-        .reduce((common, modes) => new Set([...common].filter((mode) => modes.has(mode))));
-      return { ...first, supported_modes: [...supported] };
-    }
-    const selected = this.selectedEntityId(source, request);
-    return this.entityChoices(source).find((entity) => entity.entity_id === selected);
+    const choices = this.entityChoices(source);
+    const selected = this.selectedEntityIds(source, request)
+      .map((entityId) => choices.find((entity) => entity.entity_id === entityId))
+      .filter((entity): entity is EntityDescriptor => Boolean(entity));
+    const [first, ...rest] = selected;
+    if (!first) return undefined;
+    return (first.supported_modes ?? []).filter((mode) => rest.every((entity) => entity.supported_modes?.includes(mode)));
   }
 
   /** Entities offered for a controller field. Lights arrive with the startup catalog, other domains on demand. */
@@ -721,18 +722,24 @@ export class SetupView extends LitElement {
     return domains.flatMap((domain) => (domain === "light" ? this.lights : this.deviceEntities[domain] ?? []));
   }
 
-  private selectedEntityId(field: FormField, request?: MeasurementRequest): string {
+  /**
+   * Rows a field currently shows: what the user picked, else what a previous run stored.
+   * Empty rows are kept, because an unanswered select is still a row in the form.
+   */
+  private entityRows(field: FormField, request?: MeasurementRequest): string[] {
+    const chosen = this.selectedEntities[field.name];
+    if (chosen) return chosen;
     const stored = request && requestFieldValue(request, field);
-    return this.selectedEntities[field.name] || (typeof stored === "string" ? stored : "");
+    if (Array.isArray(stored)) return stored.map(String);
+    return typeof stored === "string" && stored ? [stored] : [];
+  }
+
+  private selectedEntityId(field: FormField, request?: MeasurementRequest): string {
+    return this.entityRows(field, request)[0] ?? "";
   }
 
   private selectedEntityIds(field: FormField, request?: MeasurementRequest): string[] {
-    const stored = request && requestFieldValue(request, field);
-    const selected = this.selectedEntities[field.name];
-    const values = this.selectedEntityLists[field.name]
-      ?? (selected ? [selected] : undefined)
-      ?? (Array.isArray(stored) ? stored : typeof stored === "string" && stored ? [stored] : []);
-    return values.filter(Boolean);
+    return this.entityRows(field, request).filter(Boolean);
   }
 
   private selectType(type: MeasureType): void {
@@ -752,52 +759,51 @@ export class SetupView extends LitElement {
 
   private entityChanged(event: Event): void {
     const select = event.currentTarget as HTMLSelectElement;
-    this.selectedEntities = { ...this.selectedEntities, [select.name]: select.value };
+    this.selectEntities(select.name, [select.value]);
   }
 
   private multiEntityChanged(event: Event): void {
     const select = event.currentTarget as HTMLSelectElement;
-    const index = Number(select.dataset.index);
-    const values = [...(this.selectedEntityLists[select.name] ?? [""])];
-    values[index] = select.value;
-    this.selectedEntityLists = { ...this.selectedEntityLists, [select.name]: values };
+    const rows = [...this.currentRows(select.name)];
+    rows[Number(select.dataset.index)] = select.value;
+    this.selectEntities(select.name, rows);
   }
 
   private addEntity(event: Event): void {
     const field = (event.currentTarget as HTMLElement).dataset.field ?? "";
-    const values = this.selectedEntityLists[field] ?? this.initialControllerEntities(field);
-    this.selectedEntityLists = { ...this.selectedEntityLists, [field]: [...values, ""] };
+    this.selectEntities(field, [...this.currentRows(field), ""]);
   }
 
   private removeEntity(event: Event): void {
     const button = event.currentTarget as HTMLElement;
     const field = button.dataset.field ?? "";
-    const index = Number(button.dataset.index);
-    const values = [...(this.selectedEntityLists[field] ?? this.initialControllerEntities(field))];
-    values.splice(index, 1);
-    this.selectedEntityLists = { ...this.selectedEntityLists, [field]: values.length ? values : [""] };
+    const rows = [...this.currentRows(field)];
+    rows.splice(Number(button.dataset.index), 1);
+    this.selectEntities(field, rows);
   }
 
-  private initialControllerEntities(field: string): string[] {
+  /** Rows as the form currently shows them, so an edit starts from what the user can see. */
+  private currentRows(name: string): string[] {
+    const field = this.selectedType
+      ? this.definition(this.selectedType)?.fields.find((candidate) => candidate.name === name)
+      : undefined;
+    return field ? this.entityRows(field, this.currentRun) : [];
+  }
+
+  /** The previous run, when it belongs to the type now being configured. */
+  private get currentRun(): MeasurementRequest | undefined {
+    return this.initialRequest?.measure_type === this.selectedType ? this.initialRequest : undefined;
+  }
+
+  /** The controller field that accepts several entities at once, when this type has one. */
+  private multiControllerField(): FormField | undefined {
     const definition = this.selectedType ? this.definition(this.selectedType) : undefined;
-    const descriptor = definition?.fields.find((candidate) => candidate.name === field);
-    const stored = descriptor && this.initialRequest ? requestFieldValue(this.initialRequest, descriptor) : undefined;
-    if (Array.isArray(stored)) return stored;
-    return typeof stored === "string" && stored ? [stored] : [""];
+    return definition?.fields.find((field) => field.role === "controller" && field.multiple);
   }
 
-  private lightCountChanged(event: Event): void {
-    this.lightCountOverride = (event.currentTarget as HTMLInputElement).value;
+  private selectEntities(name: string, rows: string[]): void {
+    this.selectedEntities = { ...this.selectedEntities, [name]: rows };
   }
-
-  private selectedLightCount(request?: MeasurementRequest): number {
-    const definition = this.selectedType ? this.definition(this.selectedType) : undefined;
-    const field = definition?.fields.find((candidate) => candidate.role === "controller" && candidate.multiple);
-    if (!field) return 1;
-    return Math.max(1, new Set(this.selectedEntityIds(field, request)).size);
-  }
-
-
 
   private openSettings(): void {
     this.dispatchEvent(new CustomEvent("open-settings", { bubbles: true, composed: true }));
@@ -843,17 +849,20 @@ export class SetupView extends LitElement {
     return this.powers.find((entity) => entity.entity_id === powerEntityId)?.related_voltage_entity_id ?? "";
   }
 
+  /** Model to prefill: the one every selected device reports, or blank when they differ or any is unknown. */
   private modelId(request?: MeasurementRequest): string {
     if (request?.model_id) return request.model_id;
+    const controller = this.selectedType
+      ? this.definition(this.selectedType)?.fields.find((field) => field.role === "controller")
+      : undefined;
+    if (!controller) return "";
     const entities = [...this.lights, ...Object.values(this.deviceEntities).flat()];
-    const multiField = this.selectedType ? this.definition(this.selectedType)?.fields.find((field) => field.multiple) : undefined;
-    const multiIds = multiField ? this.selectedEntityIds(multiField, request) : [];
-    const requestEntityId = request && "controller" in request && request.controller.type === "hass" ? request.controller.entity_id : "";
-    const ids = multiIds.length ? multiIds : [Object.values(this.selectedEntities).find(Boolean) || requestEntityId].filter(Boolean);
-    const modelIds = ids.map((id) => entities.find((entity) => entity.entity_id === id)?.model_id);
-    if (!modelIds.length || modelIds.some((modelId) => !modelId)) return "";
-    const models = new Set(modelIds);
-    return models.size === 1 ? [...models][0] ?? "" : "";
+    const models = new Set(
+      this.selectedEntityIds(controller, request)
+        .map((entityId) => entities.find((entity) => entity.entity_id === entityId)?.model_id),
+    );
+    if (models.size !== 1) return "";
+    return [...models][0] ?? "";
   }
 
   private submitMeasurement(event: SubmitEvent): void {

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -1,4 +1,4 @@
-import type { AppSettings, AppSettingsUpdate, Capabilities, EntityDescriptor, MeasureDefinition, MeasurementRequest, OperatingPoint, PowerMeterDiagnostic, SessionSnapshot, SettingsSection } from "../types";
+import type { AppSettings, AppSettingsUpdate, Capabilities, DummyLoadCalibration, EntityDescriptor, MeasureDefinition, MeasurementRequest, OperatingPoint, PowerMeterDiagnostic, SessionSnapshot, SettingsSection } from "../types";
 import { sharedStyles } from "../styles";
 import { AppShell } from "./app-shell";
 import "./result-view";
@@ -36,6 +36,31 @@ const goodPowerMeterDiagnostic: PowerMeterDiagnostic = {
   messages: ["The sensor meets the recommended update frequency."],
 };
 
+/** The setup view under test, with the reactive properties these tests drive. */
+type SetupViewElement = HTMLElement & {
+  capabilities: Capabilities;
+  definitions: MeasureDefinition[];
+  initialRequest?: MeasurementRequest;
+  lights: EntityDescriptor[];
+  powers: EntityDescriptor[];
+  voltages: EntityDescriptor[];
+  deviceEntities: Record<string, EntityDescriptor[]>;
+  deviceEntityErrors: Record<string, string>;
+  dummyLoadCalibration: DummyLoadCalibration | null;
+  selectedType: string;
+  selectedEntities: Record<string, string[]>;
+  multipleLights: boolean;
+  powerMeter: string;
+  powerMeterConfigured: boolean;
+  shellyIp: string;
+  kasaIp: string;
+  defaultPowerEntityId: string;
+  defaultMeasureDevice: string;
+  errorMessage: string;
+  updateComplete: Promise<boolean>;
+  shadowRoot: ShadowRoot;
+};
+
 const modeParameter = (name: string, label: string) => ({ name, label, group: "Profile resolution" });
 
 const lightDefinition: MeasureDefinition = {
@@ -64,7 +89,7 @@ const lightDefinition: MeasureDefinition = {
   ],
   fields: [
     { name: "power_entity_id", role: "power_meter", label: "Power sensor", control: "entity", required: true, entity_domains: ["sensor"], options: [] },
-    { name: "light_entity_id", role: "controller", label: "Lights", control: "entity", required: true, multiple: true, entity_domains: ["light"], options: [] },
+    { name: "light_entity_id", role: "controller", label: "Light", plural_label: "Lights", control: "entity", required: true, multiple: true, entity_domains: ["light"], options: [] },
     {
       name: "modes",
       role: "attribute",
@@ -79,7 +104,7 @@ const lightDefinition: MeasureDefinition = {
         { value: "effect", label: "Effect", enables: ["effect_bri_steps", "measure_time_effect_min", "measure_time_effect"] },
       ],
     },
-    { name: "multiple_light_count", role: "attribute", label: "Number of lights", control: "number", required: true, options: [], default: 1, minimum: 1, maximum: 100 },
+    { name: "multiple_light_count", role: "attribute", label: "Number of lights", control: "number", required: true, options: [], default: 1, minimum: 1, maximum: 100, derived_from: "light_entity_id" },
   ],
   supports_profile: true,
   supports_resume: true,
@@ -93,25 +118,14 @@ it("uses dark native form controls so iOS select indicators remain visible", () 
 
 describe("setup view", () => {
   it("renders dynamic entities, mode choices, and collapsed advanced settings", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      selectedEntities: Record<string, string>;
-      defaultMeasureDevice: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = lights;
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
     element.voltages = [];
     element.definitions = [lightDefinition];
     element.selectedType = "light";
-    element.selectedEntities = { light_entity_id: "light.desk" };
+    element.selectedEntities = { light_entity_id: ["light.desk"] };
     document.body.append(element);
     await element.updateComplete;
 
@@ -134,16 +148,7 @@ describe("setup view", () => {
   });
 
   it("auto-selects every supported color mode for a capable light", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = [{ entity_id: "light.rgb", name: "RGB lamp", supported_modes: ["brightness", "color_temp", "hs"] }];
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
@@ -158,19 +163,7 @@ describe("setup view", () => {
   });
 
   it("submits mode-specific native light-grid steps", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      selectedEntities: Record<string, string>;
-      defaultPowerEntityId: string;
-      defaultMeasureDevice: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = [{ entity_id: "light.rgb", name: "RGB lamp", supported_modes: ["brightness", "color_temp", "hs"] }];
     element.powers = [{
@@ -182,7 +175,7 @@ describe("setup view", () => {
     element.voltages = [{ entity_id: "sensor.plug_voltage", name: "Plug voltage", unit: "V" }];
     element.definitions = [lightDefinition];
     element.selectedType = "light";
-    element.selectedEntities = { light_entity_id: "light.rgb" };
+    element.selectedEntities = { light_entity_id: ["light.rgb"] };
     element.defaultPowerEntityId = "sensor.plug_power";
     element.defaultMeasureDevice = "Shelly Plug S";
     document.body.append(element);
@@ -213,20 +206,7 @@ describe("setup view", () => {
   });
 
   it("submits multiple lights, intersects their modes, and infers model and count", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      selectedEntityLists: Record<string, string[]>;
-      multipleLights: boolean;
-      defaultPowerEntityId: string;
-      defaultMeasureDevice: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = [
       {
@@ -244,7 +224,7 @@ describe("setup view", () => {
     element.voltages = [];
     element.definitions = [lightDefinition];
     element.selectedType = "light";
-    element.selectedEntityLists = { light_entity_id: ["light.one", "light.two"] };
+    element.selectedEntities = { light_entity_id: ["light.one", "light.two"] };
     element.multipleLights = true;
     element.defaultPowerEntityId = "sensor.power";
     element.defaultMeasureDevice = "Meter";
@@ -271,16 +251,7 @@ describe("setup view", () => {
   });
 
   it("keeps multi-light controls hidden until the user opts in", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = lights;
     element.powers = [{ entity_id: "sensor.power", name: "Power", unit: "W" }];
@@ -303,16 +274,7 @@ describe("setup view", () => {
   });
 
   it("hides the virtual-device toggle unless developer mode is enabled", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = lights;
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
@@ -326,17 +288,7 @@ describe("setup view", () => {
   });
 
   it("submits a dummy light controller when the developer virtual-device toggle is on", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      defaultMeasureDevice: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = { ...capabilities, developer_mode: true };
     element.lights = lights;
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
@@ -376,12 +328,7 @@ describe("setup view", () => {
       fields: [{ name: "fan_entity_id", role: "controller", label: "Fan", control: "entity", required: true, entity_domains: ["fan"], options: [] }],
       supports_profile: true, supports_resume: false,
     };
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powerMeter: string;
-      deviceEntities: Record<string, EntityDescriptor[]>;
-      selectedType: string;
-      updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = [fanDefinition];
     element.capabilities = { ...capabilities, developer_mode: true };
     element.powerMeter = "dummy";
@@ -408,16 +355,7 @@ describe("setup view", () => {
   });
 
   it("includes effect mode when the light exposes effects", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = [{ entity_id: "light.effect", name: "Effect lamp", supported_modes: ["brightness", "effect"], effect_list: ["colorloop"] }];
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
@@ -469,12 +407,7 @@ const definitions: MeasureDefinition[] = [
 
 describe("setup type picker", () => {
   it("uses a matching saved dummy-load calibration by default", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powers: EntityDescriptor[]; powerMeter: string;
-      defaultPowerEntityId: string; defaultMeasureDevice: string; selectedType: string;
-      dummyLoadCalibration: { description: string; resistance: number; calibrated_at: string };
-      updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.capabilities = capabilities;
     element.powers = [{
@@ -517,11 +450,7 @@ describe("setup type picker", () => {
   });
 
   it("collects a load description when inline calibration is required", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powerMeter: string;
-      selectedType: string; dummyLoadCalibration: null;
-      updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.capabilities = capabilities;
     element.powerMeter = "shelly";
@@ -546,10 +475,7 @@ describe("setup type picker", () => {
   });
 
   it("does not offer a resistive dummy load for the synthetic test meter", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powerMeter: string;
-      selectedType: string; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.capabilities = capabilities;
     element.powerMeter = "dummy";
@@ -562,16 +488,7 @@ describe("setup type picker", () => {
   });
 
   it("disables a resistive dummy load when the Home Assistant meter has no voltage sensor", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[];
-      capabilities: Capabilities;
-      powers: EntityDescriptor[];
-      powerMeter: string;
-      defaultPowerEntityId: string;
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.capabilities = capabilities;
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
@@ -586,9 +503,7 @@ describe("setup type picker", () => {
   });
 
   it("requires power meter setup before choosing a measurement type", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; powerMeterConfigured: boolean; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.powerMeterConfigured = false;
     document.body.append(element);
@@ -602,9 +517,7 @@ describe("setup type picker", () => {
   });
 
   it("shows a card per measurement type before a type is chosen", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     document.body.append(element);
     await element.updateComplete;
@@ -615,10 +528,7 @@ describe("setup type picker", () => {
   });
 
   it("renders generic fields, dedupes the power sensor, and emits one typed preflight request", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powers: EntityDescriptor[]; powerMeter: string;
-      defaultPowerEntityId: string; defaultMeasureDevice: string; selectedType: string; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
     element.powerMeter = "hass";
@@ -654,10 +564,7 @@ describe("setup type picker", () => {
   });
 
   it("includes the configured Shelly adapter in the submitted request", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powerMeter: string; shellyIp: string;
-      selectedType: string; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.capabilities = capabilities;
     element.powerMeter = "shelly";
@@ -675,10 +582,7 @@ describe("setup type picker", () => {
   });
 
   it("includes the configured Kasa adapter in the submitted request", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powerMeter: string; kasaIp: string;
-      selectedType: string; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = definitions;
     element.capabilities = capabilities;
     element.powerMeter = "kasa";
@@ -711,11 +615,7 @@ describe("setup type picker", () => {
       supports_profile: true,
       supports_resume: false,
     };
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powers: EntityDescriptor[]; powerMeter: string;
-      deviceEntities: Record<string, EntityDescriptor[]>; selectedType: string;
-      updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = [fanDefinition];
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
     element.powerMeter = "hass";
@@ -821,15 +721,7 @@ describe("setup type picker", () => {
   ])("orders $type fields by dependency and prefills the selected device model ID", async ({
     type, definition, entities, entityField, entityId, expectedFields, modelId,
   }) => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[];
-      capabilities: Capabilities;
-      powerMeter: string;
-      deviceEntities: Record<string, EntityDescriptor[]>;
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = [definition];
     element.capabilities = capabilities;
     element.powerMeter = "dummy";
@@ -865,11 +757,7 @@ describe("setup type picker", () => {
       fields: [{ name: "fan_entity_id", role: "controller", label: "Fan", control: "entity", required: true, entity_domains: ["fan"], options: [] }],
       supports_profile: false, supports_resume: false,
     };
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powerMeter: string;
-      deviceEntityErrors: Record<string, string>; selectedType: string;
-      updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = [fanDefinition];
     element.capabilities = capabilities;
     element.powerMeter = "dummy";
@@ -904,11 +792,7 @@ describe("setup type picker", () => {
       ],
       supports_profile: false, supports_resume: false,
     };
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      definitions: MeasureDefinition[]; capabilities: Capabilities; powerMeter: string;
-      deviceEntities: Record<string, EntityDescriptor[]>; selectedType: string; errorMessage: string;
-      updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.definitions = [chargingDefinition];
     element.capabilities = capabilities;
     element.powerMeter = "dummy";
@@ -1229,18 +1113,7 @@ describe("running view", () => {
 
 describe("setup view defaults", () => {
   it("shows the configured power sensor as read-only measurement context", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      defaultPowerEntityId: string;
-      defaultMeasureDevice: string;
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = lights;
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
@@ -1262,17 +1135,7 @@ describe("setup view defaults", () => {
   });
 
   it("shows the voltage sensor automatically paired with the configured power sensor", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      defaultPowerEntityId: string;
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = lights;
     element.powers = [
@@ -1296,17 +1159,7 @@ describe("setup view defaults", () => {
   });
 
   it("prefills the model ID from the selected measurement device", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      defaultPowerEntityId: string;
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = [{ entity_id: "light.desk", name: "Desk lamp", supported_modes: ["brightness"], device_id: "light-device", model_id: "LWA017" }];
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", device_id: "plug-device", model_id: "WSP002" }];
@@ -1327,16 +1180,7 @@ describe("setup view defaults", () => {
   });
 
   it("orders the light fields by dependency and explains the full product name", async () => {
-    const element = document.createElement("measure-setup-view") as HTMLElement & {
-      capabilities: Capabilities;
-      lights: EntityDescriptor[];
-      powers: EntityDescriptor[];
-      voltages: EntityDescriptor[];
-      definitions: MeasureDefinition[];
-      selectedType: string;
-      updateComplete: Promise<boolean>;
-      shadowRoot: ShadowRoot;
-    };
+    const element = document.createElement("measure-setup-view") as SetupViewElement;
     element.capabilities = capabilities;
     element.lights = lights;
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power" }];

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -232,6 +232,10 @@ describe("setup view", () => {
     await element.updateComplete;
 
     expect(element.shadowRoot.querySelectorAll('select[name="light_entity_id"]')).toHaveLength(2);
+    const removeButton = element.shadowRoot.querySelector<HTMLButtonElement>("button.remove-entity");
+    expect(removeButton?.getAttribute("aria-label")).toBe("Remove Light");
+    expect(removeButton?.querySelector("svg")).toBeTruthy();
+    expect(removeButton?.textContent?.trim()).toBe("");
     expect(element.shadowRoot.querySelectorAll('input[name="modes"]')).toHaveLength(1);
     expect((element.shadowRoot.querySelector('input[name="model_id"]') as HTMLInputElement).value).toBe("LWA017");
     expect((element.shadowRoot.querySelector('input[name="multiple_light_count"]') as HTMLInputElement).value).toBe("2");
@@ -271,6 +275,10 @@ describe("setup view", () => {
 
     expect(element.shadowRoot.querySelector(".add-entity")).not.toBeNull();
     expect(element.shadowRoot.querySelector('input[name="multiple_light_count"][type="number"]')).not.toBeNull();
+    const helpLink = element.shadowRoot.querySelector<HTMLAnchorElement>(".multiple-lights .help-link");
+    expect(helpLink?.href).toBe("https://docs.powercalc.nl/contributing/measure/lights/#multiple-identical-lights");
+    expect(helpLink?.getAttribute("aria-label")).toBe("Learn more about measuring multiple identical lights");
+    expect(helpLink?.querySelector("svg")).toBeTruthy();
   });
 
   it("hides the virtual-device toggle unless developer mode is enabled", async () => {

--- a/utils/measure/frontend/src/components/views.test.ts
+++ b/utils/measure/frontend/src/components/views.test.ts
@@ -64,7 +64,7 @@ const lightDefinition: MeasureDefinition = {
   ],
   fields: [
     { name: "power_entity_id", role: "power_meter", label: "Power sensor", control: "entity", required: true, entity_domains: ["sensor"], options: [] },
-    { name: "light_entity_id", role: "controller", label: "Light", control: "entity", required: true, entity_domains: ["light"], options: [] },
+    { name: "light_entity_id", role: "controller", label: "Lights", control: "entity", required: true, multiple: true, entity_domains: ["light"], options: [] },
     {
       name: "modes",
       role: "attribute",
@@ -210,6 +210,96 @@ describe("setup view", () => {
       hs_hue_steps: 2731,
       hs_sat_steps: 32,
     });
+  });
+
+  it("submits multiple lights, intersects their modes, and infers model and count", async () => {
+    const element = document.createElement("measure-setup-view") as HTMLElement & {
+      capabilities: Capabilities;
+      lights: EntityDescriptor[];
+      powers: EntityDescriptor[];
+      voltages: EntityDescriptor[];
+      definitions: MeasureDefinition[];
+      selectedType: string;
+      selectedEntityLists: Record<string, string[]>;
+      multipleLights: boolean;
+      defaultPowerEntityId: string;
+      defaultMeasureDevice: string;
+      updateComplete: Promise<boolean>;
+      shadowRoot: ShadowRoot;
+    };
+    element.capabilities = capabilities;
+    element.lights = [
+      {
+        entity_id: "light.one",
+        name: "One group",
+        model_id: "LWA017",
+        supported_modes: ["brightness", "hs"],
+        member_entity_ids: ["light.member_one", "light.member_two"],
+      },
+      { entity_id: "light.two", name: "Two", model_id: "LWA017", supported_modes: ["brightness"] },
+      { entity_id: "light.member_one", name: "Member one", model_id: "LWA017", supported_modes: ["brightness"] },
+      { entity_id: "light.member_two", name: "Member two", model_id: "LWA017", supported_modes: ["brightness"] },
+    ];
+    element.powers = [{ entity_id: "sensor.power", name: "Power", unit: "W" }];
+    element.voltages = [];
+    element.definitions = [lightDefinition];
+    element.selectedType = "light";
+    element.selectedEntityLists = { light_entity_id: ["light.one", "light.two"] };
+    element.multipleLights = true;
+    element.defaultPowerEntityId = "sensor.power";
+    element.defaultMeasureDevice = "Meter";
+    document.body.append(element);
+    await element.updateComplete;
+
+    expect(element.shadowRoot.querySelectorAll('select[name="light_entity_id"]')).toHaveLength(2);
+    expect(element.shadowRoot.querySelectorAll('input[name="modes"]')).toHaveLength(1);
+    expect((element.shadowRoot.querySelector('input[name="model_id"]') as HTMLInputElement).value).toBe("LWA017");
+    expect((element.shadowRoot.querySelector('input[name="multiple_light_count"]') as HTMLInputElement).value).toBe("2");
+
+    (element.shadowRoot.querySelector('input[name="product_name"]') as HTMLInputElement).value = "Two identical lights";
+    const submitted = new Promise<MeasurementRequest>((resolve) => {
+      element.addEventListener("preflight", (event) => resolve((event as CustomEvent<MeasurementRequest>).detail));
+    });
+    (element.shadowRoot.querySelector("form") as HTMLFormElement).dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    const request = await submitted;
+    const lightRequest = request as Extract<MeasurementRequest, { measure_type: "light" }>;
+    expect(lightRequest.controller).toEqual({ type: "hass_multi", entity_ids: ["light.one", "light.two"] });
+    expect(lightRequest.multiple_light_count).toBe(2);
+  });
+
+  it("keeps multi-light controls hidden until the user opts in", async () => {
+    const element = document.createElement("measure-setup-view") as HTMLElement & {
+      capabilities: Capabilities;
+      lights: EntityDescriptor[];
+      powers: EntityDescriptor[];
+      voltages: EntityDescriptor[];
+      definitions: MeasureDefinition[];
+      selectedType: string;
+      updateComplete: Promise<boolean>;
+      shadowRoot: ShadowRoot;
+    };
+    element.capabilities = capabilities;
+    element.lights = lights;
+    element.powers = [{ entity_id: "sensor.power", name: "Power", unit: "W" }];
+    element.voltages = [];
+    element.definitions = [lightDefinition];
+    element.selectedType = "light";
+    document.body.append(element);
+    await element.updateComplete;
+
+    expect(element.shadowRoot.querySelector(".add-entity")).toBeNull();
+    expect(element.shadowRoot.querySelector('input[name="multiple_light_count"][type="number"]')).toBeNull();
+    expect(element.shadowRoot.querySelectorAll('select[name="light_entity_id"]')).toHaveLength(1);
+    expect(element.shadowRoot.querySelector(".multiple-lights")?.textContent).toContain("very low power use");
+
+    element.shadowRoot.querySelector<HTMLInputElement>('input[name="measure_multiple_lights"]')!.click();
+    await element.updateComplete;
+
+    expect(element.shadowRoot.querySelector(".add-entity")).not.toBeNull();
+    expect(element.shadowRoot.querySelector('input[name="multiple_light_count"][type="number"]')).not.toBeNull();
   });
 
   it("hides the virtual-device toggle unless developer mode is enabled", async () => {
@@ -1270,7 +1360,9 @@ describe("setup view defaults", () => {
     const labels = profileFields.map(
       (field) => [...field.children].find((child) => child.tagName === "SPAN")?.textContent?.trim(),
     );
-    expect(labels).toEqual(["Light", "Number of lights", "Model ID", "Full product name"]);
+    expect(labels).toEqual(["Light"]);
+    expect([...element.shadowRoot.querySelectorAll(".profile-fields > label > span")].map((label) => label.textContent?.trim()))
+      .toEqual(["Model ID", "Full product name"]);
     expect(element.shadowRoot.querySelector(".field-hint")?.textContent).toContain("complete marketed name");
   });
 });

--- a/utils/measure/frontend/src/measurement-kinds.ts
+++ b/utils/measure/frontend/src/measurement-kinds.ts
@@ -29,9 +29,10 @@ export function requestFieldValue(request: MeasurementRequest, field: FormField)
   return isFieldValue(value) ? value : undefined;
 }
 
-function controllerEntityId(request: MeasurementRequest): string | undefined {
-  const { controller } = request as { controller?: { type: string; entity_id?: string } };
-  return controller?.type === "hass" ? controller.entity_id : undefined;
+function controllerEntityId(request: MeasurementRequest): string | string[] | undefined {
+  const { controller } = request as { controller?: { type: string; entity_id?: string; entity_ids?: string[] } };
+  if (controller?.type === "hass") return controller.entity_id;
+  return controller?.type === "hass_multi" ? controller.entity_ids : undefined;
 }
 
 function isFieldValue(value: unknown): value is FieldValue {
@@ -123,7 +124,12 @@ export function buildMeasurementRequest(
   for (const field of definition.fields) {
     if (field.role === "power_meter") continue;
     if (field.role === "controller") {
-      declared.controller = dummyController ? { type: "dummy" } : { type: "hass", entity_id: text(form, field.name) };
+      const entityIds = form.getAll(field.name).map(String).map((value) => value.trim()).filter(Boolean);
+      declared.controller = dummyController
+        ? { type: "dummy" }
+        : entityIds.length > 1
+          ? { type: "hass_multi", entity_ids: entityIds }
+          : { type: "hass", entity_id: entityIds[0] ?? "" };
       continue;
     }
     declared[field.name] = formValue(form, field);

--- a/utils/measure/frontend/src/measurement-kinds.ts
+++ b/utils/measure/frontend/src/measurement-kinds.ts
@@ -1,7 +1,6 @@
 import type {
   BaseMeasurementRequest,
   Capabilities,
-  EntityDescriptor,
   FormField,
   FormFieldOption,
   LutMode,
@@ -44,8 +43,8 @@ function isFieldValue(value: unknown): value is FieldValue {
  * Options a field offers right now. A field can declare that a controller entity narrows
  * it, in which case only the options that entity reports as supported are offered.
  */
-export function fieldOptions(field: FormField, selectedEntity?: EntityDescriptor): FormFieldOption[] {
-  const supported = field.narrowed_by ? selectedEntity?.supported_modes : undefined;
+export function fieldOptions(field: FormField, supportedModes?: LutMode[]): FormFieldOption[] {
+  const supported = field.narrowed_by ? supportedModes : undefined;
   if (!supported?.length) return field.options;
   return field.options.filter((option) => supported.includes(option.value as LutMode));
 }
@@ -124,12 +123,7 @@ export function buildMeasurementRequest(
   for (const field of definition.fields) {
     if (field.role === "power_meter") continue;
     if (field.role === "controller") {
-      const entityIds = form.getAll(field.name).map(String).map((value) => value.trim()).filter(Boolean);
-      declared.controller = dummyController
-        ? { type: "dummy" }
-        : entityIds.length > 1
-          ? { type: "hass_multi", entity_ids: entityIds }
-          : { type: "hass", entity_id: entityIds[0] ?? "" };
+      declared.controller = controllerSpec(form, field, dummyController);
       continue;
     }
     declared[field.name] = formValue(form, field);
@@ -137,6 +131,14 @@ export function buildMeasurementRequest(
 
   // The server validates the assembled payload against its own discriminated model.
   return { ...base, ...declared, measure_type: definition.measure_type } as MeasurementRequest;
+}
+
+/** The controller spec a submitted entity field describes: a virtual device, one entity, or several. */
+function controllerSpec(form: FormData, field: FormField, dummyController: boolean): Record<string, unknown> {
+  if (dummyController) return { type: "dummy" };
+  const entityIds = form.getAll(field.name).map((value) => String(value).trim()).filter(Boolean);
+  if (entityIds.length > 1) return { type: "hass_multi", entity_ids: entityIds };
+  return { type: "hass", entity_id: entityIds[0] ?? "" };
 }
 
 /** The tuning parameters this type declares, taken from the form where the user set one. */

--- a/utils/measure/frontend/src/types.ts
+++ b/utils/measure/frontend/src/types.ts
@@ -102,7 +102,12 @@ export interface FormField {
   default?: PrimitiveValue;
   minimum?: number | null;
   maximum?: number | null;
+  /** Whether several entities can be selected for this field at once. */
   multiple?: boolean;
+  /** Label to use while several entities are selected. */
+  plural_label?: string;
+  /** Entity field whose number of selected entities this count follows by default. */
+  derived_from?: string | null;
   hint?: string;
 }
 

--- a/utils/measure/frontend/src/types.ts
+++ b/utils/measure/frontend/src/types.ts
@@ -34,6 +34,7 @@ export interface EntityDescriptor {
   supported_modes?: LutMode[];
   effect_list?: string[];
   related_voltage_entity_id?: string;
+  member_entity_ids?: string[];
 }
 
 export interface EntityCatalog {
@@ -101,6 +102,8 @@ export interface FormField {
   default?: PrimitiveValue;
   minimum?: number | null;
   maximum?: number | null;
+  multiple?: boolean;
+  hint?: string;
 }
 
 /** A tuning parameter as one measure type presents it. Bounds come from `Capabilities.limits`. */
@@ -170,6 +173,7 @@ export type PowerMeterSpec =
 export type LightControllerSpec =
   | { type: "dummy" }
   | { type: "hass"; entity_id: string; transition_time?: number }
+  | { type: "hass_multi"; entity_ids: string[]; transition_time?: number }
   | { type: "hue"; bridge_ip: string; light: string };
 
 export type MediaControllerSpec = { type: "dummy" } | { type: "hass"; entity_id: string };

--- a/utils/measure/measure/assembler.py
+++ b/utils/measure/measure/assembler.py
@@ -15,7 +15,7 @@ from measure.controller.fan.hass import HassFanController
 from measure.controller.fan.spec import DummyFanControllerSpec, FanControllerSpec, HassFanControllerSpec
 from measure.controller.light.controller import LightController
 from measure.controller.light.dummy import DummyLightController
-from measure.controller.light.hass import HassLightController, HassMultiLightController
+from measure.controller.light.hass import HassLightController
 from measure.controller.light.spec import (
     DummyLightControllerSpec,
     HassLightControllerSpec,
@@ -210,17 +210,9 @@ class MeasurementAssembler:
     def _light_controller(self, spec: LightControllerSpec) -> LightController:
         if isinstance(spec, DummyLightControllerSpec):
             return DummyLightController()
-        if isinstance(spec, HassLightControllerSpec):
+        if isinstance(spec, HassLightControllerSpec | HassMultiLightControllerSpec):
             hass = self._home_assistant()
             return HassLightController(
-                hass,
-                spec.transition_time,
-                entity_id=spec.entity_id,
-                wait=self._interaction.wait,
-            )
-        if isinstance(spec, HassMultiLightControllerSpec):
-            hass = self._home_assistant()
-            return HassMultiLightController(
                 hass,
                 spec.transition_time,
                 entity_ids=spec.entity_ids,

--- a/utils/measure/measure/assembler.py
+++ b/utils/measure/measure/assembler.py
@@ -15,10 +15,11 @@ from measure.controller.fan.hass import HassFanController
 from measure.controller.fan.spec import DummyFanControllerSpec, FanControllerSpec, HassFanControllerSpec
 from measure.controller.light.controller import LightController
 from measure.controller.light.dummy import DummyLightController
-from measure.controller.light.hass import HassLightController
+from measure.controller.light.hass import HassLightController, HassMultiLightController
 from measure.controller.light.spec import (
     DummyLightControllerSpec,
     HassLightControllerSpec,
+    HassMultiLightControllerSpec,
     HueLightControllerSpec,
     LightControllerSpec,
 )
@@ -215,6 +216,14 @@ class MeasurementAssembler:
                 hass,
                 spec.transition_time,
                 entity_id=spec.entity_id,
+                wait=self._interaction.wait,
+            )
+        if isinstance(spec, HassMultiLightControllerSpec):
+            hass = self._home_assistant()
+            return HassMultiLightController(
+                hass,
+                spec.transition_time,
+                entity_ids=spec.entity_ids,
                 wait=self._interaction.wait,
             )
         if isinstance(spec, HueLightControllerSpec):

--- a/utils/measure/measure/const.py
+++ b/utils/measure/measure/const.py
@@ -20,6 +20,8 @@ HASS_DEVICE_REGISTRY_MODEL_ID = "model_id"
 HASS_ENTITY_REGISTRY_UNIQUE_ID = "unique_id"
 HASS_ENTITY_DEVICE_CLASS = "device_class"
 HASS_ENTITY_UNIT_OF_MEASUREMENT = "unit_of_measurement"
+#: Light groups list the entities they drive under this state attribute.
+HASS_ENTITY_GROUP_MEMBERS = "entity_id"
 ZEROCONF_HTTP_SERVICE_TYPE = "_http._tcp.local."
 ZEROCONF_SHELLY_SERVICE_TYPE = "_shelly._tcp.local."
 SHELLY_DISCOVERY_COLLECTION_WINDOW_SECONDS = 2.0

--- a/utils/measure/measure/controller/light/capabilities.py
+++ b/utils/measure/measure/controller/light/capabilities.py
@@ -1,9 +1,30 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 import math
 from typing import Any
 
 from measure.controller.light.const import HASS_HS_COMPATIBLE_COLOR_MODES, MAX_MIRED, MIN_MIRED, LutMode
 from measure.controller.light.controller import LightInfo
+
+
+def merge_light_infos(infos: Sequence[LightInfo]) -> LightInfo:
+    """Reduce several lights to the color temperature range they all support."""
+
+    if not infos:
+        raise ValueError("Cannot merge an empty set of light infos")
+    return LightInfo(
+        "unknown",
+        min_mired=max(info.min_mired for info in infos),
+        max_mired=min(info.max_mired for info in infos),
+    )
+
+
+def common_effects(effect_lists: Sequence[Sequence[str]]) -> list[str]:
+    """Effects every light offers, in the order the first light lists them."""
+
+    if not effect_lists:
+        return []
+    first, *rest = effect_lists
+    return [effect for effect in first if all(effect in other for other in rest)]
 
 
 def light_info_from_attributes(attributes: Mapping[str, Any]) -> LightInfo:

--- a/utils/measure/measure/controller/light/hass.py
+++ b/utils/measure/measure/controller/light/hass.py
@@ -25,6 +25,10 @@ class HassLightController(HassControllerBase, LightController):
         self._wait = wait
         super().__init__(home_assistant, entity_id=entity_id)
 
+    @property
+    def target_entity_id(self) -> str | list[str] | None:
+        return self.entity_id
+
     def change_light_state(
         self,
         lut_mode: LutMode,
@@ -32,7 +36,7 @@ class HassLightController(HassControllerBase, LightController):
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         if not on:
-            self.client.trigger_service("light", "turn_off", entity_id=self.entity_id)
+            self.client.trigger_service("light", "turn_off", entity_id=self.target_entity_id)
             return
 
         if lut_mode == LutMode.HS:
@@ -68,7 +72,7 @@ class HassLightController(HassControllerBase, LightController):
 
     def build_hs_json_body(self, bri: int, hue: int, sat: int) -> dict[str, Any]:
         return {
-            "entity_id": self.entity_id,
+            "entity_id": self.target_entity_id,
             "transition": self._transition_time,
             "brightness": bri,
             "hs_color": [hue / 65535 * 360, sat / 255 * 100],
@@ -76,7 +80,7 @@ class HassLightController(HassControllerBase, LightController):
 
     def build_ct_json_body(self, bri: int, ct: int) -> dict[str, Any]:
         return {
-            "entity_id": self.entity_id,
+            "entity_id": self.target_entity_id,
             "transition": self._transition_time,
             "brightness": bri,
             "color_temp_kelvin": mired_to_kelvin(ct),
@@ -84,20 +88,57 @@ class HassLightController(HassControllerBase, LightController):
 
     def build_bri_json_body(self, bri: int) -> dict[str, Any]:
         return {
-            "entity_id": self.entity_id,
+            "entity_id": self.target_entity_id,
             "transition": self._transition_time,
             "brightness": bri,
         }
 
     def build_effect_json_body(self, bri: int, effect: str) -> dict[str, Any]:
         return {
-            "entity_id": self.entity_id,
+            "entity_id": self.target_entity_id,
             "effect": effect,
             "brightness": bri,
         }
 
     def build_white_json_body(self, bri: int) -> dict[str, Any]:
         return {
-            "entity_id": self.entity_id,
+            "entity_id": self.target_entity_id,
             "white": bri,
         }
+
+
+class HassMultiLightController(HassLightController):
+    """Control multiple Home Assistant lights through one service target."""
+
+    def __init__(
+        self,
+        home_assistant: HomeAssistantManager,
+        transition_time: int,
+        *,
+        entity_ids: list[str],
+        wait: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.entity_ids = tuple(entity_ids)
+        super().__init__(home_assistant, transition_time, entity_id=entity_ids[0], wait=wait)
+
+    @property
+    def target_entity_id(self) -> str | list[str] | None:
+        return list(self.entity_ids)
+
+    def get_light_info(self) -> LightInfo:
+        infos = [
+            light_info_from_attributes(self.client.get_state(entity_id=entity_id).attributes)
+            for entity_id in self.entity_ids
+        ]
+        return LightInfo(
+            "unknown",
+            min_mired=max(info.min_mired for info in infos),
+            max_mired=min(info.max_mired for info in infos),
+        )
+
+    def get_effect_list(self) -> list[str]:
+        effect_lists = [
+            [str(effect) for effect in self.client.get_state(entity_id=entity_id).attributes.get("effect_list", [])]
+            for entity_id in self.entity_ids
+        ]
+        return [effect for effect in effect_lists[0] if all(effect in other for other in effect_lists[1:])]

--- a/utils/measure/measure/controller/light/hass.py
+++ b/utils/measure/measure/controller/light/hass.py
@@ -1,33 +1,50 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 import time
 from typing import Any
 
+from homeassistant_api import State
 from homeassistant_api.errors import HomeassistantAPIError
 
 from measure.controller.errors import ApiConnectionError
 from measure.controller.hass_controller import HassControllerBase
-from measure.controller.light.capabilities import light_info_from_attributes, mired_to_kelvin
+from measure.controller.light.capabilities import (
+    common_effects,
+    light_info_from_attributes,
+    merge_light_infos,
+    mired_to_kelvin,
+)
 from measure.controller.light.const import LutMode
 from measure.controller.light.controller import LightController, LightInfo
 from measure.home_assistant import HomeAssistantManager
 
 
 class HassLightController(HassControllerBase, LightController):
+    """Drive one or more Home Assistant lights as a single measurement target.
+
+    Several identical lights can be measured together to lift a load that is too small
+    to register on its own. They then report the capabilities they have in common.
+    """
+
     def __init__(
         self,
         home_assistant: HomeAssistantManager,
         transition_time: int,
         *,
-        entity_id: str | None = None,
+        entity_ids: Sequence[str],
         wait: Callable[[float], None] = time.sleep,
     ) -> None:
+        if not entity_ids:
+            raise ValueError("A light controller needs at least one entity")
         self._transition_time: int = transition_time
         self._wait = wait
-        super().__init__(home_assistant, entity_id=entity_id)
+        # Every light is addressed explicitly, so the base class' single entity_id does not apply.
+        self.entity_ids = list(entity_ids)
+        super().__init__(home_assistant)
 
     @property
-    def target_entity_id(self) -> str | list[str] | None:
-        return self.entity_id
+    def service_target(self) -> str | list[str]:
+        """Entity target for light services: one light stays a plain ID, several become a list."""
+        return self.entity_ids[0] if len(self.entity_ids) == 1 else list(self.entity_ids)
 
     def change_light_state(
         self,
@@ -36,7 +53,7 @@ class HassLightController(HassControllerBase, LightController):
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         if not on:
-            self.client.trigger_service("light", "turn_off", entity_id=self.target_entity_id)
+            self.client.trigger_service("light", "turn_off", entity_id=self.service_target)
             return
 
         if lut_mode == LutMode.HS:
@@ -57,22 +74,22 @@ class HassLightController(HassControllerBase, LightController):
         self._wait(self._transition_time)
 
     def get_light_info(self) -> LightInfo:
-        state = self.client.get_state(entity_id=self.entity_id)
-        return light_info_from_attributes(state.attributes)
+        return merge_light_infos([light_info_from_attributes(state.attributes) for state in self._states()])
 
     def has_effect_support(self) -> bool:
         return True
 
     def get_effect_list(self) -> list[str]:
-        light_state = self.client.get_state(entity_id=self.entity_id)
-        return [str(effect) for effect in light_state.attributes.get("effect_list", [])]
+        return common_effects(
+            [[str(effect) for effect in state.attributes.get("effect_list", [])] for state in self._states()],
+        )
 
     def close(self) -> None:
         return
 
     def build_hs_json_body(self, bri: int, hue: int, sat: int) -> dict[str, Any]:
         return {
-            "entity_id": self.target_entity_id,
+            "entity_id": self.service_target,
             "transition": self._transition_time,
             "brightness": bri,
             "hs_color": [hue / 65535 * 360, sat / 255 * 100],
@@ -80,7 +97,7 @@ class HassLightController(HassControllerBase, LightController):
 
     def build_ct_json_body(self, bri: int, ct: int) -> dict[str, Any]:
         return {
-            "entity_id": self.target_entity_id,
+            "entity_id": self.service_target,
             "transition": self._transition_time,
             "brightness": bri,
             "color_temp_kelvin": mired_to_kelvin(ct),
@@ -88,57 +105,23 @@ class HassLightController(HassControllerBase, LightController):
 
     def build_bri_json_body(self, bri: int) -> dict[str, Any]:
         return {
-            "entity_id": self.target_entity_id,
+            "entity_id": self.service_target,
             "transition": self._transition_time,
             "brightness": bri,
         }
 
     def build_effect_json_body(self, bri: int, effect: str) -> dict[str, Any]:
         return {
-            "entity_id": self.target_entity_id,
+            "entity_id": self.service_target,
             "effect": effect,
             "brightness": bri,
         }
 
     def build_white_json_body(self, bri: int) -> dict[str, Any]:
         return {
-            "entity_id": self.target_entity_id,
+            "entity_id": self.service_target,
             "white": bri,
         }
 
-
-class HassMultiLightController(HassLightController):
-    """Control multiple Home Assistant lights through one service target."""
-
-    def __init__(
-        self,
-        home_assistant: HomeAssistantManager,
-        transition_time: int,
-        *,
-        entity_ids: list[str],
-        wait: Callable[[float], None] = time.sleep,
-    ) -> None:
-        self.entity_ids = tuple(entity_ids)
-        super().__init__(home_assistant, transition_time, entity_id=entity_ids[0], wait=wait)
-
-    @property
-    def target_entity_id(self) -> str | list[str] | None:
-        return list(self.entity_ids)
-
-    def get_light_info(self) -> LightInfo:
-        infos = [
-            light_info_from_attributes(self.client.get_state(entity_id=entity_id).attributes)
-            for entity_id in self.entity_ids
-        ]
-        return LightInfo(
-            "unknown",
-            min_mired=max(info.min_mired for info in infos),
-            max_mired=min(info.max_mired for info in infos),
-        )
-
-    def get_effect_list(self) -> list[str]:
-        effect_lists = [
-            [str(effect) for effect in self.client.get_state(entity_id=entity_id).attributes.get("effect_list", [])]
-            for entity_id in self.entity_ids
-        ]
-        return [effect for effect in effect_lists[0] if all(effect in other for other in effect_lists[1:])]
+    def _states(self) -> list[State]:
+        return [self.client.get_state(entity_id=entity_id) for entity_id in self.entity_ids]

--- a/utils/measure/measure/controller/light/spec.py
+++ b/utils/measure/measure/controller/light/spec.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from measure.controller.light.const import DEFAULT_LIGHT_TRANSITION_TIME, LightControllerType
 from measure.controller.spec import BaseControllerSpec
@@ -18,6 +18,19 @@ class HassLightControllerSpec(BaseControllerSpec):
     transition_time: int = DEFAULT_LIGHT_TRANSITION_TIME
 
 
+class HassMultiLightControllerSpec(BaseControllerSpec):
+    type: Literal["hass_multi"] = "hass_multi"
+    entity_ids: list[Annotated[str, Field(pattern=LIGHT_ENTITY_PATTERN)]] = Field(min_length=2, max_length=100)
+    transition_time: int = DEFAULT_LIGHT_TRANSITION_TIME
+
+    @field_validator("entity_ids")
+    @classmethod
+    def validate_unique_entity_ids(cls, entity_ids: list[str]) -> list[str]:
+        if len(set(entity_ids)) != len(entity_ids):
+            raise ValueError("Light entity IDs must be unique")
+        return entity_ids
+
+
 class HueLightControllerSpec(BaseControllerSpec):
     type: Literal[LightControllerType.HUE] = LightControllerType.HUE
     bridge_ip: str
@@ -25,6 +38,6 @@ class HueLightControllerSpec(BaseControllerSpec):
 
 
 LightControllerSpec = Annotated[
-    DummyLightControllerSpec | HassLightControllerSpec | HueLightControllerSpec,
+    DummyLightControllerSpec | HassLightControllerSpec | HassMultiLightControllerSpec | HueLightControllerSpec,
     Field(discriminator="type"),
 ]

--- a/utils/measure/measure/controller/light/spec.py
+++ b/utils/measure/measure/controller/light/spec.py
@@ -17,6 +17,11 @@ class HassLightControllerSpec(BaseControllerSpec):
     entity_id: str = Field(pattern=LIGHT_ENTITY_PATTERN)
     transition_time: int = DEFAULT_LIGHT_TRANSITION_TIME
 
+    @property
+    def entity_ids(self) -> list[str]:
+        """Lights this spec drives, so callers can treat single and multi specs alike."""
+        return [self.entity_id]
+
 
 class HassMultiLightControllerSpec(BaseControllerSpec):
     type: Literal["hass_multi"] = "hass_multi"

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -152,6 +152,8 @@ class FormField(BaseModel):
     default: str | int | bool | None = None
     minimum: int | float | None = None
     maximum: int | float | None = None
+    multiple: bool = False
+    hint: str = ""
 
 
 class MeasureParameter(BaseModel):
@@ -647,6 +649,8 @@ def _measure_definitions() -> list[MeasureDefinition]:
                     default=field.default,
                     minimum=field.minimum,
                     maximum=field.maximum,
+                    multiple=field.multiple,
+                    hint=field.hint,
                 )
                 for field in definition.fields
             ],

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -153,6 +153,8 @@ class FormField(BaseModel):
     minimum: int | float | None = None
     maximum: int | float | None = None
     multiple: bool = False
+    plural_label: str = ""
+    derived_from: str | None = None
     hint: str = ""
 
 
@@ -650,6 +652,8 @@ def _measure_definitions() -> list[MeasureDefinition]:
                     minimum=field.minimum,
                     maximum=field.maximum,
                     multiple=field.multiple,
+                    plural_label=field.plural_label,
+                    derived_from=field.derived_from,
                     hint=field.hint,
                 )
                 for field in definition.fields

--- a/utils/measure/measure/ha_app/contribution/coordinator.py
+++ b/utils/measure/measure/ha_app/contribution/coordinator.py
@@ -228,11 +228,13 @@ class ContributionApiCoordinator:
             return result
 
     def _integration(self, request: MeasurementRequest) -> str | None:
-        """Return the Home Assistant integration providing the measured entity, when it can be resolved."""
-        entity_id = request.controlled_entity_id
-        if entity_id is None or self._resolve_integration is None:
+        """Return the shared Home Assistant integration providing every measured entity."""
+        if not request.controlled_entity_ids or self._resolve_integration is None:
             return None
-        return self._resolve_integration(entity_id)
+        integrations = {self._resolve_integration(entity_id) for entity_id in request.controlled_entity_ids}
+        if None in integrations:
+            return None
+        return integrations.pop() if len(integrations) == 1 else None
 
     def _require_oauth_client_id(self) -> str:
         if not self._oauth_client_id:

--- a/utils/measure/measure/ha_app/contribution/coordinator.py
+++ b/utils/measure/measure/ha_app/contribution/coordinator.py
@@ -228,12 +228,11 @@ class ContributionApiCoordinator:
             return result
 
     def _integration(self, request: MeasurementRequest) -> str | None:
-        """Return the shared Home Assistant integration providing every measured entity."""
-        if not request.controlled_entity_ids or self._resolve_integration is None:
+        """Return the Home Assistant integration providing every measured entity, when they agree on one."""
+        if self._resolve_integration is None:
             return None
         integrations = {self._resolve_integration(entity_id) for entity_id in request.controlled_entity_ids}
-        if None in integrations:
-            return None
+        # A single unresolved entity yields {None}, which pops back to None just the same.
         return integrations.pop() if len(integrations) == 1 else None
 
     def _require_oauth_client_id(self) -> str:

--- a/utils/measure/measure/ha_app/contribution/service.py
+++ b/utils/measure/measure/ha_app/contribution/service.py
@@ -480,7 +480,7 @@ def _build_preview_response(
     }
     home_assistant_info: dict[str, str | int | float | bool | None] = {
         "measure_type": request.measure_type.value,
-        "controlled_entity": request.controlled_entity_id,
+        "controlled_entity": ", ".join(request.controlled_entity_ids) or None,
         "integration": content.integration,
     }
     return ContributionPreviewResponse(

--- a/utils/measure/measure/ha_app/preflight.py
+++ b/utils/measure/measure/ha_app/preflight.py
@@ -7,6 +7,7 @@ from measure.const import DUMMY_LOAD_MEASUREMENT_COUNT, DUMMY_LOAD_MEASUREMENTS_
 from measure.controller.charging.const import ATTR_BATTERY_LEVEL
 from measure.controller.charging.spec import HassChargingControllerSpec, charging_entity_domain
 from measure.controller.fan.spec import HassFanControllerSpec
+from measure.controller.light.capabilities import common_effects, merge_light_infos
 from measure.controller.light.const import MAX_MIRED, MIN_MIRED, LutMode
 from measure.controller.light.controller import LightInfo
 from measure.controller.light.dummy import DummyLightController
@@ -70,6 +71,82 @@ class PreflightResult:
     power_meter_diagnostic: PowerMeterDiagnostic | None = None
     battery_level_entity_id: str | None = None
     battery_level_attribute: str | None = None
+
+
+MODEL_UNCONFIRMED_WARNING = (
+    "Could not confirm that every selected light has the same model. Verify this before starting."
+)
+
+
+@dataclass(frozen=True)
+class LightSelection:
+    """The lights one request drives, reduced to the capabilities they all share."""
+
+    lights: tuple[EntityRecord, ...]
+    supported_modes: set[LutMode]
+    light_info: LightInfo
+    effects: list[str]
+
+
+def _no_group_member_overlap(selection: LightSelection, _: LightMeasurementRequest) -> tuple[str, ...]:
+    """A group already drives its members, so selecting both would measure them twice."""
+
+    members = {member for light in selection.lights for member in light.member_entity_ids}
+    if members & {light.entity_id for light in selection.lights}:
+        raise PreflightError("A light group and one of its members cannot both be selected")
+    return ()
+
+
+def _count_covers_selection(selection: LightSelection, request: LightMeasurementRequest) -> tuple[str, ...]:
+    """Measured power is divided by the count, so it cannot describe fewer lights than are driven."""
+
+    if request.multiple_light_count < len(selection.lights):
+        raise PreflightError("Number of lights cannot be lower than the number of selected lights")
+    return ()
+
+
+def _models_agree(selection: LightSelection, _: LightMeasurementRequest) -> tuple[str, ...]:
+    """One profile is produced for all lights, so they must be the same model."""
+
+    models = {light.model_id for light in selection.lights}
+    if len(models - {None}) > 1:
+        raise PreflightError("Selected lights must have the same model ID")
+    if len(selection.lights) > 1 and None in models:
+        return (MODEL_UNCONFIRMED_WARNING,)
+    return ()
+
+
+def _modes_supported(selection: LightSelection, request: LightMeasurementRequest) -> tuple[str, ...]:
+    if not set(request.modes).issubset(selection.supported_modes):
+        raise PreflightError("Selected light does not advertise every requested mode")
+    return ()
+
+
+def _color_temp_range_overlaps(selection: LightSelection, _: LightMeasurementRequest) -> tuple[str, ...]:
+    if selection.light_info.min_mired > selection.light_info.max_mired:
+        raise PreflightError("Selected lights do not share a color temperature range")
+    return ()
+
+
+LightRule = Callable[[LightSelection, LightMeasurementRequest], tuple[str, ...]]
+
+#: Checks applied to a light selection, in order. Each returns warnings or raises a PreflightError,
+#: so a new condition is added here rather than by growing the caller.
+LIGHT_RULES: tuple[LightRule, ...] = (
+    _no_group_member_overlap,
+    _count_covers_selection,
+    _models_agree,
+    _modes_supported,
+    _color_temp_range_overlaps,
+)
+
+
+def _light_info(light: EntityRecord) -> LightInfo:
+    return LightInfo(
+        "unknown",
+        min_mired=light.min_mired if light.min_mired is not None else MIN_MIRED,
+        max_mired=light.max_mired if light.max_mired is not None else MAX_MIRED,
+    )
 
 
 class MeasurementPreflight:
@@ -186,17 +263,17 @@ class MeasurementPreflight:
         raise PreflightError(f"{type(controller).__name__} is not supported by the Home Assistant app")
 
     def _validate_power_meter(self, request: MeasurementRequest) -> None:
-        if isinstance(request.power_meter, HassPowerMeterSpec):
-            powers = {entity.entity_id for entity in self._load_entities(None, DeviceClass.POWER)}
-            if request.power_meter.entity_id not in powers:
-                raise PreflightError("Selected power entity is unavailable or not measured in W")
-        if request.dummy_load is None:
+        power_meter = request.power_meter
+        if not isinstance(power_meter, HassPowerMeterSpec):
             return
-        if isinstance(request.power_meter, HassPowerMeterSpec):
-            if not request.power_meter.voltage_entity_id:
-                raise PreflightError("A voltage sensor is required when using a resistive dummy load")
+        powers = {entity.entity_id for entity in self._load_entities(None, DeviceClass.POWER)}
+        if power_meter.entity_id not in powers:
+            raise PreflightError("Selected power entity is unavailable or not measured in W")
+        if request.dummy_load is not None and not power_meter.voltage_entity_id:
+            raise PreflightError("A voltage sensor is required when using a resistive dummy load")
+        if power_meter.voltage_entity_id:
             voltages = {entity.entity_id for entity in self._load_entities(None, DeviceClass.VOLTAGE)}
-            if request.power_meter.voltage_entity_id not in voltages:
+            if power_meter.voltage_entity_id not in voltages:
                 raise PreflightError("Selected voltage entity is unavailable or not measured in V")
 
     @staticmethod
@@ -271,86 +348,35 @@ class MeasurementPreflight:
             None,
         )
 
-    def _validate_light(self, request: LightMeasurementRequest) -> PreflightResult:  # noqa: C901
+    def _validate_light(self, request: LightMeasurementRequest) -> PreflightResult:
         if isinstance(request.controller, DummyLightControllerSpec):
             return self._estimate_dummy_light(request)
         if not isinstance(request.controller, HassLightControllerSpec | HassMultiLightControllerSpec):
             raise PreflightError("Selected light entity is unavailable")
-        lights = {entity.entity_id: entity for entity in self._load_entities(EntityDomain.LIGHT, None)}
-        entity_ids = (
-            request.controller.entity_ids
-            if isinstance(request.controller, HassMultiLightControllerSpec)
-            else [request.controller.entity_id]
-        )
-        selected = [lights[entity_id] for entity_id in entity_ids if entity_id in lights]
-        if len(selected) != len(entity_ids):
-            raise PreflightError("Selected light entity is unavailable")
-        if isinstance(request.power_meter, HassPowerMeterSpec) and request.power_meter.voltage_entity_id:
-            voltages = {entity.entity_id for entity in self._load_entities(None, DeviceClass.VOLTAGE)}
-            if request.power_meter.voltage_entity_id not in voltages:
-                raise PreflightError("Selected voltage entity is unavailable or not measured in V")
-        expanded = self._expand_selected_lights(selected, lights)
-        leaves = list({light.entity_id: light for light in expanded}.values())
-        if len(leaves) != len(expanded):
-            raise PreflightError("A light group and one of its members cannot both be selected")
-        if request.multiple_light_count < len(selected):
-            raise PreflightError("Number of lights cannot be lower than the number of selected lights")
-        model_ids = {model_id for light in leaves if (model_id := getattr(light, "model_id", None))}
-        if len(model_ids) > 1:
-            raise PreflightError("Selected lights must have the same model ID")
-        models_confirmed = len(model_ids) == 1 and all(getattr(light, "model_id", None) for light in leaves)
-        warnings = (
-            ("Could not confirm that every selected light has the same model. Verify this before starting.",)
-            if len(leaves) > 1 and not models_confirmed
-            else ()
-        )
-        supported_sets = [set(light.supported_modes or []) for light in selected]
-        supported = set.intersection(*supported_sets)
-        if not set(request.modes).issubset(supported):
-            raise PreflightError("Selected light does not advertise every requested mode")
-        min_mired = max(light.min_mired if light.min_mired is not None else MIN_MIRED for light in selected)
-        max_mired = min(light.max_mired if light.max_mired is not None else MAX_MIRED for light in selected)
-        if min_mired > max_mired:
-            raise PreflightError("Selected lights do not share a color temperature range")
-        light_info = LightInfo(
-            "unknown",
-            min_mired=min_mired,
-            max_mired=max_mired,
-        )
-        effects = list(selected[0].effect_list or ())
-        for light in selected[1:]:
-            effects = [effect for effect in effects if effect in (light.effect_list or ())]
-        plan = build_light_plan(request.modes, request.parameters, light_info, effects)
+
+        selection = self._resolve_lights(request.controller.entity_ids)
+        warnings = tuple(warning for rule in LIGHT_RULES for warning in rule(selection, request))
+        plan = build_light_plan(request.modes, request.parameters, selection.light_info, selection.effects)
         return PreflightResult(
             warnings=warnings,
             estimated_variations=plan.variation_count,
             estimated_duration_seconds=round(estimate_light_time_left(plan, request.parameters)),
-            supported_modes=tuple(sorted(supported, key=str)),
+            supported_modes=tuple(sorted(selection.supported_modes, key=str)),
         )
 
-    @staticmethod
-    def _expand_selected_lights(
-        selected: Sequence[EntityRecord],
-        lights: dict[str, EntityRecord],
-    ) -> list[EntityRecord]:
-        leaves: list[EntityRecord] = []
+    def _resolve_lights(self, entity_ids: Sequence[str]) -> LightSelection:
+        """Look the selected lights up in the catalog and reduce them to their shared capabilities."""
 
-        def visit(light: EntityRecord, path: frozenset[str]) -> None:
-            if light.entity_id in path:
-                raise PreflightError("Selected light groups contain a cycle")
-            member_ids = getattr(light, "member_entity_ids", [])
-            if any(entity_id not in lights for entity_id in member_ids):
-                raise PreflightError("A selected light group contains an unavailable member")
-            members = [lights[entity_id] for entity_id in member_ids if entity_id in lights]
-            if not members:
-                leaves.append(light)
-                return
-            for member in members:
-                visit(member, path | {light.entity_id})
-
-        for light in selected:
-            visit(light, frozenset())
-        return leaves
+        lights = {entity.entity_id: entity for entity in self._load_entities(EntityDomain.LIGHT, None)}
+        selected = [lights[entity_id] for entity_id in entity_ids if entity_id in lights]
+        if len(selected) != len(entity_ids):
+            raise PreflightError("Selected light entity is unavailable")
+        return LightSelection(
+            lights=tuple(selected),
+            supported_modes=set.intersection(*(set(light.supported_modes or []) for light in selected)),
+            light_info=merge_light_infos([_light_info(light) for light in selected]),
+            effects=common_effects([light.effect_list or [] for light in selected]),
+        )
 
     @staticmethod
     def _estimate_dummy_light(request: LightMeasurementRequest) -> PreflightResult:

--- a/utils/measure/measure/ha_app/preflight.py
+++ b/utils/measure/measure/ha_app/preflight.py
@@ -10,7 +10,12 @@ from measure.controller.fan.spec import HassFanControllerSpec
 from measure.controller.light.const import MAX_MIRED, MIN_MIRED, LutMode
 from measure.controller.light.controller import LightInfo
 from measure.controller.light.dummy import DummyLightController
-from measure.controller.light.spec import DummyLightControllerSpec, HassLightControllerSpec, HueLightControllerSpec
+from measure.controller.light.spec import (
+    DummyLightControllerSpec,
+    HassLightControllerSpec,
+    HassMultiLightControllerSpec,
+    HueLightControllerSpec,
+)
 from measure.controller.media.spec import HassMediaControllerSpec
 from measure.home_assistant_entities import DeviceClass, EntityDomain
 from measure.powermeter.diagnostics import DiagnosticStatus, PowerMeterDiagnostic
@@ -49,6 +54,8 @@ class EntityRecord(Protocol):
     effect_list: list[str] | None
     min_mired: int | None
     max_mired: int | None
+    model_id: str | None
+    member_entity_ids: list[str]
 
 
 EntityLoader = Callable[[EntityDomain | None, DeviceClass | None], Sequence[EntityRecord]]
@@ -167,7 +174,11 @@ class MeasurementPreflight:
             return
         if isinstance(
             controller,
-            HassLightControllerSpec | HassMediaControllerSpec | HassChargingControllerSpec | HassFanControllerSpec,
+            HassLightControllerSpec
+            | HassMultiLightControllerSpec
+            | HassMediaControllerSpec
+            | HassChargingControllerSpec
+            | HassFanControllerSpec,
         ):
             return
         if isinstance(controller, HueLightControllerSpec):
@@ -260,33 +271,86 @@ class MeasurementPreflight:
             None,
         )
 
-    def _validate_light(self, request: LightMeasurementRequest) -> PreflightResult:
+    def _validate_light(self, request: LightMeasurementRequest) -> PreflightResult:  # noqa: C901
         if isinstance(request.controller, DummyLightControllerSpec):
             return self._estimate_dummy_light(request)
-        if not isinstance(request.controller, HassLightControllerSpec):
+        if not isinstance(request.controller, HassLightControllerSpec | HassMultiLightControllerSpec):
             raise PreflightError("Selected light entity is unavailable")
         lights = {entity.entity_id: entity for entity in self._load_entities(EntityDomain.LIGHT, None)}
-        light = lights.get(request.controller.entity_id)
-        if light is None:
+        entity_ids = (
+            request.controller.entity_ids
+            if isinstance(request.controller, HassMultiLightControllerSpec)
+            else [request.controller.entity_id]
+        )
+        selected = [lights[entity_id] for entity_id in entity_ids if entity_id in lights]
+        if len(selected) != len(entity_ids):
             raise PreflightError("Selected light entity is unavailable")
         if isinstance(request.power_meter, HassPowerMeterSpec) and request.power_meter.voltage_entity_id:
             voltages = {entity.entity_id for entity in self._load_entities(None, DeviceClass.VOLTAGE)}
             if request.power_meter.voltage_entity_id not in voltages:
                 raise PreflightError("Selected voltage entity is unavailable or not measured in V")
-        supported = set(light.supported_modes or [])
+        expanded = self._expand_selected_lights(selected, lights)
+        leaves = list({light.entity_id: light for light in expanded}.values())
+        if len(leaves) != len(expanded):
+            raise PreflightError("A light group and one of its members cannot both be selected")
+        if request.multiple_light_count < len(selected):
+            raise PreflightError("Number of lights cannot be lower than the number of selected lights")
+        model_ids = {model_id for light in leaves if (model_id := getattr(light, "model_id", None))}
+        if len(model_ids) > 1:
+            raise PreflightError("Selected lights must have the same model ID")
+        models_confirmed = len(model_ids) == 1 and all(getattr(light, "model_id", None) for light in leaves)
+        warnings = (
+            ("Could not confirm that every selected light has the same model. Verify this before starting.",)
+            if len(leaves) > 1 and not models_confirmed
+            else ()
+        )
+        supported_sets = [set(light.supported_modes or []) for light in selected]
+        supported = set.intersection(*supported_sets)
         if not set(request.modes).issubset(supported):
             raise PreflightError("Selected light does not advertise every requested mode")
+        min_mired = max(light.min_mired if light.min_mired is not None else MIN_MIRED for light in selected)
+        max_mired = min(light.max_mired if light.max_mired is not None else MAX_MIRED for light in selected)
+        if min_mired > max_mired:
+            raise PreflightError("Selected lights do not share a color temperature range")
         light_info = LightInfo(
             "unknown",
-            min_mired=light.min_mired if light.min_mired is not None else MIN_MIRED,
-            max_mired=light.max_mired if light.max_mired is not None else MAX_MIRED,
+            min_mired=min_mired,
+            max_mired=max_mired,
         )
-        plan = build_light_plan(request.modes, request.parameters, light_info, light.effect_list or ())
+        effects = list(selected[0].effect_list or ())
+        for light in selected[1:]:
+            effects = [effect for effect in effects if effect in (light.effect_list or ())]
+        plan = build_light_plan(request.modes, request.parameters, light_info, effects)
         return PreflightResult(
+            warnings=warnings,
             estimated_variations=plan.variation_count,
             estimated_duration_seconds=round(estimate_light_time_left(plan, request.parameters)),
             supported_modes=tuple(sorted(supported, key=str)),
         )
+
+    @staticmethod
+    def _expand_selected_lights(
+        selected: Sequence[EntityRecord],
+        lights: dict[str, EntityRecord],
+    ) -> list[EntityRecord]:
+        leaves: list[EntityRecord] = []
+
+        def visit(light: EntityRecord, path: frozenset[str]) -> None:
+            if light.entity_id in path:
+                raise PreflightError("Selected light groups contain a cycle")
+            member_ids = getattr(light, "member_entity_ids", [])
+            if any(entity_id not in lights for entity_id in member_ids):
+                raise PreflightError("A selected light group contains an unavailable member")
+            members = [lights[entity_id] for entity_id in member_ids if entity_id in lights]
+            if not members:
+                leaves.append(light)
+                return
+            for member in members:
+                visit(member, path | {light.entity_id})
+
+        for light in selected:
+            visit(light, frozenset())
+        return leaves
 
     @staticmethod
     def _estimate_dummy_light(request: LightMeasurementRequest) -> PreflightResult:

--- a/utils/measure/measure/ha_app/registry.py
+++ b/utils/measure/measure/ha_app/registry.py
@@ -55,7 +55,12 @@ class FormFieldDefinition:
     default: str | int | bool | None = None
     minimum: int | float | None = None
     maximum: int | float | None = None
+    #: Whether several entities can be selected for this field at once.
     multiple: bool = False
+    #: Label to use while several entities are selected.
+    plural_label: str = ""
+    #: Entity field whose number of selected entities this count follows by default.
+    derived_from: str | None = None
     hint: str = ""
 
 
@@ -106,6 +111,7 @@ def _controller(
     *domains: str,
     narrowed_by: str | None = None,
     multiple: bool = False,
+    plural_label: str = "",
 ) -> FormFieldDefinition:
     """Entity field that selects the device being measured, and becomes the request controller."""
     return FormFieldDefinition(
@@ -116,6 +122,7 @@ def _controller(
         narrowed_by=narrowed_by,
         entity_domains=domains,
         multiple=multiple,
+        plural_label=plural_label,
     )
 
 
@@ -259,7 +266,7 @@ MEASUREMENT_REGISTRY: dict[MeasureType, MeasurementDefinition] = {
         parameters=LIGHT_PARAMETERS,
         fields=(
             POWER_FIELD,
-            _controller("light_entity_id", "Lights", "light", multiple=True),
+            _controller("light_entity_id", "Light", "light", multiple=True, plural_label="Lights"),
             MODES_FIELD,
             FormFieldDefinition(
                 name="multiple_light_count",
@@ -268,6 +275,7 @@ MEASUREMENT_REGISTRY: dict[MeasureType, MeasurementDefinition] = {
                 default=1,
                 minimum=1,
                 maximum=100,
+                derived_from="light_entity_id",
                 hint="Total number of identical physical lights; measured power is divided by this value.",
             ),
         ),

--- a/utils/measure/measure/ha_app/registry.py
+++ b/utils/measure/measure/ha_app/registry.py
@@ -55,6 +55,8 @@ class FormFieldDefinition:
     default: str | int | bool | None = None
     minimum: int | float | None = None
     maximum: int | float | None = None
+    multiple: bool = False
+    hint: str = ""
 
 
 @dataclass(frozen=True)
@@ -98,7 +100,13 @@ class MeasurementDefinition:
         return MEASURE_TYPE_LABELS[self.kind]
 
 
-def _controller(name: str, label: str, *domains: str, narrowed_by: str | None = None) -> FormFieldDefinition:
+def _controller(
+    name: str,
+    label: str,
+    *domains: str,
+    narrowed_by: str | None = None,
+    multiple: bool = False,
+) -> FormFieldDefinition:
     """Entity field that selects the device being measured, and becomes the request controller."""
     return FormFieldDefinition(
         name=name,
@@ -107,6 +115,7 @@ def _controller(name: str, label: str, *domains: str, narrowed_by: str | None = 
         role=FieldRole.CONTROLLER,
         narrowed_by=narrowed_by,
         entity_domains=domains,
+        multiple=multiple,
     )
 
 
@@ -250,7 +259,7 @@ MEASUREMENT_REGISTRY: dict[MeasureType, MeasurementDefinition] = {
         parameters=LIGHT_PARAMETERS,
         fields=(
             POWER_FIELD,
-            _controller("light_entity_id", "Light", "light"),
+            _controller("light_entity_id", "Lights", "light", multiple=True),
             MODES_FIELD,
             FormFieldDefinition(
                 name="multiple_light_count",
@@ -259,6 +268,7 @@ MEASUREMENT_REGISTRY: dict[MeasureType, MeasurementDefinition] = {
                 default=1,
                 minimum=1,
                 maximum=100,
+                hint="Total number of identical physical lights; measured power is divided by this value.",
             ),
         ),
         supports_resume=True,

--- a/utils/measure/measure/home_assistant_entities.py
+++ b/utils/measure/measure/home_assistant_entities.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 import math
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from measure.const import (
     HASS_DEVICE_REGISTRY_ID,
@@ -60,6 +60,7 @@ class EntityDescriptor(BaseModel):
     min_mired: int | None = None
     max_mired: int | None = None
     related_voltage_entity_id: str | None = None
+    member_entity_ids: list[str] = Field(default_factory=list)
 
 
 class EntityCatalogSnapshot:
@@ -181,7 +182,30 @@ class HomeAssistantEntityCatalog:
                 _describe_entity(entity, domain, registry.get(entity.entity_id), devices)
                 for entity in group.entities.values()
             )
-        return EntityCatalogSnapshot(descriptors)
+        by_id = {descriptor.entity_id: descriptor for descriptor in descriptors}
+
+        def group_model(descriptor: EntityDescriptor, path: frozenset[str]) -> str | None:
+            if descriptor.model_id:
+                return descriptor.model_id
+            if descriptor.entity_id in path or not descriptor.member_entity_ids:
+                return None
+            members = [by_id.get(entity_id) for entity_id in descriptor.member_entity_ids]
+            if not members or any(member is None for member in members):
+                return None
+            resolved = [group_model(member, path | {descriptor.entity_id}) for member in members if member is not None]
+            if any(model is None for model in resolved):
+                return None
+            models = set(resolved)
+            return models.pop() if len(models) == 1 else None
+
+        enriched: list[EntityDescriptor] = []
+        for descriptor in descriptors:
+            if not descriptor.member_entity_ids or descriptor.model_id:
+                enriched.append(descriptor)
+                continue
+            model_id = group_model(descriptor, frozenset())
+            enriched.append(descriptor.model_copy(update={"model_id": model_id}) if model_id else descriptor)
+        return EntityCatalogSnapshot(enriched)
 
 
 def _describe_entity(
@@ -213,6 +237,9 @@ def _describe_entity(
         effect_list=[str(effect) for effect in attributes.get("effect_list", [])] or None,
         min_mired=light_info.get_min_mired() if light_info is not None else None,
         max_mired=light_info.get_max_mired() if light_info is not None else None,
+        member_entity_ids=[str(item) for item in attributes.get("entity_id", [])]
+        if isinstance(attributes.get("entity_id"), list)
+        else [],
     )
 
 

--- a/utils/measure/measure/home_assistant_entities.py
+++ b/utils/measure/measure/home_assistant_entities.py
@@ -9,6 +9,7 @@ from measure.const import (
     HASS_DEVICE_REGISTRY_MODEL,
     HASS_DEVICE_REGISTRY_MODEL_ID,
     HASS_ENTITY_DEVICE_CLASS,
+    HASS_ENTITY_GROUP_MEMBERS,
     HASS_ENTITY_UNIT_OF_MEASUREMENT,
 )
 from measure.controller.light.capabilities import light_info_from_attributes, supported_light_modes
@@ -183,29 +184,35 @@ class HomeAssistantEntityCatalog:
                 for entity in group.entities.values()
             )
         by_id = {descriptor.entity_id: descriptor for descriptor in descriptors}
+        return EntityCatalogSnapshot([_with_group_model(descriptor, by_id) for descriptor in descriptors])
 
-        def group_model(descriptor: EntityDescriptor, path: frozenset[str]) -> str | None:
-            if descriptor.model_id:
-                return descriptor.model_id
-            if descriptor.entity_id in path or not descriptor.member_entity_ids:
-                return None
-            members = [by_id.get(entity_id) for entity_id in descriptor.member_entity_ids]
-            if not members or any(member is None for member in members):
-                return None
-            resolved = [group_model(member, path | {descriptor.entity_id}) for member in members if member is not None]
-            if any(model is None for model in resolved):
-                return None
-            models = set(resolved)
-            return models.pop() if len(models) == 1 else None
 
-        enriched: list[EntityDescriptor] = []
-        for descriptor in descriptors:
-            if not descriptor.member_entity_ids or descriptor.model_id:
-                enriched.append(descriptor)
-                continue
-            model_id = group_model(descriptor, frozenset())
-            enriched.append(descriptor.model_copy(update={"model_id": model_id}) if model_id else descriptor)
-        return EntityCatalogSnapshot(enriched)
+def _with_group_model(
+    descriptor: EntityDescriptor,
+    by_id: dict[str, EntityDescriptor],
+) -> EntityDescriptor:
+    """Give a light group the model of its members, so a group can be measured as one product."""
+
+    if descriptor.model_id or not descriptor.member_entity_ids:
+        return descriptor
+    model_id = _group_model(descriptor, by_id, frozenset())
+    return descriptor.model_copy(update={"model_id": model_id}) if model_id else descriptor
+
+
+def _group_model(descriptor: EntityDescriptor, by_id: dict[str, EntityDescriptor], seen: frozenset[str]) -> str | None:
+    """Model shared by every member of a group, or None when they differ or any is unknown."""
+
+    if descriptor.model_id:
+        return descriptor.model_id
+    # Groups can nest, and a malformed one can point back at itself.
+    if descriptor.entity_id in seen or not descriptor.member_entity_ids:
+        return None
+    seen = seen | {descriptor.entity_id}
+    models = {
+        _group_model(member, by_id, seen) if (member := by_id.get(entity_id)) is not None else None
+        for entity_id in descriptor.member_entity_ids
+    }
+    return models.pop() if len(models) == 1 and None not in models else None
 
 
 def _describe_entity(
@@ -222,6 +229,7 @@ def _describe_entity(
     supported_modes = supported_light_modes(attributes) if domain == EntityDomain.LIGHT else None
     light_info = light_info_from_attributes(attributes) if domain == EntityDomain.LIGHT else None
     unit = attributes.get(HASS_ENTITY_UNIT_OF_MEASUREMENT)
+    members = attributes.get(HASS_ENTITY_GROUP_MEMBERS)
     return EntityDescriptor(
         entity_id=entity.entity_id,
         name=str(attributes.get("friendly_name", entity.entity_id)),
@@ -237,9 +245,7 @@ def _describe_entity(
         effect_list=[str(effect) for effect in attributes.get("effect_list", [])] or None,
         min_mired=light_info.get_min_mired() if light_info is not None else None,
         max_mired=light_info.get_max_mired() if light_info is not None else None,
-        member_entity_ids=[str(item) for item in attributes.get("entity_id", [])]
-        if isinstance(attributes.get("entity_id"), list)
-        else [],
+        member_entity_ids=[str(member) for member in members] if isinstance(members, list) else [],
     )
 
 

--- a/utils/measure/measure/request.py
+++ b/utils/measure/measure/request.py
@@ -143,19 +143,10 @@ class BaseMeasurementRequest(BaseModel):
         return self
 
     @property
-    def controlled_entity_id(self) -> str | None:
-        """Home Assistant entity driven during the measurement, when the controller uses one."""
-        entity_id = getattr(self.controller, "entity_id", None)
-        return str(entity_id) if entity_id else None
-
-    @property
     def controlled_entity_ids(self) -> tuple[str, ...]:
-        """Home Assistant entities driven during the measurement."""
-        entity_ids = getattr(self.controller, "entity_ids", None)
-        if entity_ids:
-            return tuple(str(entity_id) for entity_id in entity_ids)
-        entity_id = self.controlled_entity_id
-        return (entity_id,) if entity_id else ()
+        """Home Assistant entities driven during the measurement, empty when the controller drives none."""
+        entity_ids = getattr(self.controller, "entity_ids", None) or [getattr(self.controller, "entity_id", None)]
+        return tuple(str(entity_id) for entity_id in entity_ids if entity_id)
 
     @property
     def model_name(self) -> str:

--- a/utils/measure/measure/request.py
+++ b/utils/measure/measure/request.py
@@ -149,6 +149,15 @@ class BaseMeasurementRequest(BaseModel):
         return str(entity_id) if entity_id else None
 
     @property
+    def controlled_entity_ids(self) -> tuple[str, ...]:
+        """Home Assistant entities driven during the measurement."""
+        entity_ids = getattr(self.controller, "entity_ids", None)
+        if entity_ids:
+            return tuple(str(entity_id) for entity_id in entity_ids)
+        entity_id = self.controlled_entity_id
+        return (entity_id,) if entity_id else ()
+
+    @property
     def model_name(self) -> str:
         return self.product_name
 

--- a/utils/measure/tests/controller/light/test_hass.py
+++ b/utils/measure/tests/controller/light/test_hass.py
@@ -4,7 +4,7 @@ from homeassistant_api import State
 from homeassistant_api.errors import HomeassistantAPIError
 from measure.controller.errors import ApiConnectionError
 from measure.controller.light.const import MAX_MIRED, MIN_MIRED, LutMode
-from measure.controller.light.hass import HassLightController
+from measure.controller.light.hass import HassLightController, HassMultiLightController
 from measure.home_assistant import HomeAssistantManager
 import pytest
 
@@ -103,6 +103,37 @@ def test_connection_validation() -> None:
     client.get_config.side_effect = HomeassistantAPIError("Error")
     with pytest.raises(ApiConnectionError):
         HassLightController(client, 0)
+
+
+def test_multi_light_controller_targets_all_entities_and_intersects_capabilities() -> None:
+    client = _mock_client()
+    client.get_state.side_effect = [
+        State(
+            entity_id="light.one",
+            state="on",
+            attributes={"min_color_temp_kelvin": 2000, "max_color_temp_kelvin": 5000},
+        ),
+        State(
+            entity_id="light.two",
+            state="on",
+            attributes={"min_color_temp_kelvin": 2500, "max_color_temp_kelvin": 6500},
+        ),
+        State(entity_id="light.one", state="on", attributes={"effect_list": ["one", "shared"]}),
+        State(entity_id="light.two", state="on", attributes={"effect_list": ["shared", "two"]}),
+    ]
+    controller = HassMultiLightController(client, 0, entity_ids=["light.one", "light.two"])
+
+    controller.change_light_state(LutMode.BRIGHTNESS, bri=100)
+    client.trigger_service.assert_called_once_with(
+        "light",
+        "turn_on",
+        entity_id=["light.one", "light.two"],
+        brightness=100,
+        transition=0,
+    )
+    info = controller.get_light_info()
+    assert (info.min_mired, info.max_mired) == (200, 400)
+    assert controller.get_effect_list() == ["shared"]
 
 
 def _get_instance(client: MagicMock | None = None) -> HassLightController:

--- a/utils/measure/tests/controller/light/test_hass.py
+++ b/utils/measure/tests/controller/light/test_hass.py
@@ -4,7 +4,7 @@ from homeassistant_api import State
 from homeassistant_api.errors import HomeassistantAPIError
 from measure.controller.errors import ApiConnectionError
 from measure.controller.light.const import MAX_MIRED, MIN_MIRED, LutMode
-from measure.controller.light.hass import HassLightController, HassMultiLightController
+from measure.controller.light.hass import HassLightController
 from measure.home_assistant import HomeAssistantManager
 import pytest
 
@@ -102,10 +102,15 @@ def test_connection_validation() -> None:
     client = _mock_client()
     client.get_config.side_effect = HomeassistantAPIError("Error")
     with pytest.raises(ApiConnectionError):
-        HassLightController(client, 0)
+        HassLightController(client, 0, entity_ids=["light.test"])
 
 
-def test_multi_light_controller_targets_all_entities_and_intersects_capabilities() -> None:
+def test_controller_requires_an_entity() -> None:
+    with pytest.raises(ValueError, match="at least one entity"):
+        HassLightController(_mock_client(), 0, entity_ids=[])
+
+
+def test_multiple_entities_are_targeted_together_with_their_common_capabilities() -> None:
     client = _mock_client()
     client.get_state.side_effect = [
         State(
@@ -121,7 +126,7 @@ def test_multi_light_controller_targets_all_entities_and_intersects_capabilities
         State(entity_id="light.one", state="on", attributes={"effect_list": ["one", "shared"]}),
         State(entity_id="light.two", state="on", attributes={"effect_list": ["shared", "two"]}),
     ]
-    controller = HassMultiLightController(client, 0, entity_ids=["light.one", "light.two"])
+    controller = HassLightController(client, 0, entity_ids=["light.one", "light.two"])
 
     controller.change_light_state(LutMode.BRIGHTNESS, bri=100)
     client.trigger_service.assert_called_once_with(
@@ -140,7 +145,7 @@ def _get_instance(client: MagicMock | None = None) -> HassLightController:
     return HassLightController(
         client or _mock_client(),
         0,
-        entity_id="light.test",
+        entity_ids=["light.test"],
     )
 
 

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -37,7 +37,7 @@ from measure.request import MeasurementRequest
 from measure.runner.runner import RunnerResult
 from measure.tuning import MeasurementParameters
 from measure.version import measure_version
-from pydantic import SecretStr
+from pydantic import SecretStr, TypeAdapter
 import pytest
 
 
@@ -900,6 +900,33 @@ def test_contribution_device_flow_reports_configuration_and_uses_injected_servic
     assert unknown.json()["code"] == "flow_not_found"
     completed = test_client.post(f"/api/contribution/auth/device/{flow_id}")
     assert completed.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "integrations, expected",
+    [
+        ({"light.one": "hue", "light.two": "hue"}, "hue"),
+        ({"light.one": "hue", "light.two": "zha"}, None),
+        ({"light.one": "hue", "light.two": None}, None),
+    ],
+)
+def test_contribution_integration_requires_every_light_to_share_the_integration(
+    tmp_path: Path,
+    integrations: dict[str, str | None],
+    expected: str | None,
+) -> None:
+    request_payload = payload()
+    request_payload["controller"] = {
+        "type": "hass_multi",
+        "entity_ids": ["light.one", "light.two"],
+    }
+    request = TypeAdapter(MeasurementRequest).validate_python(request_payload)
+    coordinator = ContributionApiCoordinator(
+        SessionStorage(tmp_path),
+        resolve_integration=integrations.get,
+    )
+
+    assert coordinator._integration(request) == expected  # noqa: SLF001
 
 
 def test_contribution_pat_rejects_reported_insufficient_scope(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_assembler.py
+++ b/utils/measure/tests/test_assembler.py
@@ -2,7 +2,11 @@ from unittest.mock import ANY, MagicMock, patch
 
 from measure.assembler import MeasurementAssembler
 from measure.controller.fan.spec import DummyFanControllerSpec
-from measure.controller.light.spec import DummyLightControllerSpec, HassLightControllerSpec
+from measure.controller.light.spec import (
+    DummyLightControllerSpec,
+    HassLightControllerSpec,
+    HassMultiLightControllerSpec,
+)
 from measure.execution import RunInteraction
 from measure.home_assistant import HomeAssistantManager
 from measure.powermeter.spec import DummyPowerMeterSpec, HassPowerMeterSpec, ShellyPowerMeterSpec, TuyaPowerMeterSpec
@@ -97,6 +101,23 @@ def test_assembler_applies_typed_home_assistant_configuration_at_construction() 
         entity_id="light.test",
         wait=ANY,
     )
+
+
+def test_assembler_builds_multi_light_controller() -> None:
+    request = LightMeasurementRequest(
+        model_id="light",
+        product_name="Light",
+        measure_device="Meter",
+        power_meter=DummyPowerMeterSpec(),
+        controller=HassMultiLightControllerSpec(entity_ids=["light.one", "light.two"], transition_time=2),
+        multiple_light_count=2,
+    )
+    home_assistant = MagicMock(spec=HomeAssistantManager)
+
+    with patch("measure.assembler.HassMultiLightController") as controller:
+        _assembler(home_assistant=home_assistant).assemble(request)
+
+    controller.assert_called_once_with(home_assistant, 2, entity_ids=["light.one", "light.two"], wait=ANY)
 
 
 def test_assembler_reads_tuya_key_from_cli_config_dependency() -> None:

--- a/utils/measure/tests/test_assembler.py
+++ b/utils/measure/tests/test_assembler.py
@@ -98,7 +98,7 @@ def test_assembler_applies_typed_home_assistant_configuration_at_construction() 
     light_controller.assert_called_once_with(
         home_assistant,
         2,
-        entity_id="light.test",
+        entity_ids=["light.test"],
         wait=ANY,
     )
 
@@ -114,7 +114,7 @@ def test_assembler_builds_multi_light_controller() -> None:
     )
     home_assistant = MagicMock(spec=HomeAssistantManager)
 
-    with patch("measure.assembler.HassMultiLightController") as controller:
+    with patch("measure.assembler.HassLightController") as controller:
         _assembler(home_assistant=home_assistant).assemble(request)
 
     controller.assert_called_once_with(home_assistant, 2, entity_ids=["light.one", "light.two"], wait=ANY)

--- a/utils/measure/tests/test_home_assistant_entities.py
+++ b/utils/measure/tests/test_home_assistant_entities.py
@@ -133,6 +133,31 @@ def test_catalog_loads_entity_data_once_per_instance() -> None:
     assert fresh[0].state == "2.0"
 
 
+def test_catalog_exposes_group_members_and_infers_their_shared_model() -> None:
+    data = _entity_data()
+    data.entities["light"].entities["second"] = _entity(
+        "light.second",
+        "on",
+        supported_color_modes=["brightness"],
+    )
+    group = _entity(
+        "light.group",
+        "on",
+        supported_color_modes=["brightness"],
+    )
+    group.state.attributes["entity_id"] = ["light.desk", "light.second"]
+    data.entities["light"].entities["group"] = group
+    data.entity_registry.append(SimpleNamespace(entity_id="light.second", device_id="light-device", platform="hue"))
+    home_assistant = MagicMock(spec=HomeAssistantManager)
+    home_assistant.get_entity_data.return_value = data
+
+    lights = HomeAssistantEntityCatalog(home_assistant).load_snapshot().select(domain=EntityDomain.LIGHT)
+    group = next(light for light in lights if light.entity_id == "light.group")
+
+    assert group.member_entity_ids == ["light.desk", "light.second"]
+    assert group.model_id == "LWA017"
+
+
 def test_snapshot_requires_exactly_one_entity_filter() -> None:
     home_assistant = MagicMock(spec=HomeAssistantManager)
     home_assistant.get_entity_data.return_value = _entity_data()

--- a/utils/measure/tests/test_preflight.py
+++ b/utils/measure/tests/test_preflight.py
@@ -4,7 +4,11 @@ from typing import Any
 from measure.controller.charging.spec import HassChargingControllerSpec
 from measure.controller.fan.spec import HassFanControllerSpec
 from measure.controller.light.const import LutMode
-from measure.controller.light.spec import DummyLightControllerSpec, HassLightControllerSpec
+from measure.controller.light.spec import (
+    DummyLightControllerSpec,
+    HassLightControllerSpec,
+    HassMultiLightControllerSpec,
+)
 from measure.controller.media.spec import HassMediaControllerSpec
 from measure.ha_app.preflight import ActiveSessionError, EntityRecord, MeasurementPreflight, PreflightError
 from measure.powermeter.diagnostics import DiagnosticStatus, PowerMeterDiagnostic
@@ -30,6 +34,8 @@ class Entity(EntityRecord):
     state: str = "available"
     attribute_names: list[str] = field(default_factory=list)
     device_id: str | None = None
+    model_id: str | None = None
+    member_entity_ids: list[str] = field(default_factory=list)
 
 
 def preflight(
@@ -388,6 +394,114 @@ def test_hs_preflight_uses_default_native_resolution() -> None:
     result = preflight(entities).validate(request)
 
     assert result.estimated_variations == 2_025
+
+
+def test_multi_light_preflight_uses_common_capabilities_and_models() -> None:
+    entities = base_entities()
+    entities[("light", None)] = [
+        Entity(
+            "light.one",
+            [LutMode.BRIGHTNESS, LutMode.COLOR_TEMP],
+            min_mired=150,
+            max_mired=400,
+            model_id="LWA017",
+        ),
+        Entity(
+            "light.two",
+            [LutMode.BRIGHTNESS, LutMode.COLOR_TEMP],
+            min_mired=200,
+            max_mired=500,
+            model_id="LWA017",
+        ),
+    ]
+    request = LightMeasurementRequest(
+        model_id="LWA017",
+        product_name="Test lights",
+        measure_device="Test meter",
+        power_meter=HassPowerMeterSpec(entity_id="sensor.power"),
+        controller=HassMultiLightControllerSpec(entity_ids=["light.one", "light.two"]),
+        modes={LutMode.COLOR_TEMP},
+        multiple_light_count=2,
+    )
+
+    result = preflight(entities).validate(request)
+
+    assert result.warnings == ()
+    assert result.supported_modes == (LutMode.BRIGHTNESS, LutMode.COLOR_TEMP)
+
+
+def test_multi_light_preflight_rejects_mixed_models_and_group_member_overlap() -> None:
+    entities = base_entities()
+    entities[("light", None)] = [
+        Entity("light.group", [LutMode.BRIGHTNESS], member_entity_ids=["light.one", "light.two"]),
+        Entity("light.one", [LutMode.BRIGHTNESS], model_id="ONE"),
+        Entity("light.two", [LutMode.BRIGHTNESS], model_id="TWO"),
+    ]
+    common = {
+        "model_id": "ONE",
+        "product_name": "Test lights",
+        "measure_device": "Test meter",
+        "power_meter": HassPowerMeterSpec(entity_id="sensor.power"),
+        "multiple_light_count": 3,
+    }
+
+    mixed = LightMeasurementRequest(
+        **common,
+        controller=HassMultiLightControllerSpec(entity_ids=["light.one", "light.two"]),
+    )
+    with pytest.raises(PreflightError, match="same model ID"):
+        preflight(entities).validate(mixed)
+
+    overlap = LightMeasurementRequest(
+        **common,
+        controller=HassMultiLightControllerSpec(entity_ids=["light.group", "light.one"]),
+    )
+    with pytest.raises(PreflightError, match="group and one of its members"):
+        preflight(entities).validate(overlap)
+
+
+def test_multi_light_preflight_warns_for_unknown_models_and_validates_count() -> None:
+    entities = base_entities()
+    entities[("light", None)] = [
+        Entity("light.one", [LutMode.BRIGHTNESS]),
+        Entity("light.two", [LutMode.BRIGHTNESS]),
+    ]
+    request = LightMeasurementRequest(
+        model_id="manual",
+        product_name="Test lights",
+        measure_device="Test meter",
+        power_meter=HassPowerMeterSpec(entity_id="sensor.power"),
+        controller=HassMultiLightControllerSpec(entity_ids=["light.one", "light.two"]),
+        multiple_light_count=2,
+    )
+
+    assert "Could not confirm" in preflight(entities).validate(request).warnings[0]
+    with pytest.raises(PreflightError, match="Number of lights"):
+        preflight(entities).validate(request.model_copy(update={"multiple_light_count": 1}))
+
+
+def test_light_group_does_not_force_its_discovered_member_count() -> None:
+    entities = base_entities()
+    entities[("light", None)] = [
+        Entity(
+            "light.group",
+            [LutMode.BRIGHTNESS],
+            model_id="LWA017",
+            member_entity_ids=["light.one", "light.two"],
+        ),
+        Entity("light.one", [LutMode.BRIGHTNESS], model_id="LWA017"),
+        Entity("light.two", [LutMode.BRIGHTNESS], model_id="LWA017"),
+    ]
+    request = LightMeasurementRequest(
+        model_id="LWA017",
+        product_name="Test group",
+        measure_device="Test meter",
+        power_meter=HassPowerMeterSpec(entity_id="sensor.power"),
+        controller=HassLightControllerSpec(entity_id="light.group"),
+        multiple_light_count=1,
+    )
+
+    preflight(entities).validate(request)
 
 
 def test_preflight_reports_active_session_before_external_checks() -> None:

--- a/utils/measure/tests/test_registry.py
+++ b/utils/measure/tests/test_registry.py
@@ -29,3 +29,10 @@ def test_charging_definition_discovers_both_supported_domains() -> None:
     )
 
     assert entity.entity_domains == ("vacuum", "lawn_mower")
+
+
+def test_light_definition_allows_multiple_entities_and_explains_the_physical_count() -> None:
+    fields = {field.name: field for field in MEASUREMENT_REGISTRY[MeasureType.LIGHT].fields}
+
+    assert fields["light_entity_id"].multiple is True
+    assert "physical lights" in fields["multiple_light_count"].hint

--- a/utils/measure/tests/test_request.py
+++ b/utils/measure/tests/test_request.py
@@ -1,6 +1,7 @@
 from measure.cli.request_adapter import request_from_answers
 from measure.const import PARAMETER_LIMITS, QUESTION_ENTITY_ID, QUESTION_MEASURE_DEVICE, MeasureType
 from measure.controller.light.const import LightControllerType, LutMode
+from measure.controller.light.spec import HassMultiLightControllerSpec
 from measure.powermeter.const import PowerMeterType
 from measure.powermeter.spec import DummyPowerMeterSpec
 from measure.request import (
@@ -53,6 +54,28 @@ def test_request_exposes_the_controlled_entity_only_when_the_controller_drives_o
 
     assert controlled.controlled_entity_id == "light.test"
     assert uncontrolled.controlled_entity_id is None
+
+
+def test_request_exposes_all_controlled_entities_for_multi_light_controller() -> None:
+    request = LightMeasurementRequest.model_validate(
+        valid_request()
+        | {"controller": {"type": "hass_multi", "entity_ids": ["light.one", "light.two"]}, "multiple_light_count": 2},
+    )
+
+    assert isinstance(request.controller, HassMultiLightControllerSpec)
+    assert request.controlled_entity_id is None
+    assert request.controlled_entity_ids == ("light.one", "light.two")
+
+
+@pytest.mark.parametrize(
+    "entity_ids",
+    [["light.one"], ["light.one", "light.one"], ["light.one", "switch.two"]],
+)
+def test_multi_light_controller_requires_multiple_unique_light_entities(entity_ids: list[str]) -> None:
+    with pytest.raises(ValidationError):
+        LightMeasurementRequest.model_validate(
+            valid_request() | {"controller": {"type": "hass_multi", "entity_ids": entity_ids}},
+        )
 
 
 def test_request_normalizes_profile_metadata() -> None:

--- a/utils/measure/tests/test_request.py
+++ b/utils/measure/tests/test_request.py
@@ -46,14 +46,14 @@ def test_request_round_trip_preserves_typed_input() -> None:
     assert isinstance(restored.dummy_load, DummyLoadReuseRequest)
 
 
-def test_request_exposes_the_controlled_entity_only_when_the_controller_drives_one() -> None:
+def test_request_exposes_the_controlled_entities_only_when_the_controller_drives_them() -> None:
     controlled = LightMeasurementRequest.model_validate(valid_request())
     uncontrolled = AverageMeasurementRequest.model_validate(
         {"power_meter": {"type": "hass", "entity_id": "sensor.test_power"}},
     )
 
-    assert controlled.controlled_entity_id == "light.test"
-    assert uncontrolled.controlled_entity_id is None
+    assert controlled.controlled_entity_ids == ("light.test",)
+    assert uncontrolled.controlled_entity_ids == ()
 
 
 def test_request_exposes_all_controlled_entities_for_multi_light_controller() -> None:
@@ -63,7 +63,6 @@ def test_request_exposes_all_controlled_entities_for_multi_light_controller() ->
     )
 
     assert isinstance(request.controller, HassMultiLightControllerSpec)
-    assert request.controlled_entity_id is None
     assert request.controlled_entity_ids == ("light.one", "light.two")
 
 


### PR DESCRIPTION
Allow to directly measure multiple lights from within the measure app, without the need to create a HA light group.

**Normal screen for single light**
<img width="1314" height="315" alt="Screenshot 2026-08-13 at 10 53 14" src="https://github.com/user-attachments/assets/be02113b-e5a1-4ca0-a59b-c1772b662de6" />

**After checking multiple lights**
<img width="1291" height="372" alt="Screenshot 2026-08-13 at 10 52 58" src="https://github.com/user-attachments/assets/68111cf9-dcbe-4060-88a8-f36673943145" />

All the selected lights are validated on their common capabilities and model information.
When anything doesn't match you cannot continue.
