### PR TITLE
Harden remote profile downloads

### DIFF
--- a/custom_components/powercalc/power_profile/loader/remote.py
+++ b/custom_components/powercalc/power_profile/loader/remote.py
@@ -93,8 +93,27 @@ def _validate_resources(resources: object, storage_path: str) -> list[tuple[str,
     ]
 
 
+def _sync_directory(directory: Path) -> None:
+    """Persist a directory entry, so a completed rename survives an unclean shutdown."""
+    try:
+        directory_descriptor = os.open(directory, os.O_RDONLY)
+    except OSError:  # pragma: no cover - directories cannot be opened on all platforms
+        return
+    try:
+        os.fsync(directory_descriptor)
+    except OSError:  # pragma: no cover - directory fsync is not supported on all platforms
+        pass
+    finally:
+        os.close(directory_descriptor)
+
+
 def _save_resource(data: bytes, path: Path) -> None:
-    """Atomically save a downloaded resource to the local profile storage directory."""
+    """Atomically save a downloaded resource to the local profile storage directory.
+
+    The contents are flushed to disk before the rename, and the directory entry is flushed
+    after it. Without both, a power loss shortly after an update can leave the new file name
+    pointing at unwritten data, which is how a cached profile ends up as invalid JSON.
+    """
     os.makedirs(path.parent, exist_ok=True)
     file_descriptor, temporary_name = tempfile.mkstemp(
         dir=path.parent,
@@ -105,7 +124,10 @@ def _save_resource(data: bytes, path: Path) -> None:
     try:
         with os.fdopen(file_descriptor, "wb") as file_handle:
             file_handle.write(data)
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
         os.replace(temporary_path, path)
+        _sync_directory(path.parent)
     finally:
         temporary_path.unlink(missing_ok=True)
 
@@ -270,18 +292,26 @@ class RemoteLoader(Loader):
         return str(self.hass.config.path(STORAGE_DIR, BUILT_IN_LIBRARY_DIR, "library.json"))
 
     def _read_local_library_json(self) -> dict[str, Any] | None:
-        """Read library.json from local storage, None when it has not been downloaded yet."""
+        """Read library.json from local storage, None when it is missing or unusable.
+
+        A truncated or unreadable copy is reported as absent rather than raised, so the caller
+        falls through to a fresh download instead of failing setup on every restart.
+        """
         local_path = self._get_library_json_path()
         if not os.path.exists(local_path):
             return None
-        with open(local_path) as f:
-            return cast(dict[str, Any], json.load(f))
+        try:
+            with open(local_path) as f:
+                return cast(dict[str, Any], json.load(f))
+        except (JSONDecodeError, OSError) as err:
+            _LOGGER.warning("Local library.json is unusable (%s), discarding it and downloading a fresh copy", err)
+            return None
 
     def _load_local_library_json(self) -> dict[str, Any]:
-        """Load library.json from local storage, raising when it is not there."""
+        """Load library.json from local storage, raising when it is not usable."""
         library_json = self._read_local_library_json()
         if library_json is None:
-            raise ProfileDownloadError("Local library.json file not found")
+            raise ProfileDownloadError("Local library.json file not found or unusable")
         return library_json
 
     async def _download_remote_library_json(self) -> dict[str, Any] | None:
@@ -306,12 +336,7 @@ class RemoteLoader(Loader):
         except (TimeoutError, ClientError) as err:
             raise ProfileDownloadError(f"Failed to download library.json: {err}") from err
 
-        def _save_to_local_storage(data: bytes) -> None:
-            os.makedirs(os.path.dirname(local_path), exist_ok=True)
-            with open(local_path, "wb") as f:
-                f.write(data)
-
-        await self.hass.async_add_executor_job(_save_to_local_storage, data)
+        await self.hass.async_add_executor_job(_save_resource, data, Path(local_path))
 
         return cast(dict[str, Any], json.loads(data))
 
@@ -516,7 +541,7 @@ class RemoteLoader(Loader):
             callback = partial(self.download_profile, manufacturer, model, storage_path, model_hash)
             await self.download_with_retry(callback)
             self.profile_hashes[f"{manufacturer}/{model}"] = model_hash
-            await self.hass.async_add_executor_job(self._write_profile_hashes, self.profile_hashes)
+            await self.hass.async_add_executor_job(self._write_profile_hashes, dict(self.profile_hashes))
         except ProfileDownloadError as e:
             path_exists, storage_path_exists = await self.hass.async_add_executor_job(
                 self._profile_paths_exist,
@@ -616,18 +641,25 @@ class RemoteLoader(Loader):
         return str(self.hass.config.path(STORAGE_DIR, BUILT_IN_LIBRARY_DIR, ".profile_hashes"))
 
     def _load_profile_hashes(self) -> dict[str, str]:
-        """Load profile hashes from local storage"""
+        """Load profile hashes from local storage.
+
+        An unusable file is treated as empty rather than raised: the hashes are only a cache
+        validity marker, so the worst case is that every profile is downloaded once more.
+        """
 
         path = self._get_profile_hashes_path()
         if not os.path.exists(path):
             return {}
 
-        with open(path) as f:
-            return json.load(f)  # type: ignore[no-any-return]
+        try:
+            with open(path) as f:
+                return cast(dict[str, str], json.load(f))
+        except (JSONDecodeError, OSError) as err:
+            _LOGGER.warning("Profile hashes file is unusable (%s), profiles will be downloaded again", err)
+            return {}
 
     def _write_profile_hashes(self, hashes: dict[str, str]) -> None:
-        """Write profile hashes to local storage"""
+        """Write profile hashes to local storage, atomically."""
 
         path = self._get_profile_hashes_path()
-        with open(path, "w") as json_file:
-            json.dump(hashes, json_file, indent=4)
+        _save_resource(json.dumps(hashes, indent=4).encode(), Path(path))

--- a/custom_components/powercalc/power_profile/loader/remote.py
+++ b/custom_components/powercalc/power_profile/loader/remote.py
@@ -7,6 +7,7 @@ import logging
 import os
 from pathlib import Path
 import shutil
+import tempfile
 from typing import Any, NotRequired, TypedDict, cast
 from urllib.parse import urlsplit
 
@@ -35,6 +36,7 @@ ENDPOINT_LIBRARY = f"{API_URL}/library"
 ENDPOINT_DOWNLOAD = f"{API_URL}/download"
 
 TIMEOUT_SECONDS = 30
+MODEL_JSON_RETRY_LIMIT = 2
 
 ALLOWED_RESOURCE_HOSTS = frozenset({"github.com", "raw.githubusercontent.com"})
 
@@ -92,10 +94,26 @@ def _validate_resources(resources: object, storage_path: str) -> list[tuple[str,
 
 
 def _save_resource(data: bytes, path: Path) -> None:
-    """Save a downloaded resource to the local profile storage directory."""
+    """Atomically save a downloaded resource to the local profile storage directory."""
     os.makedirs(path.parent, exist_ok=True)
-    with open(path, "wb") as file_handle:
-        file_handle.write(data)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "wb") as file_handle:
+            file_handle.write(data)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _save_resources(resources: list[tuple[bytes, Path]]) -> None:
+    """Save all downloaded resources after every response has completed successfully."""
+    for data, path in resources:
+        _save_resource(data, path)
 
 
 class LibraryModel(TypedDict):
@@ -127,6 +145,7 @@ class RemoteLoader(Loader):
         self.model_lookup: dict[str, dict[str, list[LibraryModel]]] = {}
         self.manufacturer_lookup: dict[str, set[str]] = {}
         self.profile_hashes: dict[str, str] = {}
+        self._model_load_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
     async def initialize(self, prefer_cached: bool = False) -> None:
         """Initialize the loader.
@@ -410,19 +429,51 @@ class RemoteLoader(Loader):
         retry_count: int = 0,
     ) -> tuple[dict[str, Any], str] | None:
         """Load a model, downloading it if necessary, with retry logic."""
+        lock = self._model_load_locks.setdefault((manufacturer, model), asyncio.Lock())
+        async with lock:
+            return await self._load_model_locked(manufacturer, model, force_update, retry_count)
+
+    async def _load_model_locked(
+        self,
+        manufacturer: str,
+        model: str,
+        force_update: bool,
+        retry_count: int,
+    ) -> tuple[dict[str, Any], str] | None:
+        """Load a model while holding its per-profile lock."""
         model_info = self._get_library_model(manufacturer, model)
         storage_path = self.get_storage_path(manufacturer, model)
         model_path = os.path.join(storage_path, "model.json")
 
-        if await self._needs_update(model_info, manufacturer, model, model_path, force_update):
-            await self._download_profile_with_retry(manufacturer, model, storage_path, model_path)
+        while True:
+            if await self._needs_update(model_info, manufacturer, model, model_path, force_update):
+                await self._download_profile_with_retry(manufacturer, model, storage_path, model_path)
 
-        try:
-            json_data = await self._load_model_json(model_path)
-        except JSONDecodeError as e:
-            return await self._handle_json_decode_error(e, manufacturer, model, retry_count)
+            try:
+                json_data = await self._load_model_json(model_path)
+            except JSONDecodeError as error:
+                if retry_count >= MODEL_JSON_RETRY_LIMIT:
+                    _LOGGER.error(
+                        "model.json remains invalid after %d redownload attempts for manufacturer: %s, model: %s",
+                        MODEL_JSON_RETRY_LIMIT,
+                        manufacturer,
+                        model,
+                    )
+                    raise LibraryLoadingError("Failed to load model.json file") from error
 
-        return json_data, storage_path
+                retry_count += 1
+                force_update = True
+                _LOGGER.warning(
+                    "model.json is not valid JSON for manufacturer: %s, model: %s; redownloading profile "
+                    "(attempt %d of %d)",
+                    manufacturer,
+                    model,
+                    retry_count,
+                    MODEL_JSON_RETRY_LIMIT,
+                )
+                continue
+
+            return json_data, storage_path
 
     def _get_library_model(self, manufacturer: str, model: str) -> LibraryModel:
         """Retrieve model info, or raise an error if not found."""
@@ -492,20 +543,6 @@ class RemoteLoader(Loader):
 
         return await self.hass.async_add_executor_job(_load_json)
 
-    async def _handle_json_decode_error(
-        self,
-        error: JSONDecodeError,
-        manufacturer: str,
-        model: str,
-        retry_count: int,
-    ) -> tuple[dict[str, Any], str] | None:
-        """Handle JSON decode errors with retry logic."""
-        _LOGGER.error("model.json file is not valid JSON for manufacturer: %s, model: %s", manufacturer, model)
-        if retry_count < 2:
-            _LOGGER.debug("Retrying to load model.json file")
-            return await self.load_model(manufacturer, model, True, retry_count + 1)
-        raise LibraryLoadingError("Failed to load model.json file") from error
-
     def get_storage_path(self, manufacturer: str, model: str) -> str:
         """Retrieve the storage path for a given manufacturer and model."""
         return str(self.hass.config.path(STORAGE_DIR, BUILT_IN_LIBRARY_DIR, manufacturer, model))
@@ -561,13 +598,16 @@ class RemoteLoader(Loader):
                 await self.hass.async_add_executor_job(lambda: os.makedirs(storage_path, exist_ok=True))
 
                 # Download the files
+                downloaded_resources: list[tuple[bytes, Path]] = []
                 for url, destination in validated_resources:
                     async with session.get(url, allow_redirects=False) as resp:
                         if resp.status != 200:
                             raise ProfileDownloadError(f"Failed to download github URL: {url}")
 
                         contents = await resp.read()
-                        await self.hass.async_add_executor_job(_save_resource, contents, destination)
+                        downloaded_resources.append((contents, destination))
+
+                await self.hass.async_add_executor_job(_save_resources, downloaded_resources)
         except (TimeoutError, aiohttp.ClientError) as e:
             raise ProfileDownloadError(f"Failed to download profile: {manufacturer}/{model}") from e
 

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 from functools import partial
 import json
@@ -110,6 +111,40 @@ async def test_download(
             os.path.exists,
             os.path.join(storage_dir, remote_file["path"]),
         )
+
+
+async def test_download_keeps_existing_resources_when_a_later_download_fails(
+    remote_loader: RemoteLoader,
+    mock_aioresponse: aioresponses,
+    tmp_path: Path,
+) -> None:
+    """Do not partially update a cached profile when one of its resources cannot be downloaded."""
+    storage_path = tmp_path / "profiles"
+    storage_path.mkdir()
+    existing_resource = storage_path / "model.json"
+    existing_resource.write_bytes(b'{"existing": true}')
+    resources = [
+        {
+            "path": "model.json",
+            "url": "https://raw.githubusercontent.com/example/profile/model.json",
+        },
+        {
+            "path": "data.csv.gz",
+            "url": "https://raw.githubusercontent.com/example/profile/data.csv.gz",
+        },
+    ]
+    mock_aioresponse.get(
+        f"{ENDPOINT_DOWNLOAD}/test/model?hash=test_download",
+        status=200,
+        payload=resources,
+    )
+    mock_aioresponse.get(resources[0]["url"], status=200, body=b'{"new": true}')
+    mock_aioresponse.get(resources[1]["url"], status=500)
+
+    with pytest.raises(ProfileDownloadError, match="Failed to download github URL"):
+        await remote_loader.download_profile("test", "model", str(storage_path), "test_download")
+
+    assert existing_resource.read_bytes() == b'{"existing": true}'
 
 
 async def test_download_with_parenthesis(remote_loader: RemoteLoader, mock_aioresponse: aioresponses) -> None:
@@ -799,6 +834,45 @@ async def test_profile_redownloaded_when_model_json_missing(
     assert storage_path == local_storage_path
 
 
+async def test_concurrent_model_loads_only_download_profile_once(remote_loader: RemoteLoader) -> None:
+    """Concurrent entities using the same profile must not write the cached files concurrently."""
+    manufacturer = "signify"
+    model = "LCA001"
+    local_storage_path = remote_loader.get_storage_path(manufacturer, model)
+    clear_storage_dir(local_storage_path)
+    remote_loader.profile_hashes.pop(f"{manufacturer}/{model}", None)
+    download_started = asyncio.Event()
+    release_download = asyncio.Event()
+
+    async def _download_profile(
+        requested_manufacturer: str,
+        requested_model: str,
+        storage_path: str,
+        model_hash: str,
+    ) -> None:
+        download_started.set()
+        assert (requested_manufacturer, requested_model, model_hash) == (
+            manufacturer,
+            model,
+            remote_loader.model_infos[f"{manufacturer}/{model}"]["hash"],
+        )
+        await release_download.wait()
+        shutil.copytree(get_test_profile_dir("signify_LCA001"), storage_path, dirs_exist_ok=True)
+
+    with patch.object(remote_loader, "download_profile", side_effect=_download_profile) as mock_download:
+        first_load = asyncio.create_task(remote_loader.load_model(manufacturer, model))
+        await download_started.wait()
+        second_load = asyncio.create_task(remote_loader.load_model(manufacturer, model))
+        await asyncio.sleep(0)
+
+        assert mock_download.await_count == 1
+        release_download.set()
+        first_result, second_result = await asyncio.gather(first_load, second_load)
+
+    assert mock_download.await_count == 1
+    assert first_result == second_result
+
+
 async def test_profile_redownloaded_when_model_json_corrupt(
     remote_loader: RemoteLoader,
     mock_aioresponse: aioresponses,
@@ -837,14 +911,16 @@ async def test_profile_redownloaded_when_model_json_corrupt(
 
     await remote_loader.load_model("apple", "HomePod Mini")
 
-    assert "model.json file is not valid JSON" in caplog.text
-    assert "Retrying to load model.json file" in caplog.text
+    recovery_records = [record for record in caplog.records if "model.json is not valid JSON" in record.message]
+    assert len(recovery_records) == 1
+    assert recovery_records[0].levelno == logging.WARNING
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
 
 
 async def test_profile_redownloaded_when_model_json_corrupt_retry_limit(
-    hass: HomeAssistant,
     remote_loader: RemoteLoader,
     mock_aioresponse: aioresponses,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     When model.json is corrupt, retry 3 times before giving up.
@@ -877,6 +953,13 @@ async def test_profile_redownloaded_when_model_json_corrupt_retry_limit(
 
     with pytest.raises(LibraryLoadingError):
         await remote_loader.load_model("apple", "HomePod Mini")
+
+    recovery_records = [record for record in caplog.records if "model.json is not valid JSON" in record.message]
+    assert len(recovery_records) == 2
+    assert all(record.levelno == logging.WARNING for record in recovery_records)
+    failure_records = [record for record in caplog.records if "model.json remains invalid" in record.message]
+    assert len(failure_records) == 1
+    assert failure_records[0].levelno == logging.ERROR
 
 
 @pytest.mark.parametrize(

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -26,6 +26,7 @@ from custom_components.powercalc.power_profile.loader.remote import (
     ENDPOINT_LIBRARY,
     LibraryModel,
     RemoteLoader,
+    _save_resource,
 )
 from custom_components.powercalc.power_profile.power_profile import DeviceType, DiscoveryBy
 from tests.common import get_test_config_dir, get_test_profile_dir
@@ -145,6 +146,36 @@ async def test_download_keeps_existing_resources_when_a_later_download_fails(
         await remote_loader.download_profile("test", "model", str(storage_path), "test_download")
 
     assert existing_resource.read_bytes() == b'{"existing": true}'
+
+
+def test_save_resource_flushes_to_disk_before_renaming(tmp_path: Path) -> None:
+    """The contents must reach the disk before the rename, so a power loss cannot expose an empty file."""
+    destination = tmp_path / "model.json"
+    destination.write_bytes(b'{"existing": true}')
+    call_order: list[str] = []
+    real_fsync = os.fsync
+    real_replace = os.replace
+
+    def _record_fsync(fd: int) -> None:
+        call_order.append("fsync")
+        real_fsync(fd)
+
+    def _record_replace(source: object, target: object) -> None:
+        call_order.append("replace")
+        real_replace(cast(str, source), cast(str, target))
+
+    with (
+        patch("custom_components.powercalc.power_profile.loader.remote.os.fsync", side_effect=_record_fsync),
+        patch(
+            "custom_components.powercalc.power_profile.loader.remote.os.replace",
+            side_effect=_record_replace,
+        ),
+    ):
+        _save_resource(b'{"new": true}', destination)
+
+    assert destination.read_bytes() == b'{"new": true}'
+    assert call_order[: call_order.index("replace")] == ["fsync"]
+    assert not list(tmp_path.glob(".model.json.*"))
 
 
 async def test_download_with_parenthesis(remote_loader: RemoteLoader, mock_aioresponse: aioresponses) -> None:
@@ -749,6 +780,120 @@ async def test_prefer_cached_downloads_when_no_local_copy(
     await loader.initialize(prefer_cached=True)
 
     assert "signify" in loader.model_lookup
+
+
+async def test_prefer_cached_redownloads_when_local_copy_is_corrupt(
+    hass: HomeAssistant,
+    mock_library_json_response: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A truncated library.json must not brick setup, it has to be discarded and downloaded again."""
+    local_path = hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json")
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+    with open(local_path, "w") as f:
+        f.write('{"manufacturers": [')
+
+    loader = RemoteLoader(hass)
+    loader.retry_timeout = 0
+    await loader.initialize(prefer_cached=True)
+
+    assert "signify" in loader.model_lookup
+    assert "Local library.json is unusable" in caplog.text
+    with open(local_path) as f:
+        assert json.load(f)
+
+
+async def test_library_json_falls_back_when_download_fails_and_local_copy_is_corrupt(
+    hass: HomeAssistant,
+    mock_aioresponse: aioresponses,
+) -> None:
+    """With no usable local copy and no connection there is nothing to load, so setup must fail loudly."""
+    local_path = hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json")
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+    with open(local_path, "w") as f:
+        f.write("not json at all")
+
+    mock_aioresponse.get(ENDPOINT_LIBRARY, repeat=True, exception=ClientError("no connection"))
+
+    loader = RemoteLoader(hass)
+    loader.retry_timeout = 0
+    with pytest.raises(ProfileDownloadError):
+        await loader.initialize()
+
+
+async def test_library_json_is_written_atomically(
+    hass: HomeAssistant,
+    mock_library_json_response: None,
+) -> None:
+    """The downloaded library.json must land via a rename, never by truncating the existing copy."""
+    local_path = hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json")
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+    with open(local_path, "w") as f:
+        f.write('{"manufacturers": []}')
+
+    loader = RemoteLoader(hass)
+    loader.retry_timeout = 0
+
+    real_replace = os.replace
+    renamed: list[str] = []
+
+    def _record_replace(source: object, target: object) -> None:
+        renamed.append(str(target))
+        real_replace(cast(str, source), cast(str, target))
+
+    with patch(
+        "custom_components.powercalc.power_profile.loader.remote.os.replace",
+        side_effect=_record_replace,
+    ):
+        await loader.initialize()
+
+    assert local_path in renamed
+    assert "signify" in loader.model_lookup
+
+
+async def test_corrupt_profile_hashes_are_discarded(
+    hass: HomeAssistant,
+    mock_library_json_response: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A truncated .profile_hashes must not fail setup, it only costs one extra download round."""
+    hash_file = hass.config.path(STORAGE_DIR, "powercalc_profiles", ".profile_hashes")
+    os.makedirs(os.path.dirname(hash_file), exist_ok=True)
+    with open(hash_file, "w") as f:
+        f.write('{"signify/LCA001": ')
+
+    loader = RemoteLoader(hass)
+    loader.retry_timeout = 0
+    await loader.initialize()
+
+    assert loader.profile_hashes == {}
+    assert "Profile hashes file is unusable" in caplog.text
+
+
+async def test_profile_hashes_are_written_atomically(hass: HomeAssistant) -> None:
+    """The hashes file must land via a rename, so a crash cannot leave it half written."""
+    hash_file = hass.config.path(STORAGE_DIR, "powercalc_profiles", ".profile_hashes")
+    os.makedirs(os.path.dirname(hash_file), exist_ok=True)
+    with open(hash_file, "w") as f:
+        f.write('{"signify/LCA001": "old"}')
+
+    loader = RemoteLoader(hass)
+    real_replace = os.replace
+    renamed: list[str] = []
+
+    def _record_replace(source: object, target: object) -> None:
+        renamed.append(str(target))
+        real_replace(cast(str, source), cast(str, target))
+
+    with patch(
+        "custom_components.powercalc.power_profile.loader.remote.os.replace",
+        side_effect=_record_replace,
+    ):
+        await hass.async_add_executor_job(loader._write_profile_hashes, {"signify/LCA001": "new"})  # noqa: SLF001
+
+    assert renamed == [hash_file]
+    with open(hash_file) as f:
+        assert json.load(f) == {"signify/LCA001": "new"}
 
 
 async def test_library_update_refreshes_from_remote(


### PR DESCRIPTION
## Summary

- serialize concurrent loads of the same remote profile
- buffer downloads and atomically replace cached resources
- log recoverable JSON corruption as a warning and emit an error only after retries are exhausted
- cover partial download failures, concurrent loads, and retry logging

## Testing

- .venv/bin/pytest tests/power_profile -q (228 passed)
- Ruff check and format check on changed files
- .venv/bin/mypy custom_components/powercalc
- commit hooks (all passed)
- changed-line coverage: 100%

Fixes #4605