### PR TITLE
Add support for the OWON OWH98xx series power meters

### DIFF
--- a/utils/measure/.env.dist
+++ b/utils/measure/.env.dist
@@ -101,6 +101,13 @@ KASA_DEVICE_IP=x.x.x.x
 # myStrom
 MYSTROM_DEVICE_IP=x.x.x.x
 
+# Serial devices
+SERIAL_PORT=/dev/ttyUSB0
+SERIAL_BAUDRATE=115200
+
+# Owon OWH98xx
+OWON_OWH98XX_CHANNEL=1
+
 # Predefine answers to questions
 # SELECTED_MEASURE_TYPE=light
 # MODE=color_temp

--- a/utils/measure/.env.dist
+++ b/utils/measure/.env.dist
@@ -1,4 +1,4 @@
-# Set the power meter to use (hass, shelly, tuya, kasa, manual, tasmota, mystrom)
+# Set the power meter to use (hass, shelly, tuya, kasa, manual, tasmota, mystrom, owh98xx)
 POWER_METER=shelly
 
 # Set the light controller to use (hass, hue)

--- a/utils/measure/measure/assembler.py
+++ b/utils/measure/measure/assembler.py
@@ -50,6 +50,7 @@ from measure.powermeter.spec import (
     ManualPowerMeterSpec,
     MyStromPowerMeterSpec,
     OcrPowerMeterSpec,
+    OwonOwh98xxPowerMeterSpec,
     PowerMeterSpec,
     ShellyPowerMeterSpec,
     TasmotaPowerMeterSpec,
@@ -172,6 +173,9 @@ class MeasurementAssembler:
             from measure.powermeter.tuya import TuyaPowerMeter
 
             return TuyaPowerMeter(spec.device_id, spec.device_ip, self._tuya_device_key, spec.version)
+        if isinstance(spec, OwonOwh98xxPowerMeterSpec):
+            from measure.powermeter.serial_scpi import OwonOwh98xxPowerMeter
+            return OwonOwh98xxPowerMeter(spec.port, spec.baudrate, spec.timeout, spec.channel)
         raise PowerMeterError(f"Unsupported power meter specification: {type(spec).__name__}")
 
     def _runner(

--- a/utils/measure/measure/assembler.py
+++ b/utils/measure/measure/assembler.py
@@ -175,6 +175,7 @@ class MeasurementAssembler:
             return TuyaPowerMeter(spec.device_id, spec.device_ip, self._tuya_device_key, spec.version)
         if isinstance(spec, OwonOwh98xxPowerMeterSpec):
             from measure.powermeter.serial_scpi import OwonOwh98xxPowerMeter
+
             return OwonOwh98xxPowerMeter(spec.port, spec.baudrate, spec.timeout, spec.channel)
         raise PowerMeterError(f"Unsupported power meter specification: {type(spec).__name__}")
 

--- a/utils/measure/measure/cli/environment.py
+++ b/utils/measure/measure/cli/environment.py
@@ -10,7 +10,7 @@ from measure.controller.charging.const import ChargingControllerType
 from measure.controller.fan.const import FanControllerType
 from measure.controller.light.const import DEFAULT_LIGHT_TRANSITION_TIME, LightControllerType
 from measure.controller.media.const import MediaControllerType
-from measure.powermeter.const import PowerMeterType
+from measure.powermeter.const import OwonOwh98xxChannelType, PowerMeterType
 from measure.tuning import MeasurementParameters
 
 _LOGGER = logging.getLogger("measure")
@@ -382,6 +382,18 @@ class CliEnvironment:
             default=_DEFAULTS.csv_add_datetime_column,
             converter=bool,
         )
+
+    @property
+    def serial_port(self) -> str:
+        return _config_value("SERIAL_PORT", converter=str)
+
+    @property
+    def serial_baudrate(self) -> int:
+        return _config_value("SERIAL_BAUDRATE", converter=int)
+
+    @property
+    def owon_owh98xx_channel(self) -> OwonOwh98xxChannelType:
+        return _enum_value("OWON_OWH98XX_CHANNEL", OwonOwh98xxChannelType, OwonOwh98xxChannelType.CHANNEL1)
 
     @staticmethod
     def get_conf_value(key: str) -> str | None:

--- a/utils/measure/measure/cli/request_adapter.py
+++ b/utils/measure/measure/cli/request_adapter.py
@@ -114,7 +114,7 @@ def _parameters_from_environment(environment: CliEnvironment) -> MeasurementPara
 
 
 # Disable function too complex for this, as it is a simple function to read
-def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> PowerMeterSpec: #noqa: C901
+def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> PowerMeterSpec:  # noqa: C901
     selected = environment.selected_power_meter
     if selected == PowerMeterType.DUMMY:
         return DummyPowerMeterSpec()

--- a/utils/measure/measure/cli/request_adapter.py
+++ b/utils/measure/measure/cli/request_adapter.py
@@ -112,6 +112,7 @@ def _parameters_from_environment(environment: CliEnvironment) -> MeasurementPara
         **{field.name: getattr(environment, field.name) for field in dataclasses.fields(MeasurementParameters)},
     )
 
