### PR TITLE
Add Inovelli VZM31-SN dimmer profile

### DIFF
--- a/profile_library/inovelli/VZM31-SN/model.json
+++ b/profile_library/inovelli/VZM31-SN/model.json
@@ -1,0 +1,17 @@
+{
+  "author": "Martin Emde <me@martinemde.com>",
+  "calculation_strategy": "linear",
+  "created_at": "2026-08-15T20:38:56Z",
+  "device_type": "smart_dimmer",
+  "measure_description": "Device self usage measured with no load on the switch output. Draw is below the power meter's zero-suppression threshold, so it was measured by difference against a parallel bias load: 10.894 W with the switch powered vs 10.601 W with the switch disconnected at the air gap, giving 0.29 W. The on/off difference (0.03 W, the LED bar dropping from intensity 33 to 1) was resolved separately from five interleaved on/off cycles. Values carry roughly +/- 0.04 W of uncertainty from meter quantization.",
+  "measure_device": "Shelly PM Mini Gen3",
+  "measure_method": "manual",
+  "name": "2-in-1 Dimmer Switch (VZM31-SN)",
+  "standby_power": 0.26,
+  "standby_power_on": 0.29,
+  "author_info": {
+    "name": "Martin Emde",
+    "email": "me@martinemde.com",
+    "github": "martinemde"
+  }
+}


### PR DESCRIPTION
Adds a power profile for the **Inovelli VZM31-SN** Blue Series 2-in-1 Zigbee dimmer switch.

Profiled as a `smart_dimmer` using the `linear` strategy with the device's own consumption:

- **standby_power** (off): 0.26 W
- **standby_power_on** (on): 0.29 W

Companion to #4205 (VZM32-SN), which shares the manufacturer folder.

## Device information

- Inovelli Blue Series VZM31-SN, 2-in-1 switch + dimmer (Zigbee, neutral wired)
- Product page: https://inovelli.com/products/2-1-switch-dimmer-blue-series
- Paired via Zigbee2MQTT, firmware 3.04

## Home Assistant Device information

```
Manufacturer: Inovelli
Model:        2-in-1 switch + dimmer
Model ID:     VZM31-SN
Firmware:     3.04
```

## Checklist

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

(Light-specific items are not applicable — this profile covers only the switch's own consumption.)

## Additional info

Measuring this device needed an indirect method.

Without the mmWave radar that keeps the VZM32-SN above 1.5 W, the VZM31-SN draws under a third of
a watt. That is below the Shelly PM Mini Gen3's zero-suppression threshold, so the meter reports
exactly 0.00 W rather than a small value, and the energy counter does not accumulate either. The
measure script cannot be used directly here: `_take_power_reading` discards any sample rounding to
0.00 W, so every sample is rejected and the run aborts. The dummy-load compensation that would
normally solve this is not offered for `MeasureType.AVERAGE`, and setting `DUMMY_LOAD` in `.env`
does not reach it either, because predefined answers only apply to questions actually asked.

So the value was measured by difference against a bias load wired in parallel with the switch,
with the switch's air gap used to remove it from the circuit:

| State | Shelly reading |
|---|---|
| bias bulb + VZM31-SN powered (n=159) | 10.8937 W |
| bias bulb alone, switch air-gapped (n=152) | 10.6013 W |
| **self usage (on)** | **0.2924 W** |

The ON segments were sampled both before and after the air-gap window to cancel the bias bulb's
warm-up drift; they differed by 0.0009 W, so drift contributed nothing.

The on/off difference is the LED bar dropping from intensity 33 to 1. At 0.03 W it is smaller than
the meter's 0.1 W quantization step, so it was resolved from five interleaved on/off cycles paired
against each other rather than from two separate averages — the raw ON and OFF means are both
10.89 W and separate by nothing.

As an independent check, the switch's own load-side energy meter was compared against the Shelly
upstream of it (the difference between the two being the switch's own draw, since the internal
meter excludes it — confirmed by a VZM32-SN reading 0 W internally while powered with no load).
That method gave 0.333 W, landing 0.041 W from the air-gap result despite having entirely
different error sources.

Both values carry roughly ±0.04 W of uncertainty, dominated by meter quantization rather than
sampling noise. Note that the on/off delta depends on the user's `ledIntensityWhenOn` and
`ledIntensityWhenOff` settings; these measurements used the defaults of 33 and 1.

Assisted-by: Claude Opus 5
