### PR TITLE
Mark Inovelli VZM31-SN as self-usage only

### DIFF
--- a/profile_library/inovelli/VZM31-SN/model.json
+++ b/profile_library/inovelli/VZM31-SN/model.json
@@ -1,11 +1,16 @@
 {
-  "calculation_strategy": "linear",
+  "calculation_strategy": "fixed",
   "created_at": "2026-08-15T20:38:56Z",
   "device_type": "smart_dimmer",
-  "measure_description": "Device self usage measured with no load on the switch output. Draw is below the power meter's zero-suppression threshold, so it was measured by difference against a parallel bias load: 10.894 W with the switch powered vs 10.601 W with the switch disconnected at the air gap, giving 0.29 W. The on/off difference (0.03 W, the LED bar dropping from intensity 33 to 1) was resolved separately from five interleaved on/off cycles. Values carry roughly +/- 0.04 W of uncertainty from meter quantization.",
+  "measure_description": "Device self usage measured with no load on the switch output. Draw is below the power meter's zero-suppression threshold, so it was measured by difference against a parallel bias load: 10.894 W with the switch powered vs 10.601 W with the switch disconnected at the air gap, giving 0.29 W. The on/off difference (0.03 W, the LED bar dropping from intensity 33 to 1) was resolved separately from five interleaved on/off cycles. Values carry roughly +/- 0.04 W of uncertainty from meter quantization. The device meters its own load energy, so this profile reports only the device's own consumption.",
   "measure_device": "Shelly PM Mini Gen3",
   "measure_method": "manual",
   "name": "2-in-1 Dimmer Switch (VZM31-SN)",
+  "only_self_usage": true,
+  "sensor_config": {
+    "energy_sensor_naming": "{} Device Energy",
+    "power_sensor_naming": "{} Device Power"
+  },
   "standby_power": 0.26,
   "standby_power_on": 0.29,
   "author_info": {

--- a/profile_library/inovelli/VZM31-SN/model.json
+++ b/profile_library/inovelli/VZM31-SN/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "2-in-1 Dimmer Switch (VZM31-SN)",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.26,
   "standby_power_on": 0.29,
   "author_info": {


### PR DESCRIPTION
Follow-up to #4525.

Oops, this should not report the load's power because the device itself calculates the load power. This disables that choice.

Matches the VZM32-SN profile: `fixed` strategy with `only_self_usage`, and `Device Power`/`Device Energy` sensor naming.