+
 # Disable function too complex for this, as it is a simple function to read
 # ruff: disable[C901]
 def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> PowerMeterSpec:
@@ -148,12 +149,13 @@ def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> P
         )
     if selected == PowerMeterType.OWON_OWH98XX:
         return OwonOwh98xxPowerMeterSpec(
-            port=environment.serial_port,
-            baudrate=environment.serial_baudrate,
-            channel=environment.owon_owh98xx_channel
+            port=environment.serial_port, baudrate=environment.serial_baudrate, channel=environment.owon_owh98xx_channel
         )
     raise ValueError(f"Unsupported CLI power meter: {selected}")
+
+
 # ruff: enable[C901]
+
 
 def _light_controller_spec(
     environment: CliEnvironment,

--- a/utils/measure/measure/cli/request_adapter.py
+++ b/utils/measure/measure/cli/request_adapter.py
@@ -114,8 +114,7 @@ def _parameters_from_environment(environment: CliEnvironment) -> MeasurementPara
 
 
 # Disable function too complex for this, as it is a simple function to read
-# ruff: disable[C901]
-def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> PowerMeterSpec:
+def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> PowerMeterSpec: #noqa: C901
     selected = environment.selected_power_meter
     if selected == PowerMeterType.DUMMY:
         return DummyPowerMeterSpec()
@@ -152,9 +151,6 @@ def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> P
             port=environment.serial_port, baudrate=environment.serial_baudrate, channel=environment.owon_owh98xx_channel
         )
     raise ValueError(f"Unsupported CLI power meter: {selected}")
-
-
-# ruff: enable[C901]
 
 
 def _light_controller_spec(

--- a/utils/measure/measure/cli/request_adapter.py
+++ b/utils/measure/measure/cli/request_adapter.py
@@ -26,6 +26,7 @@ from measure.powermeter.spec import (
     ManualPowerMeterSpec,
     MyStromPowerMeterSpec,
     OcrPowerMeterSpec,
+    OwonOwh98xxPowerMeterSpec,
     PowerMeterSpec,
     ShellyPowerMeterSpec,
     TasmotaPowerMeterSpec,
@@ -111,7 +112,8 @@ def _parameters_from_environment(environment: CliEnvironment) -> MeasurementPara
         **{field.name: getattr(environment, field.name) for field in dataclasses.fields(MeasurementParameters)},
     )
 
-
+# Disable function too complex for this, as it is a simple function to read
+# ruff: disable[C901]
 def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> PowerMeterSpec:
     selected = environment.selected_power_meter
     if selected == PowerMeterType.DUMMY:
@@ -144,8 +146,14 @@ def _power_meter_spec(environment: CliEnvironment, answers: dict[str, Any]) -> P
             device_ip=environment.tuya_device_ip,
             version=environment.tuya_device_version,
         )
+    if selected == PowerMeterType.OWON_OWH98XX:
+        return OwonOwh98xxPowerMeterSpec(
+            port=environment.serial_port,
+            baudrate=environment.serial_baudrate,
+            channel=environment.owon_owh98xx_channel
+        )
     raise ValueError(f"Unsupported CLI power meter: {selected}")
