### PR TITLE
Add Dreame X50 Ultra profile

### DIFF
--- a/profile_library/dreame/x50-ultra/model.json
+++ b/profile_library/dreame/x50-ultra/model.json
@@ -1,0 +1,195 @@
+{
+  "aliases": [
+    "dreame.vacuum.r2538z"
+  ],
+  "author_info": {
+    "name": "philscottydev",
+    "github": "philscottydev"
+  },
+  "calculation_strategy": "composite",
+  "compatible_integrations": [
+    "dreame_vacuum"
+  ],
+  "composite_config": [
+    {
+      "condition": {
+        "condition": "state",
+        "entity_id": "[[entity_by_translation_key:task_status]]",
+        "state": "station_cleaning"
+      },
+      "fixed": {
+        "power": 559.1
+      }
+    },
+    {
+      "condition": {
+        "condition": "state",
+        "entity_id": "[[entity_by_translation_key:auto_empty_status]]",
+        "state": "active"
+      },
+      "fixed": {
+        "power": 225.0
+      }
+    },
+    {
+      "condition": {
+        "condition": "state",
+        "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
+        "state": "washing"
+      },
+      "fixed": {
+        "power": 107.8
+      }
+    },
+    {
+      "condition": {
+        "condition": "state",
+        "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
+        "state": "drying"
+      },
+      "fixed": {
+        "power": 54.9
+      }
+    },
+    {
+      "condition": {
+        "condition": "and",
+        "conditions": [
+          {
+            "condition": "state",
+            "entity_id": "[[entity]]",
+            "state": "docked"
+          },
+          {
+            "condition": "state",
+            "entity_id": "[[entity_by_translation_key:charging_state]]",
+            "state": "on"
+          }
+        ]
+      },
+      "linear": {
+        "calibrate": [
+          "3 -> 33.18",
+          "4 -> 33.2",
+          "5 -> 33.48",
+          "6 -> 33.37",
+          "7 -> 33.64",
+          "8 -> 33.74",
+          "9 -> 33.82",
+          "10 -> 33.82",
+          "11 -> 34.1",
+          "12 -> 34.02",
+          "13 -> 34.29",
+          "14 -> 34.24",
+          "15 -> 34.37",
+          "16 -> 34.34",
+          "17 -> 34.34",
+          "18 -> 34.39",
+          "19 -> 34.34",
+          "20 -> 34.4",
+          "21 -> 34.51",
+          "22 -> 34.56",
+          "23 -> 34.63",
+          "24 -> 34.74",
+          "25 -> 34.84",
+          "26 -> 34.9",
+          "27 -> 35.02",
+          "28 -> 35.04",
+          "29 -> 35.14",
+          "30 -> 35.18",
+          "31 -> 35.28",
+          "32 -> 35.3",
+          "33 -> 35.4",
+          "34 -> 35.45",
+          "35 -> 36.44",
+          "36 -> 36.98",
+          "37 -> 35.64",
+          "38 -> 35.71",
+          "39 -> 35.79",
+          "40 -> 35.86",
+          "41 -> 35.92",
+          "42 -> 35.96",
+          "43 -> 36.07",
+          "44 -> 36.11",
+          "45 -> 36.2",
+          "46 -> 36.23",
+          "47 -> 36.35",
+          "48 -> 36.35",
+          "49 -> 36.41",
+          "50 -> 34.76",
+          "51 -> 36.57",
+          "52 -> 36.58",
+          "53 -> 36.69",
+          "54 -> 36.76",
+          "55 -> 36.81",
+          "56 -> 36.89",
+          "57 -> 36.95",
+          "58 -> 37.01",
+          "59 -> 37.1",
+          "60 -> 37.13",
+          "61 -> 37.16",
+          "62 -> 37.28",
+          "63 -> 37.26",
+          "64 -> 37.38",
+          "65 -> 37.44",
+          "66 -> 37.51",
+          "67 -> 37.53",
+          "68 -> 37.6",
+          "69 -> 37.66",
+          "70 -> 37.75",
+          "71 -> 37.79",
+          "72 -> 37.81",
+          "73 -> 37.92",
+          "74 -> 37.98",
+          "75 -> 38.04",
+          "76 -> 38.09",
+          "77 -> 38.15",
+          "78 -> 38.17",
+          "79 -> 38.27",
+          "80 -> 38.27",
+          "81 -> 38.26",
+          "82 -> 38.23",
+          "83 -> 38.22",
+          "84 -> 38.02",
+          "85 -> 37.68",
+          "86 -> 37.32",
+          "87 -> 36.53",
+          "88 -> 35.61",
+          "89 -> 34.27",
+          "90 -> 32.78",
+          "91 -> 31.38",
+          "92 -> 30.02",
+          "93 -> 28.45",
+          "94 -> 26.87",
+          "95 -> 25.22",
+          "96 -> 23.64",
+          "97 -> 22.08",
+          "98 -> 20.44",
+          "99 -> 18.44",
+          "100 -> 11.32"
+        ]
+      }
+    },
+    {
+      "fixed": {
+        "power": 5.55
+      }
+    }
+  ],
+  "created_at": "2026-08-18T05:24:41Z",
+  "device_type": "vacuum_robot",
+  "measure_description": "Measured with a Shelly Plus 1PM in the socket that feeds the base station, so the numbers cover the whole station rather than battery charging alone. While the robot is away cleaning it runs on its own battery, so vacuum power levels are not visible on this meter at all and the consumption shows up later as charging.\n\nCharging: measured with the utils/measure charging type, discharged to 3 percent first, then one measurement per battery percent up to 100 followed by the 30 minute trickle phase. Auto drying, self clean and smart mop washing were switched off for that run and the pads were dry, so no station activity contaminates the curve.\n\nThe other branches were recorded separately at 5 to 6 samples per second while triggering each process from its button, with the state sensors logged alongside so power and state line up. Each fixed value is the mean over the whole window in which its condition holds, not the peak, so the energy comes out right even though the real traces are spiky. Measured windows and energies:\n  station cleaning  1.0 min at 559 W mean, 1171 W peak, 9.8 Wh\n  auto empty       26.2 s   at 225 W mean, 623 W peak, 1.6 Wh (two bursts of about 5 s)\n  mop washing       2.7 min at 108 W mean, 1152 W peak, 4.9 Wh (hot water heater fires for ~10 s)\n  hot air drying  180.3 min at  55 W mean, 156.5 Wh, no cycling, drifts 81 W down to 51 W\nIdle was measured three times independently and agreed within 0.07 W: 5.55, 5.62 and 5.5 W.\n\nNote on station cleaning: it does NOT set self_wash_base_status, that stays idle. It shows up in task_status instead, which is why it needs its own branch. UV sterilization was enabled during all of these, which is the default.\n\nKnown gaps. Drainage is not covered because my station has no plumbing kit, so station_drainage_status never leaves idle here. And because the branches are evaluated stop at first, charging while the station dries reports the drying value alone rather than the sum, which understates that combination by roughly the charging power.",
+  "measure_device": "Shelly Plus 1PM",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 3,
+    "SLEEP_TIME": 3.0,
+    "VERSION": "v0.3.0:cli"
+  },
+  "name": "X50 Ultra",
+  "standby_power": 5.55,
+  "voltage_range": {
+    "min": 225.9,
+    "max": 230.9
+  }
+}

