### PR TITLE
Register group energy sensors when the group has no unique_id

### DIFF
--- a/custom_components/powercalc/sensors/group/custom.py
+++ b/custom_components/powercalc/sensors/group/custom.py
@@ -389,9 +389,9 @@ def create_grouped_energy_sensor(
 ) -> EnergySensor:
     name = generate_energy_sensor_name(sensor_config, group_name)
     unique_id = sensor_config.get(CONF_UNIQUE_ID)
-    energy_unique_id = None
-    if unique_id:
-        energy_unique_id = f"{unique_id}_energy"
+    if not unique_id:
+        unique_id = generate_unique_id(sensor_config)
+    energy_unique_id = f"{unique_id}_energy"
     entity_id = generate_energy_sensor_entity_id(
         hass,
         sensor_config,

--- a/tests/sensors/group/test_custom.py
+++ b/tests/sensors/group/test_custom.py
@@ -79,6 +79,7 @@ from custom_components.powercalc.const import (
     CONF_UTILITY_METER_TYPES,
     DATA_GROUP_ENTITIES,
     DEFAULT_ENERGY_UPDATE_INTERVAL,
+    DEFAULT_UTILITY_METER_TYPES,
     DOMAIN,
     DUMMY_ENTITY_ID,
     ENTRY_DATA_ENERGY_ENTITY,
@@ -171,6 +172,40 @@ async def test_grouped_power_sensor(hass: HomeAssistant, entity_registry: Entity
     await set_states(hass, [("input_boolean.test1", STATE_OFF)], block_count=2)
 
     assert_entity_state(hass, "sensor.testgroup_power", "50.00")
+
+
+async def test_group_without_unique_id_registers_energy_sensors(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+) -> None:
+    """A YAML group without an explicit unique_id must still register its energy sensors.
+
+    The power sensor falls back to the group name, so it was always registered. The
+    energy sensor had no such fallback, leaving it and every utility meter derived from
+    it without a unique_id, so they never reached the entity registry.
+    """
+    await set_states(hass, [("input_boolean.test1", STATE_ON)])
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_CREATE_GROUP: "TestGroup",
+            CONF_CREATE_UTILITY_METERS: True,
+            CONF_ENTITIES: [get_simple_fixed_config("input_boolean.test1", 50)],
+        },
+    )
+
+    power_entry = entity_registry.async_get("sensor.testgroup_power")
+    assert power_entry
+    assert power_entry.unique_id == "TestGroup"
+
+    energy_entry = entity_registry.async_get("sensor.testgroup_energy")
+    assert energy_entry
+    assert energy_entry.unique_id == "TestGroup_energy"
+
+    for meter_type in DEFAULT_UTILITY_METER_TYPES:
+        meter_entry = entity_registry.async_get(f"sensor.testgroup_energy_{meter_type}")
+        assert meter_entry, f"{meter_type} utility meter was not registered"
+        assert meter_entry.unique_id == f"TestGroup_energy_{meter_type}"
 
 
 async def test_subgroups_from_config_entry(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## The problem

A YAML group without an explicit `unique_id:` gets a registered power sensor but an
unregistered energy sensor, and unregistered utility meters along with it. They hold
correct values and update normally, so nothing looks wrong until you try to rename one
or go looking for it in the registry.

I hit this on my own install with a group of 14 audio devices. Took a while to work out
why only the power sensor had a registry entry, since nothing in the logs mentions it.

```yaml
powercalc:
  create_utility_meters: true
  sensors:
    - create_group: All Audio Equipment
      entities:
        - power_sensor_id: sensor.some_power
          energy_sensor_id: sensor.some_energy
```

| Entity | In registry? |
| --- | --- |
| `sensor.all_audio_equipment_power` | yes, unique_id `All Audio Equipment` |
| `sensor.all_audio_equipment_energy` | no |
| `sensor.all_audio_equipment_energy_daily` | no |
| `sensor.all_audio_equipment_energy_weekly` | no |
| `sensor.all_audio_equipment_energy_monthly` | no |

## Cause

`create_grouped_power_sensor` falls back to the group name when no `unique_id` is
configured. `create_grouped_energy_sensor` has no such fallback, so `energy_unique_id`
stays `None`, and `create_utility_meters` then passes that `None` down to every meter
via `f"{energy_sensor.unique_id}_{meter_type}" if energy_sensor.unique_id else None`.

Only YAML custom groups are affected. GUI groups get `entry.entry_id` in
`create_group_sensors_gui`, and domain groups get a generated id in the group factory,
so both already had something to derive from. That is also why the existing tests never
caught it: they all set `CONF_UNIQUE_ID` on the group.

## The fix

Give the energy branch the same fallback the power branch already has. `CONF_NAME` is
guaranteed to be set by then, since `create_group_sensors_custom` fills it from
`group_name` before either sensor is built, so `generate_unique_id` cannot raise here.

## Upgrade impact

Existing installs keep their entity_ids. I checked this on my own instance before
opening the PR, on a group with four utility meters and months of history. After the
change all six entities came back under their original entity_ids with no `_2`
suffixes, the meters carried on from their previous values instead of resetting, and
long-term statistics ran unbroken across the restart (daily sum 204.4258, 205.9863,
207.6358, 208.5091).

The meters are safe because their entity_ids are concatenated from the energy sensor's
entity_id rather than passed through `async_generate_entity_id`, so they cannot pick up
a collision suffix. The energy sensor does use that generator, but the fix does not
change its input.

One case I could not test: a group whose energy sensor entity_id was manually diverged
from the default naming pattern. Worth a look if you think that is reachable.

## Tests

Added `test_group_without_unique_id_registers_energy_sensors`, which sets up a group
with no `unique_id` and asserts the power sensor, the energy sensor and all three
default utility meters are registered with the expected unique_ids. It fails on master
at `assert energy_entry` and passes with the fix.

Full suite passes at 1140 tests with 100% coverage maintained.
