### PR TITLE
Add altitude 8817452 power profile

### DIFF
--- a/profile_library/altitude/8817452/model.json
+++ b/profile_library/altitude/8817452/model.json
@@ -1,0 +1,49 @@
+{
+  "authors": [
+    {
+      "github": "tpascaru",
+      "name": "tpascaru"
+    }
+  ],
+  "calculation_strategy": "linear",
+  "created_at": "2026-08-23T22:00:06Z",
+  "device_type": "fan",
+  "linear_config": {
+    "calibrate": [
+      "5 -> 6.07",
+      "10 -> 6.11",
+      "15 -> 6.22",
+      "20 -> 6.36",
+      "25 -> 8.75",
+      "30 -> 10.15",
+      "35 -> 10.19",
+      "40 -> 13.47",
+      "45 -> 13.97",
+      "50 -> 13.97",
+      "55 -> 17.86",
+      "60 -> 19.61",
+      "65 -> 24.42",
+      "70 -> 27.59",
+      "75 -> 27.59",
+      "80 -> 27.53",
+      "85 -> 34.02",
+      "90 -> 35.84",
+      "95 -> 36.62",
+      "100 -> 37.25"
+    ]
+  },
+  "measure_description": "Measured with utils/measure script",
+  "measure_device": "test",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 1,
+    "SLEEP_TIME": 40.0,
+    "VERSION": "v0.4.1:app"
+  },
+  "name": "ALTITUDE SKYLARK 52-in Matte Black Covered Outdoor Propeller Ceiling Fan Without Light",
+  "standby_power": 3.45,
+  "voltage_range": {
+    "max": 121.3,
+    "min": 120.7
+  }
+}

--- a/profile_library/altitude/manufacturer.json
+++ b/profile_library/altitude/manufacturer.json
@@ -1,0 +1,4 @@
+{
+  "aliases": [],
+  "name": "Altitude"
+}


### PR DESCRIPTION
## Device information

- Manufacturer: Altitude
- Model ID: 8817452
- Product name: ALTITUDE SKYLARK 52-in Matte Black Covered Outdoor Propeller Ceiling Fan Without Light
- Measurement device: test

## Home Assistant Device information

- Measure type: fan
- Integration: matter

## Checklist

- [x] I have created a single PR per device.
- [x] For lights, only generated gzipped lookup tables are included.
- [x] I reviewed the generated files and JSON in Powercalc Measure.

## Additional info

Includes 3.125 quiescent current from other devices on my circuit. I would subtract that from the measured data to get the residual power of the fan.

### Generated files

- `profile_library/altitude/8817452/model.json`
- `profile_library/altitude/manufacturer.json`

### Duplicate warnings

- None