--- a/profile_library/dreame/x50-ultra/model.json
+++ b/profile_library/dreame/x50-ultra/model.json
@@ -10,175 +10,240 @@
   "compatible_integrations": [
     "dreame_vacuum"
   ],
-  "composite_config": [
-    {
-      "condition": {
-        "condition": "state",
-        "entity_id": "[[entity_by_translation_key:task_status]]",
-        "state": "station_cleaning"
+  "composite_config": {
+    "mode": "sum_all",
+    "strategies": [
+      {
+        "condition": {
+          "condition": "and",
+          "conditions": [
+            {
+              "condition": "state",
+              "entity_id": "[[entity_by_translation_key:charging_state]]",
+              "state": "off"
+            },
+            {
+              "condition": "or",
+              "conditions": [
+                {
+                  "condition": "state",
+                  "entity_id": "[[entity_by_translation_key:status]]",
+                  "state": "sleeping"
+                },
+                {
+                  "condition": "state",
+                  "entity_id": "[[entity_by_translation_key:status]]",
+                  "state": "idle"
+                }
+              ]
+            }
+          ]
+        },
+        "fixed": {
+          "power": 5.55
+        }
       },
-      "fixed": {
-        "power": 559.1
-      }
-    },
-    {
-      "condition": {
-        "condition": "state",
-        "entity_id": "[[entity_by_translation_key:auto_empty_status]]",
-        "state": "active"
+      {
+        "condition": {
+          "condition": "and",
+          "conditions": [
+            {
+              "condition": "state",
+              "entity_id": "[[entity_by_translation_key:charging_state]]",
+              "state": "on"
+            },
+            {
+              "condition": "template",
+              "value_template": "{{ states('[[entity_by_translation_key:self_wash_base_status]]') not in ['washing', 'clean_add_water'] and states('[[entity_by_translation_key:auto_empty_status]]') != 'active' and states('[[entity_by_translation_key:task_status]]') != 'station_cleaning' }}"
+            }
+          ]
+        },
+        "linear": {
+          "calibrate": [
+            "3 -> 27.63",
+            "4 -> 27.65",
+            "5 -> 27.93",
+            "6 -> 27.82",
+            "7 -> 28.09",
+            "8 -> 28.19",
+            "9 -> 28.27",
+            "10 -> 28.27",
+            "11 -> 28.55",
+            "12 -> 28.47",
+            "13 -> 28.74",
+            "14 -> 28.69",
+            "15 -> 28.82",
+            "16 -> 28.79",
+            "17 -> 28.79",
+            "18 -> 28.84",
+            "19 -> 28.79",
+            "20 -> 28.85",
+            "21 -> 28.96",
+            "22 -> 29.01",
+            "23 -> 29.08",
+            "24 -> 29.19",
+            "25 -> 29.29",
+            "26 -> 29.35",
+            "27 -> 29.47",
+            "28 -> 29.49",
+            "29 -> 29.59",
+            "30 -> 29.63",
+            "31 -> 29.73",
+            "32 -> 29.75",
+            "33 -> 29.85",
+            "34 -> 29.9",
+            "35 -> 30.89",
+            "36 -> 31.43",
+            "37 -> 30.09",
+            "38 -> 30.16",
+            "39 -> 30.24",
+            "40 -> 30.31",
+            "41 -> 30.37",
+            "42 -> 30.41",
+            "43 -> 30.52",
+            "44 -> 30.56",
+            "45 -> 30.65",
+            "46 -> 30.68",
+            "47 -> 30.8",
+            "48 -> 30.8",
+            "49 -> 30.86",
+            "50 -> 29.21",
+            "51 -> 31.02",
+            "52 -> 31.03",
+            "53 -> 31.14",
+            "54 -> 31.21",
+            "55 -> 31.26",
+            "56 -> 31.34",
+            "57 -> 31.4",
+            "58 -> 31.46",
+            "59 -> 31.55",
+            "60 -> 31.58",
+            "61 -> 31.61",
+            "62 -> 31.73",
+            "63 -> 31.71",
+            "64 -> 31.83",
+            "65 -> 31.89",
+            "66 -> 31.96",
+            "67 -> 31.98",
+            "68 -> 32.05",
+            "69 -> 32.11",
+            "70 -> 32.2",
+            "71 -> 32.24",
+            "72 -> 32.26",
+            "73 -> 32.37",
+            "74 -> 32.43",
+            "75 -> 32.49",
+            "76 -> 32.54",
+            "77 -> 32.6",
+            "78 -> 32.62",
+            "79 -> 32.72",
+            "80 -> 32.72",
+            "81 -> 32.71",
+            "82 -> 32.68",
+            "83 -> 32.67",
+            "84 -> 32.47",
+            "85 -> 32.13",
+            "86 -> 31.77",
+            "87 -> 30.98",
+            "88 -> 30.06",
+            "89 -> 28.72",
+            "90 -> 27.23",
+            "91 -> 25.83",
+            "92 -> 24.47",
+            "93 -> 22.9",
+            "94 -> 21.32",
+            "95 -> 19.67",
+            "96 -> 18.09",
+            "97 -> 16.53",
+            "98 -> 14.89",
+            "99 -> 12.89",
+            "100 -> 5.77"
+          ]
+        }
       },
-      "fixed": {
-        "power": 225.0
-      }
-    },
-    {
-      "condition": {
-        "condition": "state",
-        "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
-        "state": "washing"
+      {
+        "condition": {
+          "condition": "and",
+          "conditions": [
+            {
+              "condition": "state",
+              "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
+              "state": "washing"
+            },
+            {
+              "condition": "state",
+              "entity_id": "[[entity_by_translation_key:status]]",
+              "state": "cleaning"
+            }
+          ]
+        },
+        "fixed": {
+          "power": 29.5
+        }
       },
-      "fixed": {
-        "power": 107.8
-      }
-    },
-    {
-      "condition": {
-        "condition": "state",
-        "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
-        "state": "drying"
+      {
+        "condition": {
+          "condition": "and",
+          "conditions": [
+            {
+              "condition": "state",
+              "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
+              "state": "washing"
+            },
+            {
+              "condition": "template",
+              "value_template": "{{ states('[[entity_by_translation_key:status]]') != 'cleaning' }}"
+            }
+          ]
+        },
+        "fixed": {
+          "power": 107.1
+        }
       },
-      "fixed": {
-        "power": 54.9
-      }
-    },
-    {
-      "condition": {
-        "condition": "and",
-        "conditions": [
-          {
-            "condition": "state",
-            "entity_id": "[[entity]]",
-            "state": "docked"
-          },
-          {
-            "condition": "state",
-            "entity_id": "[[entity_by_translation_key:charging_state]]",
-            "state": "on"
-          }
-        ]
+      {
+        "condition": {
+          "condition": "state",
+          "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
+          "state": "clean_add_water"
+        },
+        "fixed": {
+          "power": 18.5
+        }
       },
-      "linear": {
-        "calibrate": [
-          "3 -> 33.18",
-          "4 -> 33.2",
-          "5 -> 33.48",
-          "6 -> 33.37",
-          "7 -> 33.64",
-          "8 -> 33.74",
-          "9 -> 33.82",
-          "10 -> 33.82",
-          "11 -> 34.1",
-          "12 -> 34.02",
-          "13 -> 34.29",
-          "14 -> 34.24",
-          "15 -> 34.37",
-          "16 -> 34.34",
-          "17 -> 34.34",
-          "18 -> 34.39",
-          "19 -> 34.34",
-          "20 -> 34.4",
-          "21 -> 34.51",
-          "22 -> 34.56",
-          "23 -> 34.63",
-          "24 -> 34.74",
-          "25 -> 34.84",
-          "26 -> 34.9",
-          "27 -> 35.02",
-          "28 -> 35.04",
-          "29 -> 35.14",
-          "30 -> 35.18",
-          "31 -> 35.28",
-          "32 -> 35.3",
-          "33 -> 35.4",
-          "34 -> 35.45",
-          "35 -> 36.44",
-          "36 -> 36.98",
-          "37 -> 35.64",
-          "38 -> 35.71",
-          "39 -> 35.79",
-          "40 -> 35.86",
-          "41 -> 35.92",
-          "42 -> 35.96",
-          "43 -> 36.07",
-          "44 -> 36.11",
-          "45 -> 36.2",
-          "46 -> 36.23",
-          "47 -> 36.35",
-          "48 -> 36.35",
-          "49 -> 36.41",
-          "50 -> 34.76",
-          "51 -> 36.57",
-          "52 -> 36.58",
-          "53 -> 36.69",
-          "54 -> 36.76",
-          "55 -> 36.81",
-          "56 -> 36.89",
-          "57 -> 36.95",
-          "58 -> 37.01",
-          "59 -> 37.1",
-          "60 -> 37.13",
-          "61 -> 37.16",
-          "62 -> 37.28",
-          "63 -> 37.26",
-          "64 -> 37.38",
-          "65 -> 37.44",
-          "66 -> 37.51",
-          "67 -> 37.53",
-          "68 -> 37.6",
-          "69 -> 37.66",
-          "70 -> 37.75",
-          "71 -> 37.79",
-          "72 -> 37.81",
-          "73 -> 37.92",
-          "74 -> 37.98",
-          "75 -> 38.04",
-          "76 -> 38.09",
-          "77 -> 38.15",
-          "78 -> 38.17",
-          "79 -> 38.27",
-          "80 -> 38.27",
-          "81 -> 38.26",
-          "82 -> 38.23",
-          "83 -> 38.22",
-          "84 -> 38.02",
-          "85 -> 37.68",
-          "86 -> 37.32",
-          "87 -> 36.53",
-          "88 -> 35.61",
-          "89 -> 34.27",
-          "90 -> 32.78",
-          "91 -> 31.38",
-          "92 -> 30.02",
-          "93 -> 28.45",
-          "94 -> 26.87",
-          "95 -> 25.22",
-          "96 -> 23.64",
-          "97 -> 22.08",
-          "98 -> 20.44",
-          "99 -> 18.44",
-          "100 -> 11.32"
-        ]
+      {
+        "condition": {
+          "condition": "state",
+          "entity_id": "[[entity_by_translation_key:auto_empty_status]]",
+          "state": "active"
+        },
+        "fixed": {
+          "power": 214.3
+        }
+      },
+      {
+        "condition": {
+          "condition": "state",
+          "entity_id": "[[entity_by_translation_key:task_status]]",
+          "state": "station_cleaning"
+        },
+        "fixed": {
+          "power": 540.0
+        }
+      },
+      {
+        "condition": {
+          "condition": "state",
+          "entity_id": "[[entity_by_translation_key:self_wash_base_status]]",
+          "state": "drying"
+        },
+        "fixed": {
+          "power": 47.5
+        }
       }
-    },
-    {
-      "fixed": {
-        "power": 5.55
-      }
-    }
-  ],
-  "created_at": "2026-08-18T05:24:41Z",
+    ]
+  },
+  "created_at": "2026-08-21T13:51:11Z",
   "device_type": "vacuum_robot",
-  "measure_description": "Measured with a Shelly Plus 1PM in the socket that feeds the base station, so the numbers cover the whole station rather than battery charging alone. While the robot is away cleaning it runs on its own battery, so vacuum power levels are not visible on this meter at all and the consumption shows up later as charging.\n\nCharging: measured with the utils/measure charging type, discharged to 3 percent first, then one measurement per battery percent up to 100 followed by the 30 minute trickle phase. Auto drying, self clean and smart mop washing were switched off for that run and the pads were dry, so no station activity contaminates the curve.\n\nThe other branches were recorded separately at 5 to 6 samples per second while triggering each process from its button, with the state sensors logged alongside so power and state line up. Each fixed value is the mean over the whole window in which its condition holds, not the peak, so the energy comes out right even though the real traces are spiky. Measured windows and energies:\n  station cleaning  1.0 min at 559 W mean, 1171 W peak, 9.8 Wh\n  auto empty       26.2 s   at 225 W mean, 623 W peak, 1.6 Wh (two bursts of about 5 s)\n  mop washing       2.7 min at 108 W mean, 1152 W peak, 4.9 Wh (hot water heater fires for ~10 s)\n  hot air drying  180.3 min at  55 W mean, 156.5 Wh, no cycling, drifts 81 W down to 51 W\nIdle was measured three times independently and agreed within 0.07 W: 5.55, 5.62 and 5.5 W.\n\nNote on station cleaning: it does NOT set self_wash_base_status, that stays idle. It shows up in task_status instead, which is why it needs its own branch. UV sterilization was enabled during all of these, which is the default.\n\nKnown gaps. Drainage is not covered because my station has no plumbing kit, so station_drainage_status never leaves idle here. And because the branches are evaluated stop at first, charging while the station dries reports the drying value alone rather than the sum, which understates that combination by roughly the charging power.",
   "measure_device": "Shelly Plus 1PM",
   "measure_method": "script",
   "measure_settings": {
@@ -191,5 +256,6 @@
   "voltage_range": {
     "min": 225.9,
     "max": 230.9
-  }
+  },
+  "measure_description": "Measured with a Shelly Plus 1PM in the socket feeding the base station, so every number covers the whole station rather than battery charging alone. Station settings during the runs: smart mop washing on, self clean on, mop washing with detergent on, UV sterilization on, auto drying on, silent drying off, drying time 3h. With smart mop washing on the machine selects water temperature and washing program itself and both selects read unavailable; the stored manual values are hot and standard. The heater does run under this configuration, 937 W for about 14 s during the end of job wash. Measuring the four manual settings separately gives 27.7 W on normal, where the heater never fires, 92.9 W on mild, 106.6 W on warm and 110.3 W on hot; smart washing sits between warm and hot. The washing branch carries the smart washing figure since that is the default. Fixed values are time averages over the window in which each condition holds, not peaks."
 }

--- a/profile_library/dreame/x50-ultra/model.json
+++ b/profile_library/dreame/x50-ultra/model.json
@@ -2,10 +2,10 @@
   "aliases": [
     "dreame.vacuum.r2538z"
   ],
-  "author_info": {
+  "authors": [{
     "name": "philscottydev",
     "github": "philscottydev"
-  },
+  }],
   "calculation_strategy": "composite",
   "compatible_integrations": [
     "dreame_vacuum"


### PR DESCRIPTION
Adds a profile for the Dreame X50 Ultra. The library has one Dreame vacuum so far (d10-plus) and five charging profiles in total, so I went further than just the charge curve and measured what the base station does the rest of the time.

I followed the structure of the d10-plus profile since that one already works out the conditions, but this one ended up with six branches instead of three.

## What is in it

| condition | power | measured window |
|---|---|---|
| `task_status` = `station_cleaning` | 559 W | 1.0 min, 1171 W peak, 9.8 Wh |
| `auto_empty_status` = `active` | 225 W | 26.2 s, 623 W peak, 1.6 Wh |
| `self_wash_base_status` = `washing` | 108 W | 2.7 min, 1152 W peak, 4.9 Wh |
| `self_wash_base_status` = `drying` | 55 W | 180.3 min, 156.5 Wh |
| docked and `charging_state` = `on` | linear, 98 points | 3 to 100 percent, about 119 Wh |
| everything else | 5.55 W | idle station, robot asleep |

## How it was measured

Shelly Plus 1PM in the socket that feeds the base station, so the numbers cover the whole station rather than battery charging alone. Worth saying explicitly: while the robot is out cleaning it runs on its own battery, so fan speeds are not visible on this meter at all, that consumption turns up later as charging.

The charge curve used the `charging` measure type, discharged to 3 percent first. For that run I switched off auto drying, self clean and smart mop washing and kept the pads dry, so no station activity leaked into the curve.

The other branches were recorded separately at 5 to 6 samples per second while triggering each process from its button, with the state sensors logged next to the power so the two line up. Each fixed value is the **mean over the whole window** in which its condition holds, not the peak. Both washing and station cleaning fire the hot water heater for about ten seconds at over 1100 W, so using the peak would have overstated those by a factor of ten.

Idle came out at 5.55, 5.62 and 5.5 W in three independent measurements on different days.

## Two things worth knowing

**Station cleaning does not set `self_wash_base_status`.** That stays `idle` for the whole minute. It shows up in `task_status` instead, which is why it needs its own branch. I only noticed because I was logging every status sensor at once, otherwise a 559 W process would have been reported as 5.55 W standby.

**Drying is the largest single item on the machine.** 180 minutes at 55 W is 156.5 Wh, more than a full charge from empty. It runs without cycling, drifting gently from 81 W down to 51 W. Since it starts automatically after every mop wash, leaving it out means missing the biggest part of a mopping run.

## Integration gate

`compatible_integrations` is set to `dreame_vacuum`, the HACS integration by Tasshack. All the conditions here depend on entities only that integration provides (`task_status`, `auto_empty_status`, `self_wash_base_status`, `charging_state`), so without the gate the profile would also be offered to someone running their Dreame through Xiaomi Miio, where every placeholder would fail to resolve. Thanks for pointing this field out on my Philips purifier PR, I would not have known otherwise.

## Known gaps

- **Drainage is not covered.** My station has no plumbing kit, so `station_drainage_status` never leaves `idle` here and there is nothing to measure. Anyone with the kit could add that branch.
- **Overlapping states report only the first match.** Since the branches are evaluated stop at first, a robot that docks with a low battery and wet pads is both charging and drying, and the profile reports the drying value alone. That understates the combination by roughly the charging power, and it is exactly the situation after a mopping run. A combined branch would need a measurement with an empty battery and wet pads at the same time, which I have not done. Happy to add it if you would rather have it.
- UV sterilization was enabled throughout, which is the default, so its draw is included in the washing and drying numbers rather than broken out.
