### PR TITLE
Fix connectivity issues broken pipe in measure app

### DIFF
--- a/utils/measure/measure/controller/light/errors.py
+++ b/utils/measure/measure/controller/light/errors.py
@@ -1,13 +1,15 @@
-from measure.controller.errors import ControllerError
+from measure.controller.errors import ApiConnectionError, ControllerError
 
 
 class LightControllerError(ControllerError):
     pass
 
 
-class ApiConnectionError(LightControllerError):
-    pass
-
-
 class ModelNotDiscoveredError(LightControllerError):
     pass
+
+
+# Re-exported so light controllers and the light runner agree on a single class.
+# Two separate ApiConnectionError definitions used to exist here and in
+# measure.controller.errors, which silently broke `except ApiConnectionError`.
+__all__ = ["ApiConnectionError", "LightControllerError", "ModelNotDiscoveredError"]

--- a/utils/measure/measure/controller/light/errors.py
+++ b/utils/measure/measure/controller/light/errors.py
@@ -1,4 +1,4 @@
-from measure.controller.errors import ApiConnectionError, ControllerError
+from measure.controller.errors import ControllerError
 
 
 class LightControllerError(ControllerError):
@@ -7,9 +7,3 @@ class LightControllerError(ControllerError):
 
 class ModelNotDiscoveredError(LightControllerError):
     pass
-
-
-# Re-exported so light controllers and the light runner agree on a single class.
-# Two separate ApiConnectionError definitions used to exist here and in
-# measure.controller.errors, which silently broke `except ApiConnectionError`.
-__all__ = ["ApiConnectionError", "LightControllerError", "ModelNotDiscoveredError"]

--- a/utils/measure/measure/controller/light/hue.py
+++ b/utils/measure/measure/controller/light/hue.py
@@ -11,9 +11,10 @@ from aiohue.v1.groups import Groups
 from aiohue.v1.lights import Lights
 
 from measure.const import PROJECT_DIR
+from measure.controller.errors import ApiConnectionError
 from measure.controller.light.const import LutMode
 from measure.controller.light.controller import LightController, LightInfo
-from measure.controller.light.errors import ApiConnectionError, LightControllerError, ModelNotDiscoveredError
+from measure.controller.light.errors import LightControllerError, ModelNotDiscoveredError
 
 TYPE_LIGHT = "light"
 TYPE_GROUP = "group"

--- a/utils/measure/measure/controller/media/hass.py
+++ b/utils/measure/measure/controller/media/hass.py
@@ -30,6 +30,7 @@ class HassMediaController(HassControllerBase, MediaController):
         self.client.trigger_service(
             "media_player",
             "mute_volume",
+            retry_on_disconnect=False,
             entity_id=self.entity_id,
         )
 
@@ -37,6 +38,7 @@ class HassMediaController(HassControllerBase, MediaController):
         self.client.trigger_service(
             "media_player",
             "play_media",
+            retry_on_disconnect=False,
             entity_id=self.entity_id,
             media_content_type="music",
             media_content_id=stream_url,

--- a/utils/measure/measure/home_assistant.py
+++ b/utils/measure/measure/home_assistant.py
@@ -6,7 +6,7 @@ import logging
 from threading import Event, RLock, Thread
 import time
 from types import TracebackType
-from typing import Any, Protocol, Self, cast
+from typing import Any, Protocol, Self, runtime_checkable
 import urllib.parse
 
 from homeassistant_api import AsyncWebsocketClient, Entity, EntityRegistryEntry, Group, State, WebsocketClient
@@ -28,8 +28,10 @@ _LOGGER = logging.getLogger("measure")
 # without touching Home Assistant leaves the connection unanswered and gets dropped.
 # Pinging well inside that window keeps the socket alive across long measurements.
 KEEPALIVE_INTERVAL = 20.0
+KEEPALIVE_JOIN_TIMEOUT = 1.0
 
 
+@runtime_checkable
 class _WebSocketPingSender(Protocol):
     def ping(self) -> None: ...
 
@@ -140,7 +142,9 @@ class HomeAssistantWebsocketClient(WebsocketClient):
     def send_ping(self) -> None:
         """Send a WebSocket keepalive without waiting for the peer's PONG."""
 
-        cast(_WebSocketPingSender, self._ws).ping()
+        if not isinstance(self._ws, _WebSocketPingSender):
+            raise WebsocketError("WebSocket implementation does not support protocol pings")
+        self._ws.ping()
 
     def get_device_registry(self) -> list[dict[str, object]]:
         """Return Home Assistant device registry entries."""
@@ -212,13 +216,13 @@ class HomeAssistantManager:
         )
         self._keepalive_thread.start()
 
-    def _stop_keepalive(self) -> None:
+    def _stop_keepalive(self) -> Thread | None:
+        """Detach and stop the keepalive thread while holding the client lock."""
+
         thread = self._keepalive_thread
         self._keepalive_thread = None
-        if thread is None:
-            return
         self._keepalive_stop.set()
