### PR TITLE
Add philscottydev as author of Paulmann 29150 profile

### DIFF
--- a/profile_library/paulmann licht/29150/model.json
+++ b/profile_library/paulmann licht/29150/model.json
@@ -23,6 +23,10 @@
     {
       "name": "71820SM01",
       "github": "71820SM01"
+    },
+    {
+      "name": "philscottydev",
+      "github": "philscottydev"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #4551, adding myself to the author list now that #4564 supports multiple authors. Thanks for making that change.