### PR TITLE
Only warn once when a linear value attribute is missing

### DIFF
--- a/custom_components/powercalc/strategy/linear.py
+++ b/custom_components/powercalc/strategy/linear.py
@@ -69,6 +69,7 @@ class LinearStrategy(PowerCalculationStrategyInterface):
         self._attribute: str | None = None
         self._standby_power = standby_power
         self._initialized: bool = False
+        self._missing_attribute_warned: bool = False
         self._calibration: list[tuple[int, float]] | None = None
 
     async def initialize(self) -> None:
@@ -199,12 +200,15 @@ class LinearStrategy(PowerCalculationStrategyInterface):
 
         value = entity_state.attributes.get(self._attribute)
         if value is None:
-            _LOGGER.warning(
-                "No %s attribute for entity: %s",
-                self._attribute,
-                entity_state.entity_id,
-            )
+            if not self._missing_attribute_warned:
+                _LOGGER.warning(
+                    "No %s attribute for entity: %s",
+                    self._attribute,
+                    entity_state.entity_id,
+                )
+                self._missing_attribute_warned = True
             return None
+        self._missing_attribute_warned = False
         # Convert volume level to 0-100 range
         if self._attribute == ATTR_MEDIA_VOLUME_LEVEL:
             if entity_state.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is True:

--- a/tests/strategy/test_linear.py
+++ b/tests/strategy/test_linear.py
@@ -192,6 +192,43 @@ async def test_error_on_non_number_state(
     assert "Expecting state to be a number for entity" in caplog.text
 
 
+async def test_missing_attribute_warning_is_logged_once(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The 'no attribute' warning fires once per occurrence, not every calculation.
+
+    A fan in a preset mode without a percentage attribute is a normal runtime
+    state, so the warning must not spam the log. It should warn when entering the
+    state, stay quiet while it persists, and warn again only after a successful
+    reading in between.
+
+    See https://github.com/bramstroker/homeassistant-powercalc/issues/4585
+    """
+    caplog.set_level(logging.WARNING)
+    strategy = await _create_strategy_instance(
+        hass,
+        create_source_entity("fan.test", hass),
+        {CONF_MIN_POWER: 10, CONF_MAX_POWER: 100},
+    )
+
+    missing = State("fan.test", STATE_ON, {ATTR_PERCENTAGE: None})
+
+    assert await strategy.calculate(missing) is None
+    assert caplog.text.count("No percentage attribute for entity") == 1
+
+    # Same state again must not raise another warning.
+    assert await strategy.calculate(missing) is None
+    assert caplog.text.count("No percentage attribute for entity") == 1
+
+    # A successful reading resets the flag.
+    assert await strategy.calculate(State("fan.test", STATE_ON, {ATTR_PERCENTAGE: 50})) == 55
+
+    # Entering the missing state again warns once more.
+    assert await strategy.calculate(missing) is None
+    assert caplog.text.count("No percentage attribute for entity") == 2
+
+
 async def test_validate_raises_exception_not_allowed_domain(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
Fixes #4585.

`LinearStrategy.get_value_from_attribute` logs `No <attr> attribute for entity` on every calculation while the value attribute is missing. That happens continuously when, for example, a fan sits in a preset mode that exposes no `percentage` (auto is the default on many air purifiers), so the log fills up.

As discussed in the issue, the warning is worth keeping rather than downgrading, because the power sensor goes unavailable in that state and that is worth surfacing. So this memoizes it instead: warn once when entering the missing-attribute state, stay quiet while it persists, and reset the flag on the next successful reading so a later recurrence warns again.

Added a test covering the once-only behaviour and the reset after a valid reading.
