### PR TITLE
Remove sensor naming override from Inovelli VZM32-SN

### DIFF
--- a/profile_library/inovelli/VZM32-SN/model.json
+++ b/profile_library/inovelli/VZM32-SN/model.json
@@ -7,10 +7,6 @@
   "measure_method": "script",
   "name": "2-in-1 mmWave Dimmer Switch (VZM32-SN)",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 1.54,
   "standby_power_on": 1.59,
   "author_info": {


### PR DESCRIPTION
Follow-up to a review remark on #4534.

The integration appends `Device Power`/`Device Energy` internally when `only_self_usage` is true, so the override in the profile is redundant. Entity names are unchanged.