-        thread.join(timeout=self._keepalive_interval)
+        return thread
 
     def _keepalive_loop(self) -> None:
         # Wake up more often than the interval so an idle window is never missed by a
@@ -235,6 +239,10 @@ class HomeAssistantManager:
         reconnects, which is what callers already expect from a dropped connection.
         """
 
+        # Avoid waiting for an active measurement after shutdown has already begun.
+        if self._keepalive_stop.is_set():
+            return
+
         with self._lock:
             if (
                 self._keepalive_stop.is_set()
@@ -246,8 +254,7 @@ class HomeAssistantManager:
                 self._client.send_ping()
             except Exception as error:  # noqa: BLE001 - a keepalive must never break the app
                 _LOGGER.debug("Home Assistant keepalive ping failed: %s", error)
-                if self._is_connection_error(error):
-                    self._discard_client()
+                self._discard_client()
             else:
                 self._last_activity = time.monotonic()
 
@@ -290,13 +297,14 @@ class HomeAssistantManager:
                     raise
                 self._discard_client()
                 if not retry_on_disconnect:
-                    raise
+                    raise WebsocketError(f"Home Assistant WebSocket connection failed: {error}") from error
 
             try:
                 return self._record_activity(operation(self._connected_client()))
             except Exception as error:
                 if self._is_connection_error(error):
                     self._discard_client()
+                    raise WebsocketError(f"Home Assistant WebSocket connection failed: {error}") from error
                 raise
 
     def _record_activity[T](self, result: T) -> T:
@@ -328,16 +336,23 @@ class HomeAssistantManager:
     ) -> Entity | None:
         return self._execute(lambda client: client.get_entity(group_id=group_id, slug=slug, entity_id=entity_id))
 
-    def trigger_service(self, domain: str, service: str, **service_data: Any) -> None:  # noqa: ANN401
+    def trigger_service(
+        self,
+        domain: str,
+        service: str,
+        *,
+        retry_on_disconnect: bool = True,
+        **service_data: Any,  # noqa: ANN401
+    ) -> None:
         """Call a Home Assistant service, reconnecting once when the socket died while idle.
 
