### PR TITLE
Add dreo DR-HTF008S power profile

### DIFF
--- a/profile_library/dreo/DR-HTF008S/model.json
+++ b/profile_library/dreo/DR-HTF008S/model.json
@@ -32,7 +32,7 @@
   },
   "max_voltage": 236.7,
   "measure_description": "Measured with utils/measure script",
-  "measure_device": "Shelly Plus 1 PM",
+  "measure_device": "Shelly Plus 1PM",
   "measure_method": "script",
   "measure_settings": {
     "SAMPLE_COUNT": 1,

--- a/profile_library/dreo/DR-HTF008S/model.json
+++ b/profile_library/dreo/DR-HTF008S/model.json
@@ -1,0 +1,45 @@
+{
+  "author_info": {
+    "github": "wagnerpizza",
+    "name": "wagnerpizza"
+  },
+  "calculation_strategy": "linear",
+  "created_at": "2026-08-13T15:43:19Z",
+  "device_type": "fan",
+  "linear_config": {
+    "calibrate": [
+      "5 -> 16.90",
+      "10 -> 16.86",
+      "15 -> 16.75",
+      "20 -> 16.65",
+      "25 -> 18.84",
+      "30 -> 18.87",
+      "35 -> 18.78",
+      "40 -> 18.82",
+      "45 -> 21.28",
+      "50 -> 21.19",
+      "55 -> 21.10",
+      "60 -> 21.16",
+      "65 -> 25.28",
+      "70 -> 25.28",
+      "75 -> 25.06",
+      "80 -> 25.09",
+      "85 -> 36.02",
+      "90 -> 36.03",
+      "95 -> 35.80",
+      "100 -> 35.90"
+    ]
+  },
+  "max_voltage": 236.7,
+  "measure_description": "Measured with utils/measure script",
+  "measure_device": "Shelly Plus 1 PM",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 1,
+    "SLEEP_TIME": 2.0,
+    "VERSION": "v0.3.0:app"
+  },
+  "min_voltage": 234.4,
+  "name": "Dreo DR-HTF008S",
+  "standby_power": 1.57
+}

--- a/profile_library/dreo/DR-HTF008S/model.json
+++ b/profile_library/dreo/DR-HTF008S/model.json
@@ -40,6 +40,6 @@
     "VERSION": "v0.3.0:app"
   },
   "min_voltage": 234.4,
-  "name": "Dreo DR-HTF008S",
+  "name": "Cruiser Pro S Smart Tower Fan",
   "standby_power": 1.57
 }


### PR DESCRIPTION
## Device information

- Manufacturer: Dreo
- Model ID: DR-HTF008S
- Product name: Dreo DR-HTF008S
- Measurement device: Shelly Plus 1 PM

## Home Assistant Device information

- Measure type: fan
- Integration: dreo

## Checklist

- [x] I have created a single PR per device.
- [x] For lights, only generated gzipped lookup tables are included.
- [x] I reviewed the generated files and JSON in Powercalc Measure.

## Additional info

Generated and validated by Powercalc Measure.

### Generated files

- `profile_library/dreo/DR-HTF008S/model.json`

### Duplicate warnings

- None