-
+# ruff: enable[C901]
 
 def _light_controller_spec(
     environment: CliEnvironment,

--- a/utils/measure/measure/powermeter/const.py
+++ b/utils/measure/measure/powermeter/const.py
@@ -11,7 +11,11 @@ class PowerMeterType(StrEnum):
     TASMOTA = "tasmota"
     TUYA = "tuya"
     MYSTROM = "mystrom"
+    OWON_OWH98XX = "owh98xx"
 
+class OwonOwh98xxChannelType(StrEnum):
+    CHANNEL1 = "1"
+    CHANNEL2 = "2"
 
 QUESTION_POWERMETER_ENTITY_ID = "powermeter_entity_id"
 QUESTION_VOLTAGEMETER_ENTITY_ID = "voltagemeter_entity_id"

--- a/utils/measure/measure/powermeter/const.py
+++ b/utils/measure/measure/powermeter/const.py
@@ -13,9 +13,11 @@ class PowerMeterType(StrEnum):
     MYSTROM = "mystrom"
     OWON_OWH98XX = "owh98xx"
 
+
 class OwonOwh98xxChannelType(StrEnum):
     CHANNEL1 = "1"
     CHANNEL2 = "2"
+
 
 QUESTION_POWERMETER_ENTITY_ID = "powermeter_entity_id"
 QUESTION_VOLTAGEMETER_ENTITY_ID = "voltagemeter_entity_id"

--- a/utils/measure/measure/powermeter/serial_scpi.py
+++ b/utils/measure/measure/powermeter/serial_scpi.py
@@ -36,7 +36,7 @@ class SerialScpiPowerMeter(PowerMeter):
     def _retrieve_data(self, request: bytes) -> bytes:
         try:
             self._serial.write(request)
-            return self._serial.readline()
+            return bytes(self._serial.readline())
         except serial.SerialException as error:
             raise PowerMeterError(error) from error
 
@@ -60,10 +60,11 @@ class SerialScpiPowerMeter(PowerMeter):
 
     def get_power(self, include_voltage: bool = False) -> PowerMeasurementResult:
         power = self._retrieve_float(self.power_request())
-        if include_voltage and self.has_voltage_support:
+        measure_voltage = include_voltage and self.has_voltage_support
+        if measure_voltage:
             voltage = self._retrieve_float(self.voltage_request())
         return PowerMeasurementResult(
-            power=power, updated=time.time(), voltage=voltage if include_voltage and self.has_voltage_support else None
+            power=power, updated=time.time(), voltage=voltage if measure_voltage else None
         )
 
 

--- a/utils/measure/measure/powermeter/serial_scpi.py
+++ b/utils/measure/measure/powermeter/serial_scpi.py
@@ -1,0 +1,91 @@
+from abc import abstractmethod
+import time
+
+import serial
+
+from measure.powermeter.const import OwonOwh98xxChannelType
+from measure.powermeter.errors import PowerMeterError
+from measure.powermeter.powermeter import PowerMeasurementResult, PowerMeter
+
+
+class SerialScpiPowerMeter(PowerMeter):
+    # Tested on Linux only
+    def __init__(self, port: str, baudrate: int, timeout: float = 5.0) -> None:
+        # Timeout so the readline cannot hang indefinitely
+        self._serial = serial.Serial(port, baudrate, timeout=timeout)
+        self.manufacturer, self.model, self.serial, self.software_version = \
+            self._identify()
+
+    def identify_request(self) -> bytes:
+        """
+        The bytes to send for the identify request
+        Can be overwritten because serial devices are sometimes weird
+        """
+        return b"*IDN?\n"
+
+    @abstractmethod
+    def power_request(self) -> bytes:
+        """The bytes to send for the power request"""
+
+    @abstractmethod
+    def voltage_request(self) -> bytes:
+        """The bytes to send for the voltage request"""
+
+    def _retrieve_data(self, request: bytes) -> bytes:
+        self._serial.write(request)
+        return self._serial.readline()
+
+    def _retrieve_float(self, request: bytes) -> float:
+        response = self._retrieve_data(request)
+        return float(response.strip().decode())
+
+    def _identify(self) -> (bytes, bytes, bytes, bytes):
+        response = self._retrieve_data(self.identify_request())
+        manufacturer, model, serial, software_version = \
+            response.strip().split(b",")
+        return manufacturer, model, serial, software_version
+
+    def get_power(self, include_voltage: bool = False) -> PowerMeasurementResult:
+        power = self._retrieve_float(self.power_request())
+        if include_voltage and self.has_voltage_support:
+            voltage = self._retrieve_float(self.voltage_request())
+        return PowerMeasurementResult(
+            power=power,
+            updated=time.time(),
+            voltage=voltage if include_voltage and self.has_voltage_support else None
+        )
+
+class OwonOwh98xxPowerMeter(SerialScpiPowerMeter):
+    # Based on https://storage.eleshop.eu/files/OWH9811_Power_Meter_Programming_Manual.pdf
+
+    def __init__(self, port: str, baudrate: int, timeout: float, channel: OwonOwh98xxChannelType) -> None:
+        super().__init__(port, baudrate, timeout)
+
+        if channel == OwonOwh98xxChannelType.CHANNEL2:
+            self.channel = 2
+        else:
+            self.channel = 1
+
+        if self.manufacturer != b"OWON":
+            raise PowerMeterError("Not an OWON device")
+        if not self.model.startswith(b"OWH98"):
+            raise PowerMeterError("Not an OWON OWH98xx series device")
+
+        if self._retrieve_data(self.power_request()) == b"\n":
+            # If the device's local controls are not locked, it will not return the value
+            raise PowerMeterError("Cannot retrieve power, is local locked?")
+
+    def _retrieve_float(self, request: bytes) -> float:
+        # It has a special case for zero, hence the override
+        response = self._retrieve_data(request).strip().decode()
+        return 0 if response == "----" else float(response)
+
+    def power_request(self) -> bytes:
+        return f":MEAS:POW:REAL:ELEMENT{self.channel}?\n".encode()
+
+    def voltage_request(self) -> bytes:
+        return f":MEAS:VOLT:ELEMENT{self.channel}?\n".encode()
+
+    def has_voltage_support(self) -> bool:
+        return True
+

--- a/utils/measure/measure/powermeter/serial_scpi.py
+++ b/utils/measure/measure/powermeter/serial_scpi.py
@@ -63,9 +63,7 @@ class SerialScpiPowerMeter(PowerMeter):
         measure_voltage = include_voltage and self.has_voltage_support
         if measure_voltage:
             voltage = self._retrieve_float(self.voltage_request())
-        return PowerMeasurementResult(
-            power=power, updated=time.time(), voltage=voltage if measure_voltage else None
-        )
+        return PowerMeasurementResult(power=power, updated=time.time(), voltage=voltage if measure_voltage else None)
 
 
 class OwonOwh98xxPowerMeter(SerialScpiPowerMeter):

--- a/utils/measure/measure/powermeter/serial_scpi.py
+++ b/utils/measure/measure/powermeter/serial_scpi.py
@@ -43,7 +43,7 @@ class SerialScpiPowerMeter(PowerMeter):
     def _bytes_to_float(self, data: bytes) -> float:
         try:
             return float(data.strip().decode())
-        except (UnicodeError, ValueError, OverflowError) as error:
+        except (ValueError, OverflowError) as error:
             raise PowerMeterError(error) from error
 
     def _retrieve_float(self, request: bytes) -> float:

--- a/utils/measure/measure/powermeter/serial_scpi.py
+++ b/utils/measure/measure/powermeter/serial_scpi.py
@@ -13,8 +13,7 @@ class SerialScpiPowerMeter(PowerMeter):
     def __init__(self, port: str, baudrate: int, timeout: float = 5.0) -> None:
         # Timeout so the readline cannot hang indefinitely
         self._serial = serial.Serial(port, baudrate, timeout=timeout)
-        self.manufacturer, self.model, self.serial, self.software_version = \
-            self._identify()
+        self.manufacturer, self.model, self.serial, self.software_version = self._identify()
 
     def identify_request(self) -> bytes:
         """
@@ -41,8 +40,7 @@ class SerialScpiPowerMeter(PowerMeter):
 
     def _identify(self) -> (bytes, bytes, bytes, bytes):
         response = self._retrieve_data(self.identify_request())
-        manufacturer, model, serial, software_version = \
-            response.strip().split(b",")
+        manufacturer, model, serial, software_version = response.strip().split(b",")
         return manufacturer, model, serial, software_version
 
     def get_power(self, include_voltage: bool = False) -> PowerMeasurementResult:
@@ -50,10 +48,9 @@ class SerialScpiPowerMeter(PowerMeter):
         if include_voltage and self.has_voltage_support:
             voltage = self._retrieve_float(self.voltage_request())
         return PowerMeasurementResult(
-            power=power,
-            updated=time.time(),
-            voltage=voltage if include_voltage and self.has_voltage_support else None
+            power=power, updated=time.time(), voltage=voltage if include_voltage and self.has_voltage_support else None
         )
+
 
 class OwonOwh98xxPowerMeter(SerialScpiPowerMeter):
     # Based on https://storage.eleshop.eu/files/OWH9811_Power_Meter_Programming_Manual.pdf
@@ -88,4 +85,3 @@ class OwonOwh98xxPowerMeter(SerialScpiPowerMeter):
 
     def has_voltage_support(self) -> bool:
         return True
-

--- a/utils/measure/measure/powermeter/serial_scpi.py
+++ b/utils/measure/measure/powermeter/serial_scpi.py
@@ -12,7 +12,10 @@ class SerialScpiPowerMeter(PowerMeter):
     # Tested on Linux only
     def __init__(self, port: str, baudrate: int, timeout: float = 5.0) -> None:
         # Timeout so the readline cannot hang indefinitely
-        self._serial = serial.Serial(port, baudrate, timeout=timeout)
+        try:
+            self._serial = serial.Serial(port, baudrate, timeout=timeout, exclusive=True)
+        except (ValueError, serial.SerialException) as error:
+            raise PowerMeterError(error) from error
         self.manufacturer, self.model, self.serial, self.software_version = self._identify()
 
     def identify_request(self) -> bytes:
@@ -31,16 +34,28 @@ class SerialScpiPowerMeter(PowerMeter):
         """The bytes to send for the voltage request"""
 
     def _retrieve_data(self, request: bytes) -> bytes:
-        self._serial.write(request)
+        try:
+            self._serial.write(request)
+        except serial.SerialTimeoutException as error:
+            raise PowerMeterError(error) from error
         return self._serial.readline()
+
+    def _bytes_to_float(self, data: bytes) -> float:
+        try:
+            return float(data.strip().decode())
+        except (UnicodeError, ValueError, OverflowError) as error:
+            raise PowerMeterError(error) from error
 
     def _retrieve_float(self, request: bytes) -> float:
         response = self._retrieve_data(request)
-        return float(response.strip().decode())
+        return self._bytes_to_float(response)
 
-    def _identify(self) -> (bytes, bytes, bytes, bytes):
+    def _identify(self) -> tuple[bytes, bytes, bytes, bytes]:
         response = self._retrieve_data(self.identify_request())
-        manufacturer, model, serial, software_version = response.strip().split(b",")
+        try:
+            manufacturer, model, serial, software_version = response.strip().split(b",")
+        except ValueError as error:
+            raise PowerMeterError(error) from error
         return manufacturer, model, serial, software_version
 
     def get_power(self, include_voltage: bool = False) -> PowerMeasurementResult:
@@ -58,10 +73,7 @@ class OwonOwh98xxPowerMeter(SerialScpiPowerMeter):
     def __init__(self, port: str, baudrate: int, timeout: float, channel: OwonOwh98xxChannelType) -> None:
         super().__init__(port, baudrate, timeout)
 
-        if channel == OwonOwh98xxChannelType.CHANNEL2:
-            self.channel = 2
-        else:
-            self.channel = 1
+        self.channel = int(channel)
 
         if self.manufacturer != b"OWON":
             raise PowerMeterError("Not an OWON device")
@@ -74,8 +86,8 @@ class OwonOwh98xxPowerMeter(SerialScpiPowerMeter):
 
     def _retrieve_float(self, request: bytes) -> float:
         # It has a special case for zero, hence the override
-        response = self._retrieve_data(request).strip().decode()
-        return 0 if response == "----" else float(response)
+        response = self._retrieve_data(request).strip()
+        return 0 if response == b"----" else self._bytes_to_float(response)
 
     def power_request(self) -> bytes:
         return f":MEAS:POW:REAL:ELEMENT{self.channel}?\n".encode()

--- a/utils/measure/measure/powermeter/serial_scpi.py
+++ b/utils/measure/measure/powermeter/serial_scpi.py
@@ -36,9 +36,9 @@ class SerialScpiPowerMeter(PowerMeter):
     def _retrieve_data(self, request: bytes) -> bytes:
         try:
             self._serial.write(request)
-        except serial.SerialTimeoutException as error:
+            return self._serial.readline()
+        except serial.SerialException as error:
             raise PowerMeterError(error) from error
-        return self._serial.readline()
 
     def _bytes_to_float(self, data: bytes) -> float:
         try:

--- a/utils/measure/measure/powermeter/spec.py
+++ b/utils/measure/measure/powermeter/spec.py
@@ -64,12 +64,14 @@ class TuyaPowerMeterSpec(_PowerMeterSpec):
     device_ip: str
     version: str = "3.3"
 
+
 class OwonOwh98xxPowerMeterSpec(_PowerMeterSpec):
     type: Literal[PowerMeterType.OWON_OWH98XX] = PowerMeterType.OWON_OWH98XX
     port: str
     baudrate: int
     timeout: float = 5.0
     channel: OwonOwh98xxChannelType
+
 
 PowerMeterSpec = Annotated[
     DummyPowerMeterSpec

--- a/utils/measure/measure/powermeter/spec.py
+++ b/utils/measure/measure/powermeter/spec.py
@@ -2,7 +2,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from measure.powermeter.const import PowerMeterType
+from measure.powermeter.const import OwonOwh98xxChannelType, PowerMeterType
 
 POWER_ENTITY_PATTERN = r"^sensor\.[a-z0-9_]+$"
 VOLTAGE_ENTITY_PATTERN = r"^sensor\.[a-z0-9_]+$"
@@ -64,6 +64,12 @@ class TuyaPowerMeterSpec(_PowerMeterSpec):
     device_ip: str
     version: str = "3.3"
 
+class OwonOwh98xxPowerMeterSpec(_PowerMeterSpec):
+    type: Literal[PowerMeterType.OWON_OWH98XX] = PowerMeterType.OWON_OWH98XX
+    port: str
+    baudrate: int
+    timeout: float = 5.0
+    channel: OwonOwh98xxChannelType
 
 PowerMeterSpec = Annotated[
     DummyPowerMeterSpec
@@ -74,6 +80,7 @@ PowerMeterSpec = Annotated[
     | OcrPowerMeterSpec
     | ShellyPowerMeterSpec
     | TasmotaPowerMeterSpec
-    | TuyaPowerMeterSpec,
+    | TuyaPowerMeterSpec
+    | OwonOwh98xxPowerMeterSpec,
     Field(discriminator="type"),
 ]

--- a/utils/measure/pyproject.toml
+++ b/utils/measure/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "homeassistant-api~=6.0",
     "jsonschema>=4.0",
     "pydantic>=2.13",
-    "pyserial>=3.5",
     "requests>=2.28",
 ]
 
@@ -25,6 +24,7 @@ cli = [
     "aiohue>=4.8.1,<5",
     "inquirer>=3.1",
     "pycryptodome>=3.20",
+    "pyserial>=3.5",
     "python-decouple>=3.4",
     "python-kasa>=0.7",
     "tuyapower>=0.2",

--- a/utils/measure/pyproject.toml
+++ b/utils/measure/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "homeassistant-api~=6.0",
     "jsonschema>=4.0",
     "pydantic>=2.13",
+    "pyserial>=3.5",
     "requests>=2.28",
 ]
 

--- a/utils/measure/tests/powermeter/test_serial_scpi.py
+++ b/utils/measure/tests/powermeter/test_serial_scpi.py
@@ -1,4 +1,3 @@
-import serial
 from unittest.mock import MagicMock, patch
 
 from measure.powermeter.errors import PowerMeterError
@@ -29,7 +28,7 @@ def test_owh98xx_retrieve_float() -> None:
 
     serial.readline = MagicMock(return_value=b"1.0\n")
 
-    assert 1.0 == meter._retrieve_float(b"")
+    assert meter._retrieve_float(b"") == 1.0 #noqa: SLF001
     serial.readline.assert_called_once()
 
 
@@ -43,7 +42,7 @@ def test_owh98xx_retrieve_float_zero() -> None:
 
     serial.readline = MagicMock(return_value=b"----\n")
 
-    assert 0.0 == meter._retrieve_float(b"")
+    assert meter._retrieve_float(b"") == 0.0 #noqa: SLF001
     serial.readline.assert_called_once()
 
 
@@ -57,7 +56,7 @@ def test_owh98xx_retrieve_float_failure() -> None:
     serial.readline = MagicMock(return_value=b"\n")
 
     with pytest.raises(PowerMeterError):
-        meter._retrieve_float(b"")
+        meter._retrieve_float(b"") #noqa: SLF001
 
     serial.readline.assert_called_once()
 
@@ -74,7 +73,7 @@ def test_owh98xx_get_power_no_voltage() -> None:
     measurement = meter.get_power(False)
 
     assert measurement.power == 5.0
-    assert measurement.voltage == None
+    assert measurement.voltage is None
     serial.readline.assert_called_once()
 
 
@@ -88,13 +87,12 @@ def test_owh98xx_get_power_with_voltage() -> None:
     # Ugly way of giving back different values based on if it's the first call
     global firstCall
     firstCall = True
-    def readline_side_effect():
+    def readline_side_effect() -> bytes:
         global firstCall
         if firstCall:
             firstCall = False
             return b"1.0\n"
-        else:
-            return b"2.0\n"
+        return b"2.0\n"
     serial.readline = MagicMock(side_effect=readline_side_effect)
 
     measurement = meter.get_power(True)

--- a/utils/measure/tests/powermeter/test_serial_scpi.py
+++ b/utils/measure/tests/powermeter/test_serial_scpi.py
@@ -28,7 +28,7 @@ def test_owh98xx_retrieve_float() -> None:
 
     serial.readline = MagicMock(return_value=b"1.0\n")
 
-    assert meter._retrieve_float(b"") == 1.0 #noqa: SLF001
+    assert meter._retrieve_float(b"") == 1.0  # noqa: SLF001
     serial.readline.assert_called_once()
 
 
@@ -42,7 +42,7 @@ def test_owh98xx_retrieve_float_zero() -> None:
 
     serial.readline = MagicMock(return_value=b"----\n")
 
-    assert meter._retrieve_float(b"") == 0.0 #noqa: SLF001
+    assert meter._retrieve_float(b"") == 0.0  # noqa: SLF001
     serial.readline.assert_called_once()
 
 
@@ -56,7 +56,7 @@ def test_owh98xx_retrieve_float_failure() -> None:
     serial.readline = MagicMock(return_value=b"\n")
 
     with pytest.raises(PowerMeterError):
-        meter._retrieve_float(b"") #noqa: SLF001
+        meter._retrieve_float(b"")  # noqa: SLF001
 
     serial.readline.assert_called_once()
 
@@ -87,12 +87,14 @@ def test_owh98xx_get_power_with_voltage() -> None:
     # Ugly way of giving back different values based on if it's the first call
     global firstCall
     firstCall = True
+
     def readline_side_effect() -> bytes:
         global firstCall
         if firstCall:
             firstCall = False
             return b"1.0\n"
         return b"2.0\n"
+
     serial.readline = MagicMock(side_effect=readline_side_effect)
 
     measurement = meter.get_power(True)
@@ -100,4 +102,3 @@ def test_owh98xx_get_power_with_voltage() -> None:
     assert measurement.power == 1.0
     assert measurement.voltage == 2.0
     assert serial.readline.call_count == 2
-

--- a/utils/measure/tests/powermeter/test_serial_scpi.py
+++ b/utils/measure/tests/powermeter/test_serial_scpi.py
@@ -1,0 +1,105 @@
+import serial
+from unittest.mock import MagicMock, patch
+
+from measure.powermeter.errors import PowerMeterError
+from measure.powermeter.serial_scpi import OwonOwh98xxPowerMeter
+import pytest
+
+
+def test_owh98xx_identify() -> None:
+    serial = MagicMock()
+    serial.readline = MagicMock(return_value=b"OWON,OWH9811,SERIAL,FV:V1.1.0\n")
+
+    with patch("serial.Serial", return_value=serial):
+        # Identify is called in the init
+        meter = OwonOwh98xxPowerMeter("/dev/ttyUSB0", 115200, 5.0, 1)
+
+    assert meter.manufacturer == b"OWON"
+    assert meter.model == b"OWH9811"
+    assert meter.serial == b"SERIAL"
+    assert meter.software_version == b"FV:V1.1.0"
+
+
+def test_owh98xx_retrieve_float() -> None:
+    serial = MagicMock()
+    serial.readline = MagicMock(return_value=b"OWON,OWH9811,SERIAL,FV:V1.1.0\n")
+
+    with patch("serial.Serial", return_value=serial):
+        meter = OwonOwh98xxPowerMeter("/dev/ttyUSB0", 115200, 5.0, 1)
+
+    serial.readline = MagicMock(return_value=b"1.0\n")
+
+    assert 1.0 == meter._retrieve_float(b"")
+    serial.readline.assert_called_once()
+
+
+def test_owh98xx_retrieve_float_zero() -> None:
+    # Special case for the Owon OWH series
+    serial = MagicMock()
+    serial.readline = MagicMock(return_value=b"OWON,OWH9811,SERIAL,FV:V1.1.0\n")
+
+    with patch("serial.Serial", return_value=serial):
+        meter = OwonOwh98xxPowerMeter("/dev/ttyUSB0", 115200, 5.0, 1)
+
+    serial.readline = MagicMock(return_value=b"----\n")
+
+    assert 0.0 == meter._retrieve_float(b"")
+    serial.readline.assert_called_once()
+
+
+def test_owh98xx_retrieve_float_failure() -> None:
+    serial = MagicMock()
+    serial.readline = MagicMock(return_value=b"OWON,OWH9811,SERIAL,FV:V1.1.0\n")
+
+    with patch("serial.Serial", return_value=serial):
+        meter = OwonOwh98xxPowerMeter("/dev/ttyUSB0", 115200, 5.0, 1)
+
+    serial.readline = MagicMock(return_value=b"\n")
+
+    with pytest.raises(PowerMeterError):
+        meter._retrieve_float(b"")
+
+    serial.readline.assert_called_once()
+
+
+def test_owh98xx_get_power_no_voltage() -> None:
+    serial = MagicMock()
+    serial.readline = MagicMock(return_value=b"OWON,OWH9811,SERIAL,FV:V1.1.0\n")
+
+    with patch("serial.Serial", return_value=serial):
+        meter = OwonOwh98xxPowerMeter("/dev/ttyUSB0", 115200, 5.0, 1)
+
+    serial.readline = MagicMock(return_value=b"5.0\n")
+
+    measurement = meter.get_power(False)
+
+    assert measurement.power == 5.0
+    assert measurement.voltage == None
+    serial.readline.assert_called_once()
+
+
+def test_owh98xx_get_power_with_voltage() -> None:
+    serial = MagicMock()
+    serial.readline = MagicMock(return_value=b"OWON,OWH9811,SERIAL,FV:V1.1.0\n")
+
+    with patch("serial.Serial", return_value=serial):
+        meter = OwonOwh98xxPowerMeter("/dev/ttyUSB0", 115200, 5.0, 1)
+
+    # Ugly way of giving back different values based on if it's the first call
+    global firstCall
+    firstCall = True
+    def readline_side_effect():
+        global firstCall
+        if firstCall:
+            firstCall = False
+            return b"1.0\n"
+        else:
+            return b"2.0\n"
+    serial.readline = MagicMock(side_effect=readline_side_effect)
+
+    measurement = meter.get_power(True)
+
+    assert measurement.power == 1.0
+    assert measurement.voltage == 2.0
+    assert serial.readline.call_count == 2
+

--- a/utils/measure/uv.lock
+++ b/utils/measure/uv.lock
@@ -1028,6 +1028,7 @@ dependencies = [
     { name = "homeassistant-api" },
     { name = "jsonschema" },
     { name = "pydantic" },
+    { name = "pyserial" },
     { name = "requests" },
 ]
 
@@ -1078,6 +1079,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'ocr'", specifier = ">=12.0" },
     { name = "pycryptodome", marker = "extra == 'cli'", specifier = ">=3.20" },
     { name = "pydantic", specifier = ">=2.13" },
+    { name = "pyserial", specifier = ">=3.5" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
@@ -1530,6 +1532,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyserial"
+version = "3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
 ]
 
 [[package]]

--- a/utils/measure/uv.lock
+++ b/utils/measure/uv.lock
@@ -1028,7 +1028,6 @@ dependencies = [
     { name = "homeassistant-api" },
     { name = "jsonschema" },
     { name = "pydantic" },
-    { name = "pyserial" },
     { name = "requests" },
 ]
 
@@ -1042,6 +1041,7 @@ cli = [
     { name = "aiohue" },
     { name = "inquirer" },
     { name = "pycryptodome" },
+    { name = "pyserial" },
     { name = "python-decouple" },
     { name = "python-kasa" },
     { name = "tuyapower" },
@@ -1079,7 +1079,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'ocr'", specifier = ">=12.0" },
     { name = "pycryptodome", marker = "extra == 'cli'", specifier = ">=3.20" },
     { name = "pydantic", specifier = ">=2.13" },
-    { name = "pyserial", specifier = ">=3.5" },
+    { name = "pyserial", marker = "extra == 'cli'", specifier = ">=3.5" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },


### PR DESCRIPTION
This PR adds support for using the OWON OWH98xx series power meters for power measurements. These are power meters with a serial SCPI port, supporting two channels at the same time (though measuring is only implemented on one channel at a time). Since there are more serial SCPI devices around, I've tried to ensure it has a base that is reusable for those other devices.

Using pySerial for the serial communication.

I have only tested this with the CLI on Linux. I don't know if more is necessary to get it to work with the HA app.