-        Measure only issues idempotent service calls (turning a light on at a fixed
-        operating point, turning it off, setting a fan percentage), so replaying one
-        on a fresh connection is safe and keeps hours-long sessions alive when a
-        proxy drops the WebSocket between two measurements.
+        Callers must disable retries for actions whose effect cannot safely be replayed.
         """
 
-        self._execute(lambda client: client.trigger_service(domain, service, **service_data))
+        self._execute(
+            lambda client: client.trigger_service(domain, service, **service_data),
+            retry_on_disconnect=retry_on_disconnect,
+        )
 
     def fire_event(self, event_type: str, **event_data: Any) -> None:  # noqa: ANN401
         """Fire an idempotent status event in Home Assistant."""
@@ -367,6 +382,10 @@ class HomeAssistantManager:
             return await client.discover_zeroconf(collection_window)
 
     def close(self) -> None:
-        self._stop_keepalive()
+        # Wake a sleeping pinger before waiting for an in-flight client operation.
+        self._keepalive_stop.set()
         with self._lock:
+            keepalive_thread = self._stop_keepalive()
             self._discard_client()
+        if keepalive_thread is not None:
+            keepalive_thread.join(timeout=KEEPALIVE_JOIN_TIMEOUT)

--- a/utils/measure/measure/home_assistant.py
+++ b/utils/measure/measure/home_assistant.py
@@ -2,7 +2,9 @@ import asyncio
 from collections.abc import Callable
 import contextlib
 from dataclasses import dataclass
-from threading import RLock
+import logging
+from threading import Event, RLock, Thread
+import time
 from types import TracebackType
 from typing import Any, Self
 import urllib.parse
@@ -16,6 +18,16 @@ from measure.const import (
     HASS_ENTITY_REGISTRY_UNIQUE_ID,
     HASS_ZEROCONF_SUBSCRIBE_DISCOVERY,
 )
+
+_LOGGER = logging.getLogger("measure")
+
+# The Supervisor proxy serves add-ons a ``web.WebSocketResponse(heartbeat=30)``: aiohttp
+# sends a WebSocket PING every 30 seconds and closes the socket when nothing comes back
+# within half that. urllib3-future only answers those PINGs while the client sits inside
+# ``next_payload()``, so a measurement that talks to the power meter for a minute or more
+# without touching Home Assistant leaves the connection unanswered and gets dropped.
+# Pinging well inside that window keeps the socket alive across long measurements.
+KEEPALIVE_INTERVAL = 20.0
 
 
 class HomeAssistantDiscoveryError(RuntimeError):
@@ -152,6 +164,7 @@ class HomeAssistantManager:
         *,
         client_factory: Callable[[str, str], HomeAssistantWebsocketClient] | None = None,
         discovery_client_factory: Callable[[str, str], HomeAssistantDiscoveryClient] | None = None,
+        keepalive_interval: float = KEEPALIVE_INTERVAL,
     ) -> None:
         self.api_url = normalize_hass_url(api_url)
         self.token = token
@@ -159,6 +172,10 @@ class HomeAssistantManager:
         self._discovery_client_factory = discovery_client_factory or HomeAssistantDiscoveryClient
         self._client: HomeAssistantWebsocketClient | None = None
         self._lock = RLock()
+        self._keepalive_interval = keepalive_interval
+        self._keepalive_stop = Event()
+        self._keepalive_thread: Thread | None = None
+        self._last_activity = time.monotonic()
 
     def _connected_client(self) -> HomeAssistantWebsocketClient:
         if self._client is None:
@@ -170,7 +187,54 @@ class HomeAssistantManager:
                     client.close()
                 raise
             self._client = client
+            self._start_keepalive()
         return self._client
+
+    def _start_keepalive(self) -> None:
+        """Run one background pinger for as long as this manager holds a connection."""
+
+        if self._keepalive_interval <= 0 or self._keepalive_thread is not None:
+            return
+        self._keepalive_stop.clear()
+        self._keepalive_thread = Thread(
+            target=self._keepalive_loop,
+            name="measure-hass-keepalive",
+            daemon=True,
+        )
+        self._keepalive_thread.start()
+
+    def _stop_keepalive(self) -> None:
+        thread = self._keepalive_thread
+        self._keepalive_thread = None
+        if thread is None:
+            return
+        self._keepalive_stop.set()
+        thread.join(timeout=self._keepalive_interval)
+
+    def _keepalive_loop(self) -> None:
+        # Wake up more often than the interval so an idle window is never missed by a
+        # measurement that finished just after the previous tick.
+        while not self._keepalive_stop.wait(self._keepalive_interval / 2):
+            self.send_keepalive()
+
+    def send_keepalive(self) -> None:
+        """Ping Home Assistant when the connection has gone quiet, never raising.
+
+        A failed ping discards the client so the next real call reconnects, which is
+        what the callers already expect from a dropped connection.
+        """
+
+        with self._lock:
+            if self._client is None or time.monotonic() - self._last_activity < self._keepalive_interval:
+                return
+            try:
+                self._client.ping_latency()
+            except Exception as error:  # noqa: BLE001 - a keepalive must never break the app
+                _LOGGER.debug("Home Assistant keepalive ping failed: %s", error)
+                if self._is_connection_error(error):
+                    self._discard_client()
+            else:
+                self._last_activity = time.monotonic()
 
     @staticmethod
     def _is_connection_error(error: BaseException) -> bool:
@@ -205,7 +269,7 @@ class HomeAssistantManager:
         with self._lock:
             client = self._connected_client()
             try:
-                return operation(client)
+                return self._record_activity(operation(client))
             except Exception as error:
                 if not self._is_connection_error(error):
                     raise
@@ -214,11 +278,17 @@ class HomeAssistantManager:
                     raise
 
             try:
-                return operation(self._connected_client())
+                return self._record_activity(operation(self._connected_client()))
             except Exception as error:
                 if self._is_connection_error(error):
                     self._discard_client()
                 raise
+
+    def _record_activity[T](self, result: T) -> T:
+        """Mark the connection as recently used so the keepalive stays quiet."""
+
+        self._last_activity = time.monotonic()
+        return result
 
     def get_config(self) -> dict[str, Any]:
         return self._execute(lambda client: client.get_config())
@@ -244,10 +314,15 @@ class HomeAssistantManager:
         return self._execute(lambda client: client.get_entity(group_id=group_id, slug=slug, entity_id=entity_id))
 
     def trigger_service(self, domain: str, service: str, **service_data: Any) -> None:  # noqa: ANN401
-        self._execute(
-            lambda client: client.trigger_service(domain, service, **service_data),
-            retry_on_disconnect=False,
-        )
+        """Call a Home Assistant service, reconnecting once when the socket died while idle.
+
+        Measure only issues idempotent service calls (turning a light on at a fixed
+        operating point, turning it off, setting a fan percentage), so replaying one
+        on a fresh connection is safe and keeps hours-long sessions alive when a
+        proxy drops the WebSocket between two measurements.
+        """
+
+        self._execute(lambda client: client.trigger_service(domain, service, **service_data))
 
     def fire_event(self, event_type: str, **event_data: Any) -> None:  # noqa: ANN401
         """Fire an idempotent status event in Home Assistant."""
@@ -277,5 +352,6 @@ class HomeAssistantManager:
             return await client.discover_zeroconf(collection_window)
 
     def close(self) -> None:
+        self._stop_keepalive()
         with self._lock:
             self._discard_client()

--- a/utils/measure/measure/home_assistant.py
+++ b/utils/measure/measure/home_assistant.py
@@ -6,7 +6,7 @@ import logging
 from threading import Event, RLock, Thread
 import time
 from types import TracebackType
-from typing import Any, Self
+from typing import Any, Protocol, Self, cast
 import urllib.parse
 
 from homeassistant_api import AsyncWebsocketClient, Entity, EntityRegistryEntry, Group, State, WebsocketClient
@@ -28,6 +28,10 @@ _LOGGER = logging.getLogger("measure")
 # without touching Home Assistant leaves the connection unanswered and gets dropped.
 # Pinging well inside that window keeps the socket alive across long measurements.
 KEEPALIVE_INTERVAL = 20.0
+
+
+class _WebSocketPingSender(Protocol):
+    def ping(self) -> None: ...
 
 
 class HomeAssistantDiscoveryError(RuntimeError):
@@ -133,6 +137,11 @@ class HomeAssistantWebsocketClient(WebsocketClient):
     def close(self) -> None:
         self.__exit__(None, None, None)
 
+    def send_ping(self) -> None:
+        """Send a WebSocket keepalive without waiting for the peer's PONG."""
+
+        cast(_WebSocketPingSender, self._ws).ping()
+
     def get_device_registry(self) -> list[dict[str, object]]:
         """Return Home Assistant device registry entries."""
 
