### PR TITLE
feat(profile): add LED2402C3 aliases

### DIFF
--- a/profile_library/ikea/LED2402C3/model.json
+++ b/profile_library/ikea/LED2402C3/model.json
@@ -1,4 +1,8 @@
 {
+  "aliases": [
+    "KAJPLATS E14 WS B38 CL 470lm",
+    "36872"
+  ],
   "calculation_strategy": "lut",
   "created_at": "2026-06-18T00:07:18Z",
   "device_type": "light",


### PR DESCRIPTION
Adding aliases to IKEA Kajplats E14 WS B38 CL 470lm as it didn't auto discover my Matter connected bulbs.