### PR TITLE
Fix MODE from .env being split into characters when a dummy load is configured

### DIFF
--- a/utils/measure/measure/cli/main.py
+++ b/utils/measure/measure/cli/main.py
@@ -259,6 +259,10 @@ class Measure:
                 answer_value: Any = conf_value
                 if isinstance(question, inquirer.Confirm):
                     answer_value = str_to_bool(conf_value)
+                elif question_name == QUESTION_MODE:
+                    # Normalize before prompting: question callbacks may build a request from the
+                    # answers collected so far, and set() on a plain string splits it into letters.
+                    answer_value = {LutMode(conf_value)}
                 predefined_answers[question_name] = answer_value
                 questions_to_ask.remove(question)
 

--- a/utils/measure/measure/cli/main.py
+++ b/utils/measure/measure/cli/main.py
@@ -259,7 +259,7 @@ class Measure:
                 answer_value: Any = conf_value
                 if isinstance(question, inquirer.Confirm):
                     answer_value = str_to_bool(conf_value)
-                elif question_name == QUESTION_MODE:
+                elif question_name == QUESTION_MODE and not isinstance(conf_value, set):
                     # Normalize before prompting: question callbacks may build a request from the
                     # answers collected so far, and set() on a plain string splits it into letters.
                     answer_value = {LutMode(conf_value)}

--- a/utils/measure/measure/cli/main.py
+++ b/utils/measure/measure/cli/main.py
@@ -259,10 +259,10 @@ class Measure:
                 answer_value: Any = conf_value
                 if isinstance(question, inquirer.Confirm):
                     answer_value = str_to_bool(conf_value)
-                elif question_name == QUESTION_MODE and not isinstance(conf_value, set):
+                elif question_name == QUESTION_MODE and not isinstance(answer_value, set):
                     # Normalize before prompting: question callbacks may build a request from the
                     # answers collected so far, and set() on a plain string splits it into letters.
-                    answer_value = {LutMode(conf_value)}
+                    answer_value = {LutMode(answer_value)}
                 predefined_answers[question_name] = answer_value
                 questions_to_ask.remove(question)
 


### PR DESCRIPTION
Fixes a crash in the measure CLI when `MODE` is set in `.env` **and** a resistive dummy load is used.

## What happens

```
measure.request.MeasurementRequest
modes.0
  Input should be 'hs', 'color_temp', 'brightness', 'effect' or 'white'
  [type=enum, input_value='b', input_type=str]
modes.1
  Input should be 'hs', 'color_temp', 'brightness', 'effect' or 'white'
  [type=enum, input_value='r', input_type=str]
...
```

Nine validation errors, one per distinct letter of `brightness`.

## Why

`ask_questions` stores the value from `.env` as a plain string and only converts it to `{LutMode(...)}` after `inquirer.prompt` returns:

```python
predefined_answers[question_name] = answer_value      # still "brightness"
answers = inquirer.prompt(questions_to_ask, answers=predefined_answers, ...)
answers.update(predefined_answers)

if QUESTION_MODE in answers and not isinstance(answers[QUESTION_MODE], set):
    answers[QUESTION_MODE] = {LutMode(answers[QUESTION_MODE])}   # too late
```

The dummy load question runs callbacks *during* the prompt to decide whether a saved calibration can be offered:

```python
def mode_choices(answers: dict[str, Any]) -> list[tuple[str, str]]:
    calibration = matching_calibration(answers)     # -> request_from_answers(...)
```

and `request_adapter.py` does `modes=set(answers[QUESTION_MODE])`. A string is iterable, so `set("brightness")` silently becomes `{'b','r','i','g','h','t','n','e','s'}` instead of raising.

That is why it only shows up with `DUMMY_LOAD=true`: without a dummy load nothing reads the answers before the prompt finishes, so the late conversion is soon enough.

## The change

Convert the mode when the predefined answer is stored, so anything reading the answers during the prompt sees the right type. The existing conversion after the prompt is left in place for the interactive path.

## Reproducing

No hardware needed, dummy controllers are enough:

```
POWER_METER=dummy
LIGHT_CONTROLLER=dummy
SELECTED_MEASURE_TYPE=light
MODE=brightness
DUMMY_LOAD=true
ENTITY_ID=light.does_not_exist
```

Run it on a TTY so the dummy load question is actually rendered. Before the change it aborts with the letter errors above. After it, the question appears normally:

```
[?] How do you want to prepare the dummy load?:
 > Calibrate the connected dummy load
```

Note that predefining `DUMMY_LOAD_MODE` in `.env` hides the bug, since the question is then removed from the list and its callbacks never run.

## Test matrix

Ran every combination with dummy controllers, before and after. `mode in answers` is the value that reaches the request:

| case | before | after | mode in answers |
|---|---|---|---|
| `MODE=brightness` + dummy load | crash | ok | |
| `MODE=color_temp` + dummy load | crash | ok | |
| `MODE=hs` + dummy load | crash | ok | |
| `MODE=effect` + dummy load | crash | ok | |
| `MODE` unset + dummy load | ok | ok | |
| `MODE=brightness`, no dummy load | ok | ok | `{LutMode.BRIGHTNESS}` both |
| `MODE=hs`, no dummy load | ok | ok | `{LutMode.HS}` both |
| `MODE=brightness` + dummy load + `DUMMY_LOAD_MODE` | ok | ok | `{LutMode.BRIGHTNESS}` both |
| `MODE=BOGUS` + dummy load | crash, letters | clear enum error | |
| `MODE=BOGUS`, no dummy load | clear enum error | clear enum error | |

Two things worth pointing out. The value reaching the request is byte for byte the same on every path that already worked, so this only changes when the conversion happens, not what comes out of it. And an invalid `MODE` now fails the same way with and without a dummy load, instead of turning into nine confusing enum errors about single letters.

I also verified it against real hardware, a Shelly Plus 1PM with a hot glue gun as the dummy load and a stored calibration for that meter, since that is the path where `matching_calibration` actually returns something. Before the change it aborts, after it the question renders with the saved calibration offered:

```
[?] How do you want to prepare the dummy load?:
 > Use saved calibration: ... (6435.56 Ω)
   Calibrate the connected dummy load
```

Following that through with a real lamp attached, the whole path runs: both confirmations, then the measurement starts and produces points, with the dummy load subtraction active and `MODE` still coming from `.env`.

```
Measured power: 0.45 W
Progress: 3%, Estimated time left: 4.7m
Changing light to: Variation(bri=11)
```

I hit this while measuring a lamp with a hot glue gun as dummy load and assumed for a while it was not reproducible, because my first attempt to reproduce had `DUMMY_LOAD=false`.

For the automated test matrix I used a bash script written with Claude.