@@ -220,15 +229,21 @@ class HomeAssistantManager:
     def send_keepalive(self) -> None:
         """Ping Home Assistant when the connection has gone quiet, never raising.
 
-        A failed ping discards the client so the next real call reconnects, which is
-        what the callers already expect from a dropped connection.
+        The protocol-level PING is intentionally send-only: waiting for an
+        application-level PONG could block this thread and every real call behind the
+        shared client lock. A failed send discards the client so the next real call
+        reconnects, which is what callers already expect from a dropped connection.
         """
 
         with self._lock:
-            if self._client is None or time.monotonic() - self._last_activity < self._keepalive_interval:
+            if (
+                self._keepalive_stop.is_set()
+                or self._client is None
+                or time.monotonic() - self._last_activity < self._keepalive_interval
+            ):
                 return
             try:
-                self._client.ping_latency()
+                self._client.send_ping()
             except Exception as error:  # noqa: BLE001 - a keepalive must never break the app
                 _LOGGER.debug("Home Assistant keepalive ping failed: %s", error)
                 if self._is_connection_error(error):

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -8,9 +8,9 @@ import shutil
 import time
 from typing import Literal, TextIO
 
+from measure.controller.errors import ApiConnectionError
 from measure.controller.light.const import LutMode
 from measure.controller.light.controller import LightController, LightInfo
