### PR TITLE
Remove redundant self-usage sensor naming overrides

### DIFF
--- a/profile_library/aeotec/ZWA023/model.json
+++ b/profile_library/aeotec/ZWA023/model.json
@@ -12,10 +12,6 @@
   "measure_method": "script",
   "name": "Smart Switch 7 B plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.7,
   "standby_power_on": 0.8,
   "author_info": {

--- a/profile_library/aqara/lumi.plug.maeu01/model.json
+++ b/profile_library/aqara/lumi.plug.maeu01/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Smart Plug EU",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.17,
   "standby_power_on": 0.46,
   "author_info": {

--- a/profile_library/arlec/PC191HA/model.json
+++ b/profile_library/arlec/PC191HA/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "White Grid Connect Smart Plug In Socket With Energy Meter",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.267,
   "standby_power_on": 1.144,
   "author_info": {

--- a/profile_library/arlec/PC192HA/model.json
+++ b/profile_library/arlec/PC192HA/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Grid Connect Smart Plug In Multi-Function Socket With USB",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.66,
   "standby_power_on": 1.596,
   "author_info": {

--- a/profile_library/arlec/PC287HA/model.json
+++ b/profile_library/arlec/PC287HA/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Grid Connect Smart Twin Socket With Energy Meter And Surge Protection PC287HA",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.29,
   "standby_power_on": 2.565,
   "author_info": {

--- a/profile_library/athom/smart-plug-au/model.json
+++ b/profile_library/athom/smart-plug-au/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Smart Plug AU",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.66,
   "standby_power_on": 1.03,
   "author_info": {

--- a/profile_library/avm/FRITZ!DECT 200/model.json
+++ b/profile_library/avm/FRITZ!DECT 200/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "FRITZ!DECT 200",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.45,
   "standby_power_on": 1.0,
   "author_info": {

--- a/profile_library/avm/FRITZ!DECT 210/model.json
+++ b/profile_library/avm/FRITZ!DECT 210/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "FRITZ!DECT 210",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.35,
   "standby_power_on": 1.1,
   "author_info": {

--- a/profile_library/blitzwolf/SHP6-15A/model.json
+++ b/profile_library/blitzwolf/SHP6-15A/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "BW-SHP6 version 15A",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.4,
   "standby_power_on": 0.8,
   "author_info": {

--- a/profile_library/blitzwolf/SHP6/model.json
+++ b/profile_library/blitzwolf/SHP6/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "BW-SHP6 version 10A",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.5,
   "standby_power_on": 0.85,
   "author_info": {

--- a/profile_library/ecodim/ECO-DIM.07 Zigbee Basic/model.json
+++ b/profile_library/ecodim/ECO-DIM.07 Zigbee Basic/model.json
@@ -11,10 +11,6 @@
   "measure_method": "manual",
   "name": "ZigBee LED Dimmer",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.3,
   "standby_power_on": 0.3,
   "author_info": {

--- a/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
+++ b/profile_library/eq-3/HM-ES-PMSw1-DR/model.json
@@ -11,10 +11,6 @@
   },
   "name": "HM-ES-PMSw1-DR",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.37,
   "standby_power_on": 0.73,
   "author_info": {

--- a/profile_library/eq-3/HmIP-BSM/model.json
+++ b/profile_library/eq-3/HmIP-BSM/model.json
@@ -11,10 +11,6 @@
   },
   "name": "HmIP-BSM",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.2,
   "standby_power_on": 0.2,
   "author_info": {

--- a/profile_library/eq-3/HmIP-FSM/model.json
+++ b/profile_library/eq-3/HmIP-FSM/model.json
@@ -11,10 +11,6 @@
   },
   "name": "HmIP-FSM",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.2,
   "standby_power_on": 0.74,
   "author_info": {

--- a/profile_library/eq-3/HmIP-FSM16/model.json
+++ b/profile_library/eq-3/HmIP-FSM16/model.json
@@ -11,10 +11,6 @@
   },
   "name": "HmIP-FSM16",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.2,
   "standby_power_on": 0.2,
   "author_info": {

--- a/profile_library/eq-3/HmIP-PSM/model.json
+++ b/profile_library/eq-3/HmIP-PSM/model.json
@@ -11,10 +11,6 @@
   },
   "name": "HmIP-PSM",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.21,
   "standby_power_on": 0.78,
   "author_info": {

--- a/profile_library/eve/20EBU4101/model.json
+++ b/profile_library/eve/20EBU4101/model.json
@@ -15,10 +15,6 @@
   "measure_method": "manual",
   "name": "Energy (Matter) Smart Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.4,
   "standby_power_on": 0.9,
   "author_info": {

--- a/profile_library/everspring/AN158/model.json
+++ b/profile_library/everspring/AN158/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Z-Wave On/Off Plug with Power Metering",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.3,
   "standby_power_on": 0.5,
   "author_info": {

--- a/profile_library/fibaro/FGWP102/model.json
+++ b/profile_library/fibaro/FGWP102/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Wall Plug (Z-Wave Plus)",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.3,
   "standby_power_on": 0.8,
   "author_info": {

--- a/profile_library/greenwave/GWPN1/model.json
+++ b/profile_library/greenwave/GWPN1/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "PowerNode Z-Wave Smart Plug (1-port)",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.3,
   "standby_power_on": 1.1,
   "author_info": {

--- a/profile_library/ikea/E2206/model.json
+++ b/profile_library/ikea/E2206/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "INSPELNING smart plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.23,
   "standby_power_on": 0.8,
   "author_info": {

--- a/profile_library/ikea/E2221/model.json
+++ b/profile_library/ikea/E2221/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "INSPELNING smart plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.2,
   "standby_power_on": 0.7,
   "author_info": {

--- a/profile_library/ikea/E2491/model.json
+++ b/profile_library/ikea/E2491/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "GRILLPLATS Smart Plug (Matter)",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.22,
   "standby_power_on": 0.47,
   "author_info": {

--- a/profile_library/innr/SP 120/model.json
+++ b/profile_library/innr/SP 120/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Zigbee Smart Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.41,
   "standby_power_on": 0.61,
   "author_info": {

--- a/profile_library/innr/SP 240/model.json
+++ b/profile_library/innr/SP 240/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Zigbee Smart Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.2,
   "standby_power_on": 0.75,
   "author_info": {

--- a/profile_library/inovelli/VZM32-SN/model.json
+++ b/profile_library/inovelli/VZM32-SN/model.json
@@ -7,10 +7,6 @@
   "measure_method": "script",
   "name": "2-in-1 mmWave Dimmer Switch (VZM32-SN)",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 1.54,
   "standby_power_on": 1.59,
   "author_info": {

--- a/profile_library/lidl/HG08673/model.json
+++ b/profile_library/lidl/HG08673/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Silvercrest Smart Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.595,
   "standby_power_on": 1.071,
   "author_info": {

--- a/profile_library/neo-coolcam/NAS-WR01Z/model.json
+++ b/profile_library/neo-coolcam/NAS-WR01Z/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Smart Power Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.31,
   "standby_power_on": 0.58,
   "author_info": {

--- a/profile_library/nodon/Micro Smart Plug/model.json
+++ b/profile_library/nodon/Micro Smart Plug/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Micro Smart Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.67,
   "standby_power_on": 0.96,
   "author_info": {

--- a/profile_library/nous/A1T/model.json
+++ b/profile_library/nous/A1T/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Smart Wi-Fi Socket with Power Meter",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.29,
   "standby_power_on": 0.54,
   "author_info": {

--- a/profile_library/nous/A1Z/model.json
+++ b/profile_library/nous/A1Z/model.json
@@ -11,10 +11,6 @@
   "measure_method": "manual",
   "name": "Smart Zigbee Power Metering Plug / Socket",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.1,
   "standby_power_on": 0.4,
   "author_info": {

--- a/profile_library/nuki/220694/model.json
+++ b/profile_library/nuki/220694/model.json
@@ -11,10 +11,6 @@
   "name": "Hardware Bridge",
   "discovery_by": "device",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.51,
   "author_info": {
     "name": "Tim",

--- a/profile_library/qubino/Smart Plug 16A/model.json
+++ b/profile_library/qubino/Smart Plug 16A/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Smart Plug 16A",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.3,
   "standby_power_on": 0.5,
   "author_info": {

--- a/profile_library/robb/ROB_200-017-0/model.json
+++ b/profile_library/robb/ROB_200-017-0/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Zigbee Smart Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.2,
   "standby_power_on": 0.65,
   "author_info": {

--- a/profile_library/shelly/Shelly 1 Mini Gen4/model.json
+++ b/profile_library/shelly/Shelly 1 Mini Gen4/model.json
@@ -15,10 +15,6 @@
   },
   "name": "1 Mini Gen4",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "Jasper",
     "email": "jaspervanvliet1996@gmail.com",

--- a/profile_library/shelly/Shelly 1L Gen3/model.json
+++ b/profile_library/shelly/Shelly 1L Gen3/model.json
@@ -16,10 +16,6 @@
   },
   "name": "1L Gen3",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "Victor Burlacu-Zane",
     "email": "vvbbzz@yahoo.com",

--- a/profile_library/shelly/Shelly 1PM Mini Gen3/model.json
+++ b/profile_library/shelly/Shelly 1PM Mini Gen3/model.json
@@ -14,10 +14,6 @@
   },
   "name": "Shelly 1PM Mini Gen3",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "CV",
     "github": "dagobert"

--- a/profile_library/shelly/Shelly 1PM Mini Gen4/model.json
+++ b/profile_library/shelly/Shelly 1PM Mini Gen4/model.json
@@ -17,10 +17,6 @@
   },
   "name": "1PM Mini Gen4",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "Michal Bartak",
     "email": "michal.bartak@betsys.com",

--- a/profile_library/shelly/Shelly 1PM/model.json
+++ b/profile_library/shelly/Shelly 1PM/model.json
@@ -16,10 +16,6 @@
   },
   "name": "1PM",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.589,
   "standby_power_on": 0.85,
   "author_info": {

--- a/profile_library/shelly/Shelly 2.5/model.json
+++ b/profile_library/shelly/Shelly 2.5/model.json
@@ -19,10 +19,6 @@
   },
   "name": "2.5",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.676,
   "author_info": {
     "name": "Michal Bartak",

--- a/profile_library/shelly/Shelly 3EM/model.json
+++ b/profile_library/shelly/Shelly 3EM/model.json
@@ -11,10 +11,6 @@
   "measure_method": "manual",
   "name": "3EM",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 1.22,
   "standby_power_on": 1.22,
   "author_info": {

--- a/profile_library/shelly/Shelly Dimmer/model.json
+++ b/profile_library/shelly/Shelly Dimmer/model.json
@@ -16,10 +16,6 @@
   },
   "name": "Dimmer",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.596,
   "author_info": {
     "name": "Michal Bartak",

--- a/profile_library/shelly/Shelly I4 Gen3/model.json
+++ b/profile_library/shelly/Shelly I4 Gen3/model.json
@@ -17,10 +17,6 @@
   },
   "name": "i4 Gen3",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "CV",
     "github": "dagobert"

--- a/profile_library/shelly/Shelly Plug S MTR Gen3/model.json
+++ b/profile_library/shelly/Shelly Plug S MTR Gen3/model.json
@@ -15,10 +15,6 @@
   },
   "name": "Plug S Gen3",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "Largelos",
     "email": "vasilenkoeyu@gmail.com",

--- a/profile_library/shelly/Shelly Plus 1PM/model.json
+++ b/profile_library/shelly/Shelly Plus 1PM/model.json
@@ -17,10 +17,6 @@
   },
   "name": "Plus 1PM",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "sub_profile_select": {
     "default": "default"
   },

--- a/profile_library/shelly/Shelly Plus 2PM/model.json
+++ b/profile_library/shelly/Shelly Plus 2PM/model.json
@@ -20,10 +20,6 @@
     "SLEEP_TIME": 0.5
   },
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.822,
   "multi_switch_config": {
     "power": 0.145

--- a/profile_library/shelly/Shelly Pro 3EM 3CT63/model.json
+++ b/profile_library/shelly/Shelly Pro 3EM 3CT63/model.json
@@ -16,10 +16,6 @@
   },
   "name": "Pro 3EM",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "Michal Bartak",
     "email": "michal.bartak@betsys.com",

--- a/profile_library/shelly/Shelly i3/model.json
+++ b/profile_library/shelly/Shelly i3/model.json
@@ -16,10 +16,6 @@
   },
   "name": "i3",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.587,
   "author_info": {
     "name": "Michal Bartak",

--- a/profile_library/shelly/shelly plug s/model.json
+++ b/profile_library/shelly/shelly plug s/model.json
@@ -12,10 +12,6 @@
   "measure_method": "manual",
   "name": "Plug S",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "sub_profile_select": {
     "default": "+wlan"
   },

--- a/profile_library/shelly/shelly plus plug s/model.json
+++ b/profile_library/shelly/shelly plus plug s/model.json
@@ -13,10 +13,6 @@
   "measure_method": "manual",
   "name": "Plus Plug S",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.74,
   "standby_power_on": 1.01,
   "author_info": {

--- a/profile_library/shelly/shelly pm mini gen3/model.json
+++ b/profile_library/shelly/shelly pm mini gen3/model.json
@@ -11,10 +11,6 @@
   "measure_method": "manual",
   "name": "PM Mini Gen3",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.642,
   "author_info": {
     "name": "RubenKelevra",

--- a/profile_library/tp-link/HS100/model.json
+++ b/profile_library/tp-link/HS100/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Kasa Wi-Fi Smart Plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.89,
   "standby_power_on": 1.461,
   "author_info": {

--- a/profile_library/tp-link/HS110/model.json
+++ b/profile_library/tp-link/HS110/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Kasa Wi-Fi Smart Plug with Energy Monitoring",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 1.54,
   "standby_power_on": 2.19,
   "author_info": {

--- a/profile_library/tp-link/HS300/model.json
+++ b/profile_library/tp-link/HS300/model.json
@@ -14,9 +14,6 @@
   },
   "name": "Kasa Smart Wi-Fi Power Strip",
   "only_self_usage": true,
-  "sensor_config": {
-    "power_sensor_naming": "{} Device Power"
-  },
   "author_info": {
     "name": "Bram Gerritsen",
     "email": "bgerritsen@gmail.com",

--- a/profile_library/tp-link/KP115/model.json
+++ b/profile_library/tp-link/KP115/model.json
@@ -11,10 +11,6 @@
   "measure_method": "manual",
   "name": "Kasa Smart WiFi Plug Slim with Energy Monitoring",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.5,
   "standby_power_on": 0.9,
   "author_info": {

--- a/profile_library/tp-link/KP125M/model.json
+++ b/profile_library/tp-link/KP125M/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Kasa Smart Wi-Fi Plug Slim with Energy Monitoring",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.475,
   "standby_power_on": 0.92,
   "author_info": {

--- a/profile_library/tp-link/P110/model.json
+++ b/profile_library/tp-link/P110/model.json
@@ -10,10 +10,6 @@
   "measure_method": "manual",
   "name": "Tapo Mini Smart Wi-Fi Socket with Energy Monitoring",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.6,
   "standby_power_on": 1.0,
   "author_info": {

--- a/profile_library/tp-link/P110M/model.json
+++ b/profile_library/tp-link/P110M/model.json
@@ -11,10 +11,6 @@
   "measure_method": "manual",
   "name": "Tapo Mini Smart Wi-Fi Plug with Energy Monitoring, Matter Certified",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.3,
   "standby_power_on": 1.2,
   "author_info": {

--- a/profile_library/tp-link/P115/model.json
+++ b/profile_library/tp-link/P115/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "Tapo Mini Smart Wi-Fi Socket with Energy Monitoring",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.6,
   "standby_power_on": 1.0,
   "author_info": {

--- a/profile_library/tuya/TS011F/model.json
+++ b/profile_library/tuya/TS011F/model.json
@@ -12,10 +12,6 @@
   "measure_method": "manual",
   "name": "Smart plug (with power monitoring)",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.13,
   "standby_power_on": 0.39,
   "author_info": {

--- a/profile_library/tuya/TS0121_plug/model.json
+++ b/profile_library/tuya/TS0121_plug/model.json
@@ -7,10 +7,6 @@
   "measure_method": "manual",
   "name": "TS0121_plug",
   "only_self_usage": true,
-  "sensor_config": {
-    "energy_sensor_naming": "{} Device Energy",
-    "power_sensor_naming": "{} Device Power"
-  },
   "standby_power": 0.404,
   "standby_power_on": 0.866,
   "author_info": {

--- a/profile_library/xiaomi/lumi.gateway.mgl03/model.json
+++ b/profile_library/xiaomi/lumi.gateway.mgl03/model.json
@@ -16,10 +16,6 @@
   "only_self_usage": true,
   "calculation_strategy": "fixed",
   "standby_power": 1.51,
-  "sensor_config": {
-    "power_sensor_naming": "{} Device Power",
-    "energy_sensor_naming": "{} Device Energy"
-  },
   "author_info": {
     "name": "Largelos",
     "github": "Largelos"


### PR DESCRIPTION
Noticed while doing this in #4535 that the sweep to drop these overrides missed a batch, so here is the rest of them.

The integration applies `Device Power`/`Device Energy` internally when `only_self_usage` is true, so repeating it in the profile has no effect. This removes the override from the 62 profiles where it is byte-identical to the default. Deletions only, no entity names change.

The 18 profiles which set the same naming *without* `only_self_usage` are left alone, since there the override is what produces the name. Might be worth a look separately — several of them (the FRITZ! repeaters, the Bosch controller) look like they were meant to be self-usage profiles.