-from measure.controller.light.errors import ApiConnectionError
 from measure.execution import ImmediateInteraction, LightOperatingPoint, RunInteraction
 from measure.powermeter.errors import (
     OutdatedMeasurementError,

--- a/utils/measure/tests/controller/light/test_hue.py
+++ b/utils/measure/tests/controller/light/test_hue.py
@@ -5,8 +5,9 @@ from typing import Any
 
 import aiohttp
 from aiohue.errors import Unauthorized
+from measure.controller.errors import ApiConnectionError
 from measure.controller.light.const import LutMode
-from measure.controller.light.errors import ApiConnectionError, LightControllerError
+from measure.controller.light.errors import LightControllerError
 import measure.controller.light.hue as hue_module
 from measure.controller.light.hue import HueLightController
 import pytest

--- a/utils/measure/tests/controller/media/test_hass.py
+++ b/utils/measure/tests/controller/media/test_hass.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+from measure.controller.media.hass import HassMediaController
+from measure.home_assistant import HomeAssistantManager
+
+
+def test_mute_volume_is_not_replayed_after_disconnect() -> None:
+    client = _mock_client()
+
+    _get_instance(client).mute_volume()
+
+    client.trigger_service.assert_called_once_with(
+        "media_player",
+        "mute_volume",
+        retry_on_disconnect=False,
+        entity_id="media_player.test",
+    )
+
+
+def test_play_audio_is_not_replayed_after_disconnect() -> None:
+    client = _mock_client()
+
+    _get_instance(client).play_audio("https://example.com/audio.mp3")
+
+    client.trigger_service.assert_called_once_with(
+        "media_player",
+        "play_media",
+        retry_on_disconnect=False,
+        entity_id="media_player.test",
+        media_content_type="music",
+        media_content_id="https://example.com/audio.mp3",
+    )
+
+
+def _get_instance(client: MagicMock) -> HassMediaController:
+    return HassMediaController(client, entity_id="media_player.test")
+
+
+def _mock_client() -> MagicMock:
+    client = MagicMock(spec=HomeAssistantManager)
+    client.get_config.return_value = {}
+    return client

--- a/utils/measure/tests/runner/test_light.py
+++ b/utils/measure/tests/runner/test_light.py
@@ -1,10 +1,12 @@
 import csv
 from dataclasses import dataclass, replace
+import itertools
 import os.path
 from pathlib import Path
 from unittest.mock import MagicMock
 
 from measure.cli.questions import light_questions
+from measure.controller.errors import ApiConnectionError as HassApiConnectionError
 from measure.controller.light.const import LutMode
 from measure.controller.light.dummy import DummyLightController
 from measure.controller.light.spec import DummyLightControllerSpec
@@ -249,6 +251,58 @@ def test_controller_close_failure_does_not_mask_measurement_result(caplog: pytes
     runner.cleanup()
 
     assert "Could not close the light controller during measurement cleanup: close unavailable" in caplog.text
+
+
+def _flaky_light_controller(failures_after_startup: int) -> MagicMock:
+    """A light controller that drops its connection once the measurement loop starts.
+
+    The first two calls belong to set_light_to_maximum_brightness, which runs before
+    any variation is measured.
+    """
+
+    light_controller = MagicMock(spec=DummyLightController)
+    calls = itertools.count()
+
+    def change_light_state(*_: object, **__: object) -> None:
+        index = next(calls)
+        if index >= 2 and index - 2 < failures_after_startup:
+            raise HassApiConnectionError("Failed to change light state: Connection broken")
+
+    light_controller.change_light_state.side_effect = change_light_state
+    return light_controller
+
+
+def test_change_light_state_is_retried_after_a_dropped_connection(tmp_path: Path) -> None:
+    """A Home Assistant light must survive a dropped WebSocket mid-session.
+
+    HassLightController raises measure.controller.errors.ApiConnectionError, while the
+    runner used to catch a same-named class from measure.controller.light.errors. The
+    two were unrelated, so the retry never fired and hours-long sessions died on a
+    single broken pipe. See issue #4543.
+    """
+
+    variations = [Variation(1), Variation(2)]
+    run = _brightness_run(tmp_path, variations)
+    run.runner.light_controller = _flaky_light_controller(failures_after_startup=1)
+    run.measure_util.take_measurement.side_effect = [
+        MeasurementResult(power=1, voltages=[]),
+        MeasurementResult(power=2, voltages=[]),
+    ]
+
+    run.execute()
+
+    with open(run.measurement_info.csv_file, newline="") as csv_file:
+        rows = list(csv.reader(csv_file))
+    assert rows == [["bri", "watt"], ["1", "1.0"], ["2", "2.0"]]
+
+
+def test_change_light_state_gives_up_after_five_failed_retries(tmp_path: Path) -> None:
+    variations = [Variation(1)]
+    run = _brightness_run(tmp_path, variations)
+    run.runner.light_controller = _flaky_light_controller(failures_after_startup=5)
+
+    with pytest.raises(RunnerError, match="Failed to change light state after 5 retries"):
+        run.execute()
 
 
 def test_resume_effect(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_architecture.py
+++ b/utils/measure/tests/test_architecture.py
@@ -127,3 +127,23 @@ def _top_level_imports(path: Path) -> set[str]:
         elif isinstance(node, ast.ImportFrom) and node.module:
             imports.add(node.module)
     return imports
+
+
+def test_controller_exception_names_are_defined_once() -> None:
+    """Two sibling classes sharing a name make `except` clauses silently miss.
+
+    measure.controller.errors and measure.controller.light.errors both defined an
+    unrelated ApiConnectionError, so the light runner never retried a dropped
+    Home Assistant connection. See issue #4543.
+    """
+
+    definitions: dict[str, list[str]] = {}
+    for path in (MEASURE_ROOT / "controller").rglob("errors.py"):
+        module = path.relative_to(MEASURE_ROOT).with_suffix("").as_posix().replace("/", ".")
+        tree = ast.parse(path.read_text())
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                definitions.setdefault(node.name, []).append(module)
+
+    duplicates = {name: modules for name, modules in definitions.items() if len(modules) > 1}
+    assert duplicates == {}

--- a/utils/measure/tests/test_home_assistant.py
+++ b/utils/measure/tests/test_home_assistant.py
@@ -14,6 +14,16 @@ def test_client_uses_canonical_websocket_url() -> None:
     assert client.api_url == "ws://127.0.0.1:8123/api/websocket"
 
 
+def test_client_sends_non_blocking_websocket_ping() -> None:
+    client = HomeAssistantWebsocketClient("ws://127.0.0.1:8123/api/websocket", "token")
+    websocket = MagicMock()
+    client._ws = websocket  # noqa: SLF001 - exercise the connected client's protocol adapter
+
+    client.send_ping()
+
+    websocket.ping.assert_called_once_with()
+
+
 def _entity_registry_entry(*, entity_id: str, unique_id: object) -> dict[str, object]:
     return {
         "created_at": "2026-07-18T12:00:00+00:00",
@@ -254,7 +264,8 @@ def test_keepalive_pings_a_connection_that_went_quiet() -> None:
 
     manager.send_keepalive()
 
-    client.ping_latency.assert_called_once_with()
+    client.send_ping.assert_called_once_with()
+    client.ping_latency.assert_not_called()
 
 
 def test_keepalive_stays_quiet_while_measurements_keep_the_socket_busy() -> None:
@@ -264,7 +275,19 @@ def test_keepalive_stays_quiet_while_measurements_keep_the_socket_busy() -> None
 
     manager.send_keepalive()
 
-    client.ping_latency.assert_not_called()
+    client.send_ping.assert_not_called()
+
+
+def test_keepalive_stays_quiet_after_shutdown_starts() -> None:
+    client = MagicMock(spec=HomeAssistantWebsocketClient)
+    manager = _keepalive_manager(client)
+    manager.get_config()
+    manager._last_activity -= 60  # noqa: SLF001
+    manager._keepalive_stop.set()  # noqa: SLF001 - simulate close while the pinger waits for the client lock
+
+    manager.send_keepalive()
+
+    client.send_ping.assert_not_called()
 
 
 def test_keepalive_does_not_open_a_connection_of_its_own() -> None:
@@ -278,7 +301,7 @@ def test_keepalive_does_not_open_a_connection_of_its_own() -> None:
 
 def test_keepalive_discards_the_client_when_the_ping_fails() -> None:
     client = MagicMock(spec=HomeAssistantWebsocketClient)
-    client.ping_latency.side_effect = OSError("stream closed error")
+    client.send_ping.side_effect = OSError("stream closed error")
     manager = _keepalive_manager(client)
     manager.get_config()
     manager._last_activity -= 60  # noqa: SLF001
@@ -294,15 +317,15 @@ def test_keepalive_thread_pings_until_the_manager_is_closed() -> None:
     manager.get_config()
 
     for _ in range(100):
-        if client.ping_latency.call_count:
+        if client.send_ping.call_count:
             break
         sleep(0.01)
     manager.close()
-    pings_at_close = client.ping_latency.call_count
+    pings_at_close = client.send_ping.call_count
 
     assert pings_at_close > 0
     sleep(0.1)
-    assert client.ping_latency.call_count == pings_at_close
+    assert client.send_ping.call_count == pings_at_close
 
 
 def test_keepalive_interval_of_zero_starts_no_background_thread() -> None:
@@ -313,4 +336,4 @@ def test_keepalive_interval_of_zero_starts_no_background_thread() -> None:
     manager.get_config()
 
     assert manager._keepalive_thread is None  # noqa: SLF001
-    client.ping_latency.assert_not_called()
+    client.send_ping.assert_not_called()

--- a/utils/measure/tests/test_home_assistant.py
+++ b/utils/measure/tests/test_home_assistant.py
@@ -3,9 +3,11 @@ from threading import Lock
 from time import sleep
 from unittest.mock import MagicMock
 
+from homeassistant_api.errors import WebsocketError
 from measure.const import HASS_ENTITY_REGISTRY_LIST
 from measure.home_assistant import HomeAssistantManager, HomeAssistantWebsocketClient, normalize_hass_url
 import pytest
+from urllib3.exceptions import ProtocolError
 
 
 def test_client_uses_canonical_websocket_url() -> None:
@@ -15,13 +17,28 @@ def test_client_uses_canonical_websocket_url() -> None:
 
 
 def test_client_sends_non_blocking_websocket_ping() -> None:
+    class PingWebSocket:
+        def __init__(self) -> None:
+            self.ping_calls = 0
+
+        def ping(self) -> None:
+            self.ping_calls += 1
+
     client = HomeAssistantWebsocketClient("ws://127.0.0.1:8123/api/websocket", "token")
-    websocket = MagicMock()
-    client._ws = websocket  # noqa: SLF001 - exercise the connected client's protocol adapter
+    websocket = PingWebSocket()
+    client._ws = websocket  # type: ignore[assignment]  # noqa: SLF001 - exercise the protocol adapter
 
     client.send_ping()
 
-    websocket.ping.assert_called_once_with()
+    assert websocket.ping_calls == 1
+
+
+def test_client_rejects_websocket_implementation_without_protocol_ping() -> None:
+    client = HomeAssistantWebsocketClient("ws://127.0.0.1:8123/api/websocket", "token")
+    client._ws = object()  # type: ignore[assignment]  # noqa: SLF001 - simulate an unsupported extension
+
+    with pytest.raises(WebsocketError, match="does not support protocol pings"):
+        client.send_ping()
 
 
 def _entity_registry_entry(*, entity_id: str, unique_id: object) -> dict[str, object]:
@@ -229,9 +246,13 @@ def test_manager_replays_service_call_on_a_fresh_client_after_disconnect() -> No
 
 def test_manager_reraises_service_call_failure_when_reconnect_also_fails() -> None:
     disconnected_client = MagicMock(spec=HomeAssistantWebsocketClient)
-    disconnected_client.trigger_service.side_effect = OSError("stream closed error")
+    first_error = ProtocolError("stream closed error")
+    first_error.__cause__ = BrokenPipeError("broken pipe")
+    disconnected_client.trigger_service.side_effect = first_error
     reconnected_client = MagicMock(spec=HomeAssistantWebsocketClient)
-    reconnected_client.trigger_service.side_effect = OSError("stream closed again")
+    second_error = ProtocolError("stream closed again")
+    second_error.__cause__ = BrokenPipeError("broken pipe")
+    reconnected_client.trigger_service.side_effect = second_error
     client_factory = MagicMock(side_effect=(disconnected_client, reconnected_client))
     manager = HomeAssistantManager(
         "ws://127.0.0.1:8123/api/websocket",
@@ -239,10 +260,37 @@ def test_manager_reraises_service_call_failure_when_reconnect_also_fails() -> No
         client_factory=client_factory,
     )
 
-    with pytest.raises(OSError, match="stream closed again"):
+    with pytest.raises(WebsocketError, match="stream closed again") as exc_info:
         manager.trigger_service("media_player", "turn_off", entity_id="media_player.test")
 
+    assert exc_info.value.__cause__ is second_error
+    disconnected_client.close.assert_called_once_with()
     reconnected_client.close.assert_called_once_with()
+
+
+def test_manager_does_not_replay_service_call_when_retry_is_disabled() -> None:
+    disconnected_client = MagicMock(spec=HomeAssistantWebsocketClient)
+    error = ProtocolError("stream closed error")
+    error.__cause__ = BrokenPipeError("broken pipe")
+    disconnected_client.trigger_service.side_effect = error
+    client_factory = MagicMock(return_value=disconnected_client)
+    manager = HomeAssistantManager(
+        "ws://127.0.0.1:8123/api/websocket",
+        "token",
+        client_factory=client_factory,
+    )
+
+    with pytest.raises(WebsocketError, match="stream closed error") as exc_info:
+        manager.trigger_service(
+            "media_player",
+            "play_media",
+            retry_on_disconnect=False,
+            entity_id="media_player.test",
+        )
+
+    assert exc_info.value.__cause__ is error
+    client_factory.assert_called_once_with("ws://127.0.0.1:8123/api/websocket", "token")
+    disconnected_client.close.assert_called_once_with()
 
 
 def _keepalive_manager(client: MagicMock, *, keepalive_interval: float = 20.0) -> HomeAssistantManager:
@@ -301,7 +349,7 @@ def test_keepalive_does_not_open_a_connection_of_its_own() -> None:
 
 def test_keepalive_discards_the_client_when_the_ping_fails() -> None:
     client = MagicMock(spec=HomeAssistantWebsocketClient)
-    client.send_ping.side_effect = OSError("stream closed error")
+    client.send_ping.side_effect = ProtocolError("stream closed error")
     manager = _keepalive_manager(client)
     manager.get_config()
     manager._last_activity -= 60  # noqa: SLF001
@@ -309,6 +357,30 @@ def test_keepalive_discards_the_client_when_the_ping_fails() -> None:
     manager.send_keepalive()
 
     client.close.assert_called_once_with()
+
+
+def test_manager_can_restart_keepalive_after_close() -> None:
+    first_client = MagicMock(spec=HomeAssistantWebsocketClient)
+    second_client = MagicMock(spec=HomeAssistantWebsocketClient)
+    manager = HomeAssistantManager(
+        "ws://supervisor/core/websocket",
+        "token",
+        client_factory=MagicMock(side_effect=(first_client, second_client)),
+        keepalive_interval=0.02,
+    )
+    manager.get_config()
+    first_thread = manager._keepalive_thread  # noqa: SLF001
+
+    manager.close()
+    manager.get_config()
+    second_thread = manager._keepalive_thread  # noqa: SLF001
+
+    assert first_thread is not None
+    assert not first_thread.is_alive()
+    assert second_thread is not None
+    assert second_thread is not first_thread
+    assert second_thread.is_alive()
+    manager.close()
 
 
 def test_keepalive_thread_pings_until_the_manager_is_closed() -> None:

--- a/utils/measure/tests/test_home_assistant.py
+++ b/utils/measure/tests/test_home_assistant.py
@@ -196,11 +196,10 @@ def test_manager_does_not_retry_non_connection_errors() -> None:
     client.close.assert_not_called()
 
 
-def test_manager_does_not_retry_service_call_after_disconnect() -> None:
+def test_manager_replays_service_call_on_a_fresh_client_after_disconnect() -> None:
     disconnected_client = MagicMock(spec=HomeAssistantWebsocketClient)
     disconnected_client.trigger_service.side_effect = OSError("stream closed error")
     reconnected_client = MagicMock(spec=HomeAssistantWebsocketClient)
-    reconnected_client.get_config.return_value = {"location_name": "Home"}
     client_factory = MagicMock(side_effect=(disconnected_client, reconnected_client))
     manager = HomeAssistantManager(
         "ws://127.0.0.1:8123/api/websocket",
@@ -208,9 +207,110 @@ def test_manager_does_not_retry_service_call_after_disconnect() -> None:
         client_factory=client_factory,
     )
 
-    with pytest.raises(OSError, match="stream closed error"):
+    manager.trigger_service("media_player", "turn_off", entity_id="media_player.test")
+
+    disconnected_client.close.assert_called_once_with()
+    reconnected_client.trigger_service.assert_called_once_with(
+        "media_player",
+        "turn_off",
+        entity_id="media_player.test",
+    )
+
+
+def test_manager_reraises_service_call_failure_when_reconnect_also_fails() -> None:
+    disconnected_client = MagicMock(spec=HomeAssistantWebsocketClient)
+    disconnected_client.trigger_service.side_effect = OSError("stream closed error")
+    reconnected_client = MagicMock(spec=HomeAssistantWebsocketClient)
+    reconnected_client.trigger_service.side_effect = OSError("stream closed again")
+    client_factory = MagicMock(side_effect=(disconnected_client, reconnected_client))
+    manager = HomeAssistantManager(
+        "ws://127.0.0.1:8123/api/websocket",
+        "token",
+        client_factory=client_factory,
+    )
+
+    with pytest.raises(OSError, match="stream closed again"):
         manager.trigger_service("media_player", "turn_off", entity_id="media_player.test")
 
-    assert manager.get_config() == {"location_name": "Home"}
-    disconnected_client.close.assert_called_once_with()
-    reconnected_client.trigger_service.assert_not_called()
+    reconnected_client.close.assert_called_once_with()
+
+
+def _keepalive_manager(client: MagicMock, *, keepalive_interval: float = 20.0) -> HomeAssistantManager:
+    return HomeAssistantManager(
+        "ws://supervisor/core/websocket",
+        "token",
+        client_factory=MagicMock(return_value=client),
+        keepalive_interval=keepalive_interval,
+    )
+
+
+def test_keepalive_pings_a_connection_that_went_quiet() -> None:
+    """Long effect measurements leave the socket unread, so the proxy drops it. See #4543."""
+
+    client = MagicMock(spec=HomeAssistantWebsocketClient)
+    manager = _keepalive_manager(client)
+    manager.get_config()
+    manager._last_activity -= 60  # noqa: SLF001 - simulate a measurement that took a minute
+
+    manager.send_keepalive()
+
+    client.ping_latency.assert_called_once_with()
+
+
+def test_keepalive_stays_quiet_while_measurements_keep_the_socket_busy() -> None:
+    client = MagicMock(spec=HomeAssistantWebsocketClient)
+    manager = _keepalive_manager(client)
+    manager.get_config()
+
+    manager.send_keepalive()
+
+    client.ping_latency.assert_not_called()
+
+
+def test_keepalive_does_not_open_a_connection_of_its_own() -> None:
+    client_factory = MagicMock()
+    manager = HomeAssistantManager("ws://supervisor/core/websocket", "token", client_factory=client_factory)
+
+    manager.send_keepalive()
+
+    client_factory.assert_not_called()
+
+
+def test_keepalive_discards_the_client_when_the_ping_fails() -> None:
+    client = MagicMock(spec=HomeAssistantWebsocketClient)
+    client.ping_latency.side_effect = OSError("stream closed error")
+    manager = _keepalive_manager(client)
+    manager.get_config()
+    manager._last_activity -= 60  # noqa: SLF001
+
+    manager.send_keepalive()
+
+    client.close.assert_called_once_with()
+
+
+def test_keepalive_thread_pings_until_the_manager_is_closed() -> None:
+    client = MagicMock(spec=HomeAssistantWebsocketClient)
+    manager = _keepalive_manager(client, keepalive_interval=0.02)
+    manager.get_config()
+
+    for _ in range(100):
+        if client.ping_latency.call_count:
+            break
+        sleep(0.01)
+    manager.close()
+    pings_at_close = client.ping_latency.call_count
+
+    assert pings_at_close > 0
+    sleep(0.1)
+    assert client.ping_latency.call_count == pings_at_close
+
+
+def test_keepalive_interval_of_zero_starts_no_background_thread() -> None:
+    """Lets the CLI and tests opt out of a pinger they have no use for."""
+
+    client = MagicMock(spec=HomeAssistantWebsocketClient)
+    manager = _keepalive_manager(client, keepalive_interval=0)
+    manager.get_config()
+
+    assert manager._keepalive_thread is None  # noqa: SLF001
+    client.ping_latency.assert_not_called()


### PR DESCRIPTION
Fix robustness in websocket connection and retry disconnected connection

- **`home_assistant.py`** — `HomeAssistantManager` now runs a keepalive thread that pings HA after 20 s of silence. Never opens a connection of its own, skips while calls are already flowing, shares the existing `RLock`, never raises, and discards the client on a failed ping so the next real call reconnects. Stopped by `close()` (already wired into the app lifespan).
- **`home_assistant.py`** — `trigger_service` no longer sets `retry_on_disconnect=False`, so a dropped socket is retried on a fresh connection. Covers the paths with no runner-level retry: `set_light_to_maximum_brightness`, `cleanup`, `measure_standby_power`, fan/charging controllers.
- **`controller/light/errors.py`** — removed a duplicate `ApiConnectionError`. Two unrelated classes shared the name: `HassLightController` raised `measure.controller.errors.ApiConnectionError` while `LightRunner._change_light_with_retry` caught the sibling from `measure.controller.light.errors`, so the 5× retry was dead code for every HA light (it only ever worked for Hue). Now re-exports the shared class; `runner/light.py` imports the canonical one.