### PR TITLE
Improve power profile contribution consistency

### DIFF
--- a/docs/source/contributing/measure/home-assistant-app.md
+++ b/docs/source/contributing/measure/home-assistant-app.md
@@ -37,7 +37,7 @@ Direct Hue, Tuya, Tasmota and myStrom controllers or meters, OCR, and manual pow
 
 ## Measurement device setup
 
-Configure the measurement device once from the app settings before creating a session. Select the power-meter type, choose or discover the sensor or plug, and enter a recognizable measurement-device name for generated profile metadata.
+Configure the measurement device once from the app settings before creating a session. Select the power-meter type, choose or discover the sensor or plug, and choose the meter name used by existing Powercalc profiles. The app loads these canonical names from the published library. You can still type a name when your meter is not listed or the library is temporarily unavailable.
 
 Use **Test connection** to sample the configured meter before starting a long run. For Home Assistant sensors, the app checks:
 
@@ -54,7 +54,7 @@ GitHub authentication can be configured in **Settings** before starting a measur
 
 The credential is stored separately in the app's private `/data` directory and is never included in session diagnostics. Home Assistant may include it in app backups. Disconnect locally and revoke the OAuth authorization or token in GitHub when it is no longer needed.
 
-After a completed light, speaker, fan, or charging measurement, the result page can prepare a profile contribution. Review the manufacturer, model, exact file list, JSON, commit message, and pull-request text before explicitly creating the pull request. The app creates or reuses your fork and submits one device to the Powercalc `master` branch.
+After a completed light, speaker, fan, or charging measurement, the result page can prepare a profile contribution. Enter the marketed product name without repeating the manufacturer. When the manufacturer already exists, use the link to its library page to compare names and metadata with existing profiles. Review the manufacturer, model, exact file list, JSON, commit message, and pull-request text before explicitly creating the pull request. The app creates or reuses your fork and submits one device to the Powercalc `master` branch.
 
 Manual contribution remains available at all times. You can still download every generated file and follow the contribution guide when GitHub is not configured, automatic contribution is unavailable, or an existing profile needs to be updated.
 

--- a/docs/source/contributing/measure/index.md
+++ b/docs/source/contributing/measure/index.md
@@ -49,7 +49,9 @@ Before spending time on a long measurement session, check that the device can be
 
 - Use the real manufacturer and exact model where possible.
 - Avoid profiles for generic white-label devices when the same identifier may refer to different hardware.
-- Add the full product name as an alias when the model directory uses only the model ID.
+- Use the marketed product name for `name`, without repeating the manufacturer. For example, use
+  `Hue White Ambiance GU10` for Signify rather than `Signify Hue White Ambiance GU10`.
+- Use `aliases` only for additional model identifiers used to discover the same hardware.
 
 When the device is not suitable for the public library, you can still use the generated files as a custom profile in your own Home Assistant installation.
 

--- a/docs/source/contributing/measure/output.md
+++ b/docs/source/contributing/measure/output.md
@@ -65,7 +65,7 @@ Profiles belong under:
 profile_library/<manufacturer>/<model>/
 ```
 
-Use the exact model identifier for the model directory, not the full marketing name. Add the full product name to `aliases` in `model.json` when it differs from the model identifier.
+Use the exact model identifier for the model directory, not the full marketing name. Set `name` in `model.json` to the marketed product name without repeating the manufacturer. For example, a Signify profile should use `Hue White Ambiance GU10`, not `Signify Hue White Ambiance GU10`. Reserve `aliases` for additional model identifiers that can discover the same hardware.
 
 For example:
 
@@ -92,8 +92,9 @@ Completed light, speaker, fan, and charging measurements that generated a valid 
 1. Open **Settings → GitHub** in Powercalc Measure.
 2. Connect your GitHub account with the device login, or supply a personal access token with public-repository access.
 3. Return to the completed measurement and select **Create pull request automatically**.
-4. Confirm the manufacturer and model details, then review the exact files, generated JSON, commit message, and pull-request text.
-5. Select **Create pull request** only after the preview is correct.
+4. Confirm the manufacturer and model details. For an existing manufacturer, follow the library link and compare the product naming and metadata with its other profiles.
+5. Review the exact files, generated JSON, commit message, and pull-request text.
+6. Select **Create pull request** only after the preview is correct.
 
 The app reuses your existing fork or creates one when needed. It then creates a focused branch and commit and opens a pull request against Powercalc. An existing profile with the same manufacturer and model is not replaced automatically; use the manual process when proposing an update.
 
@@ -135,7 +136,9 @@ Open the link printed by `git push`, create the pull request against Powercalc `
 Before submitting, confirm that:
 
 - the manufacturer and exact model identifier are correct;
+- the product name does not repeat the manufacturer;
 - the model directory uses the model ID rather than a generic family or marketing name;
+- `measure_device` uses an existing library value when the same meter is already listed;
 - `model.json` describes the measured product and calculation strategy correctly;
 - generated CSV files match the capabilities and modes of the device;
 - compressed `.csv.gz` files do not have uncompressed `.csv` duplicates;

--- a/utils/measure/frontend/e2e/happy-flow.spec.ts
+++ b/utils/measure/frontend/e2e/happy-flow.spec.ts
@@ -45,6 +45,21 @@ test("configures a measurement and reaches the setup check", async ({ page }) =>
   await expect(page.getByRole("button", { name: "Start measurement" })).toBeEnabled();
 });
 
+test("searches and selects a Home Assistant light with the shared combobox", async ({ page }) => {
+  await page.getByRole("button", { name: "New measurement" }).click();
+  await page.getByRole("button", { name: /Light bulb/ }).click();
+
+  const light = page.getByRole("combobox", { name: "Light" });
+  await light.fill("desk");
+  await expect(page.getByRole("listbox", { name: "Light options" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "Desk lamp · light.desk" })).toBeVisible();
+  await light.press("ArrowDown");
+  await light.press("Enter");
+
+  await expect(light).toHaveValue("Desk lamp · light.desk");
+  await expect(page.getByRole("listbox", { name: "Light options" })).toBeHidden();
+});
+
 test("starts the measurement and shows live events on the running screen", async ({ page }) => {
   await startAverageSetup(page);
   await page.getByRole("button", { name: "Check setup" }).click();
@@ -75,6 +90,17 @@ test("opens settings from setup with the configured power meter", async ({ page 
   await page.getByRole("button", { name: "Change power meter" }).click();
 
   await expect(page.getByRole("heading", { name: "Measurement defaults" })).toBeVisible();
-  await expect(page.getByLabel("Measurement device name")).toHaveValue("Shelly Plug S");
+  await expect(page.getByRole("combobox", { name: "Measurement device name" })).toHaveValue("Shelly Plug S");
   await expect(page.getByLabel("Type")).toHaveValue("hass");
+  await expect(page.getByRole("combobox", { name: "Power sensor" })).toHaveValue("Plug power · sensor.plug_power");
+
+  const deviceName = page.getByRole("combobox", { name: "Measurement device name" });
+  await deviceName.fill("plus");
+  await expect(page.getByRole("listbox", { name: "Measurement device name options" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "Shelly Plus Plug S" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "Aeotec ZWA023" })).toBeHidden();
+  await deviceName.press("ArrowDown");
+  await deviceName.press("Enter");
+  await expect(deviceName).toHaveValue("Shelly Plus Plug S");
+  await expect(page.getByRole("listbox", { name: "Measurement device name options" })).toBeHidden();
 });

--- a/utils/measure/frontend/e2e/mock-api.ts
+++ b/utils/measure/frontend/e2e/mock-api.ts
@@ -5,6 +5,7 @@ import type {
   EntityCatalog,
   EntityDescriptor,
   MeasureDefinition,
+  MeasureDeviceCatalog,
   MeasurementParameters,
   PlotCollection,
   PreflightResponse,
@@ -45,6 +46,9 @@ const voltages: EntityDescriptor[] = [{ entity_id: "sensor.plug_voltage", name: 
 const lights: EntityDescriptor[] = [{ entity_id: "light.desk", name: "Desk lamp", supported_modes: ["brightness"] }];
 
 const catalog: EntityCatalog = { lights, powers, voltages };
+const measureDevices: MeasureDeviceCatalog = {
+  devices: ["Aeotec ZWA023", "Kasa EP25", "Shelly Plug S", "Shelly Plus Plug S", "TP-Link Kasa KP115"],
+};
 
 const settings: AppSettings = {
   default_power_entity_id: "sensor.plug_power",
@@ -83,7 +87,7 @@ const lightDefinition: MeasureDefinition = {
   description: "Build a lookup-table power profile for a light.",
   icon: "💡",
   model_id_example: "LWA017",
-  product_name_example: "Philips Hue White Ambiance A60 E27",
+  product_name_example: "Hue White Ambiance A60 E27",
   parameters: [
     { name: "sleep_time", label: "Settle time (seconds)", step: "0.1", group: "Sampling" },
     { name: "bri_bri_steps", label: "Brightness mode step", group: "Profile resolution" },
@@ -225,6 +229,7 @@ const fixedRoutes = new Map<string, unknown>([
   ["contribution/auth", { connected: false }],
   ["contribution/status", { submitted: false }],
   ["measure-definitions", [averageDefinition, lightDefinition]],
+  ["library/measure-devices", measureDevices],
   ["dummy-load/calibration", null],
   ["preflight", preflight],
   ["sessions/session-running", startedSnapshot],

--- a/utils/measure/frontend/src/api-client.test.ts
+++ b/utils/measure/frontend/src/api-client.test.ts
@@ -148,6 +148,18 @@ describe("MeasureApiClient", () => {
     );
   });
 
+  it("loads canonical measurement-device names below the ingress prefix", async () => {
+    const catalog = { devices: ["Shelly Plug S", "TP-Link Kasa KP115"] };
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(catalog));
+    const client = new MeasureApiClient(fetcher, "http://ha.local/prefix/");
+
+    await expect(client.getMeasureDevices()).resolves.toEqual(catalog);
+    expect(fetcher).toHaveBeenCalledWith(
+      new URL("http://ha.local/prefix/api/library/measure-devices"),
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+  });
+
   it("discovers Shelly power meters below the ingress prefix", async () => {
     const discovery = { available: true, message: null, devices: [] };
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(discovery));

--- a/utils/measure/frontend/src/api-client.ts
+++ b/utils/measure/frontend/src/api-client.ts
@@ -20,6 +20,7 @@ import type {
   ErrorHelp,
   MeasurementRequest,
   MeasureDefinition,
+  MeasureDeviceCatalog,
   PlotCollection,
   PowerMeterDiagnostic,
   PreflightResponse,
@@ -63,6 +64,10 @@ export class MeasureApiClient {
 
   getMeasureDefinitions(): Promise<MeasureDefinition[]> {
     return this.request("api/measure-definitions");
+  }
+
+  getMeasureDevices(): Promise<MeasureDeviceCatalog> {
+    return this.request("api/library/measure-devices");
   }
 
   getSettings(): Promise<AppSettings> {

--- a/utils/measure/frontend/src/app-controller.test.ts
+++ b/utils/measure/frontend/src/app-controller.test.ts
@@ -49,6 +49,7 @@ function state(): MeasureAppState {
     files: [], plotCollection: { partial: false, plots: [], warnings: [] },
     logs: [], samples: [], lights: [], powers: [], voltages: [], definitions: [],
     dummyLoadCalibration: null, dummyLoadCalibrationError: "",
+    measureDevices: [], measureDevicesLoading: false, measureDevicesError: "",
     contributionBusy: false, contributionAuthBusy: false, contributionError: "", contributionAuthError: "",
     deviceEntities: {}, deviceEntityErrors: {}, testingPowerMeter: false,
     shellyDiscoveryDevices: [], discoveringShellys: false, shellyDiscoveryError: "",
@@ -59,6 +60,7 @@ function api(overrides: Partial<MeasureAppApi> = {}): MeasureAppApi {
   return {
     getCapabilities: async () => capabilities,
     getMeasureDefinitions: async () => [],
+    getMeasureDevices: async () => ({ devices: [] }),
     getSettings: async () => settings,
     getContributionAuth: async () => ({ connected: false }),
     getContributionStatus: async () => ({ state: "idle" as const }),
@@ -372,6 +374,33 @@ describe("measure app controller", () => {
     vi.useRealTimers();
   });
 
+  it("preserves contribution field errors for inline feedback", async () => {
+    const appState = state();
+    const controller = new MeasureAppController(appState, () => api({
+      previewContribution: async () => {
+        throw new ApiError(
+          "Product name must not start with the manufacturer",
+          422,
+          "invalid_metadata",
+          "product_name",
+        );
+      },
+    }), () => connection(), () => undefined);
+    appState.snapshot = { state: "completed", session_id: "session-1" };
+
+    await controller.previewContribution({
+      manufacturer_name: "Signify",
+      manufacturer_directory: "signify",
+      model_id: "LCT010",
+      product_name: "Signify Hue lamp",
+      contributor: "octocat",
+      notes: "",
+    });
+
+    expect(appState.contributionError).toBe("Product name must not start with the manufacturer");
+    expect(appState.contributionErrorField).toBe("product_name");
+  });
+
   it("backs off automatic device polling and stops when the code expires", async () => {
     vi.useFakeTimers();
     const appState = state();
@@ -648,6 +677,37 @@ describe("measure app controller", () => {
     controller.openSettings();
 
     expect(appState.settingsSection).toBeUndefined();
+  });
+
+  it("loads canonical measurement-device names without blocking settings", async () => {
+    const appState = state();
+    appState.view = "setup";
+    const controller = new MeasureAppController(appState, () => api({
+      getMeasureDevices: async () => ({ devices: ["Shelly Plug S", "TP-Link Kasa KP115"] }),
+    }), () => connection(), () => undefined);
+
+    controller.openSettings();
+
+    expect(appState.view).toBe("settings");
+    expect(appState.measureDevicesLoading).toBe(true);
+    await vi.waitFor(() => expect(appState.measureDevicesLoading).toBe(false));
+    expect(appState.measureDevices).toEqual(["Shelly Plug S", "TP-Link Kasa KP115"]);
+    expect(appState.measureDevicesError).toBe("");
+  });
+
+  it("keeps settings usable when measurement-device suggestions fail", async () => {
+    const appState = state();
+    appState.view = "setup";
+    const controller = new MeasureAppController(appState, () => api({
+      getMeasureDevices: async () => { throw new Error("Library unavailable"); },
+    }), () => connection(), () => undefined);
+
+    controller.openSettings();
+
+    await vi.waitFor(() => expect(appState.measureDevicesLoading).toBe(false));
+    expect(appState.view).toBe("settings");
+    expect(appState.measureDevices).toEqual([]);
+    expect(appState.measureDevicesError).toBe("Library unavailable");
   });
 
   it("discovers Shellys when opening Shelly settings and exposes unavailable discovery", async () => {

--- a/utils/measure/frontend/src/app-controller.ts
+++ b/utils/measure/frontend/src/app-controller.ts
@@ -58,6 +58,9 @@ export interface MeasureAppState {
   dummyLoadCalibration: DummyLoadCalibration | null;
   dummyLoadCalibrationError: string;
   settings?: AppSettings;
+  measureDevices: string[];
+  measureDevicesLoading: boolean;
+  measureDevicesError: string;
   contributionAuth?: ContributionAuthState;
   contributionDeviceFlow?: ContributionDeviceFlow;
   contributionDeviceStatus?: ContributionAuthDeviceStatus;
@@ -67,6 +70,7 @@ export interface MeasureAppState {
   contributionBusy: boolean;
   contributionAuthBusy: boolean;
   contributionError: string;
+  contributionErrorField?: string;
   contributionAuthError: string;
   definitions: MeasureDefinition[];
   deviceEntities: Record<string, EntityDescriptor[]>;
@@ -300,6 +304,7 @@ export class MeasureAppController {
     this.state.testingPowerMeter = false;
     this.state.view = "settings";
     this.changed();
+    void this.loadMeasureDevices();
     const meter = this.state.settings?.power_meter;
     if (meter && meterFor(meter).discoverable) void this.discoverShellys();
   }
@@ -308,6 +313,20 @@ export class MeasureAppController {
     this.clearError();
     this.state.view = this.settingsReturnView;
     this.changed();
+  }
+
+  private async loadMeasureDevices(): Promise<void> {
+    this.state.measureDevicesLoading = true;
+    this.state.measureDevicesError = "";
+    this.changed();
+    try {
+      this.state.measureDevices = (await this.api().getMeasureDevices()).devices;
+    } catch (error) {
+      this.state.measureDevicesError = message(error);
+    } finally {
+      this.state.measureDevicesLoading = false;
+      this.changed();
+    }
   }
 
   async testPowerMeter(settings: AppSettingsUpdate): Promise<void> {
@@ -669,6 +688,7 @@ export class MeasureAppController {
     this.state.contributionPreview = undefined;
     this.state.contributionResult = undefined;
     this.state.contributionError = "";
+    this.state.contributionErrorField = undefined;
     this.clearError();
   }
 
@@ -694,11 +714,13 @@ export class MeasureAppController {
   private async runContribution(work: () => Promise<void>): Promise<void> {
     this.state.contributionBusy = true;
     this.state.contributionError = "";
+    this.state.contributionErrorField = undefined;
     this.changed();
     try {
       await work();
     } catch (error) {
       this.state.contributionError = message(error);
+      this.state.contributionErrorField = error instanceof ApiError ? error.field ?? undefined : undefined;
     } finally {
       this.state.contributionBusy = false;
       this.changed();
@@ -749,6 +771,7 @@ export class MeasureAppController {
       this.state.contributionDraft = contribution.value;
       this.state.contributionPreview = undefined;
       this.state.contributionError = "";
+      this.state.contributionErrorField = undefined;
     } else {
       this.state.contributionDraft = undefined;
       this.state.contributionPreview = undefined;
@@ -775,6 +798,7 @@ export class MeasureAppController {
     if (status.state === "failed" && status.error && !this.state.contributionResult) {
       if (status.preview) this.state.contributionPreview = status.preview;
       this.state.contributionError = status.error;
+      this.state.contributionErrorField = undefined;
     }
   }
 }

--- a/utils/measure/frontend/src/components/app-shell.test.ts
+++ b/utils/measure/frontend/src/components/app-shell.test.ts
@@ -294,9 +294,10 @@ describe("app shell", () => {
     expect(element.shadowRoot?.querySelector(".sequence")).toBeNull();
     const settings = element.shadowRoot?.querySelector("measure-settings-view") as HTMLElement & { updateComplete: Promise<boolean>; shadowRoot: ShadowRoot };
     await settings.updateComplete;
-    const powerSensor = settings.shadowRoot.querySelector('select[name="default_power_entity_id"]') as HTMLSelectElement;
-    powerSensor.value = "sensor.other_power";
-    powerSensor.dispatchEvent(new Event("change"));
+    const powerSensor = settings.shadowRoot.querySelector('measure-combobox[name="default_power_entity_id"]') as HTMLElement;
+    powerSensor.dispatchEvent(new CustomEvent("combobox-change", {
+      detail: { value: "sensor.other_power" }, bubbles: true, composed: true,
+    }));
     await settings.updateComplete;
     await element.updateComplete;
 

--- a/utils/measure/frontend/src/components/app-shell.ts
+++ b/utils/measure/frontend/src/components/app-shell.ts
@@ -58,6 +58,9 @@ export class AppShell extends LitElement implements MeasureAppState {
   dummyLoadCalibration: DummyLoadCalibration | null = null;
   dummyLoadCalibrationError = "";
   settings?: AppSettings;
+  measureDevices: string[] = [];
+  measureDevicesLoading = false;
+  measureDevicesError = "";
   contributionAuth?: ContributionAuthState;
   contributionDeviceFlow?: ContributionDeviceFlow;
   contributionDeviceStatus?: ContributionAuthDeviceStatus;
@@ -67,6 +70,7 @@ export class AppShell extends LitElement implements MeasureAppState {
   contributionBusy = false;
   contributionAuthBusy = false;
   contributionError = "";
+  contributionErrorField?: string;
   contributionAuthError = "";
   definitions: MeasureDefinition[] = [];
   deviceEntities: Record<string, EntityDescriptor[]> = {};
@@ -189,6 +193,7 @@ export class AppShell extends LitElement implements MeasureAppState {
     return html`
       <measure-settings-view
         .powers=${this.powers} .settings=${this.settings} .capabilities=${this.capabilities}
+        .measureDevices=${this.measureDevices} .measureDevicesLoading=${this.measureDevicesLoading} .measureDevicesError=${this.measureDevicesError}
         .busy=${this.busy} .testing=${this.testingPowerMeter} .testResult=${this.powerMeterTestResult} .errorMessage=${this.errorMessage}
         .shellyDiscoveryDevices=${this.shellyDiscoveryDevices} .discoveringShellys=${this.discoveringShellys}
         .shellyDiscoveryError=${this.shellyDiscoveryError} .shellyDiscoveryAvailable=${this.shellyDiscoveryAvailable}
@@ -251,6 +256,7 @@ export class AppShell extends LitElement implements MeasureAppState {
         .contributionAuth=${this.contributionAuth} .contributionDraft=${this.contributionDraft}
         .contributionPreview=${this.contributionPreview} .contributionResult=${this.contributionResult}
         .contributionBusy=${this.contributionBusy} .contributionError=${this.contributionError}
+        .contributionErrorField=${this.contributionErrorField}
         @sessions=${this.showSessions} @new=${() => this.controller.newMeasurement()} @resume=${() => void this.controller.resume()}
         @open-settings=${this.openSettings}
         @contribution-preview=${(event: CustomEvent<ContributionPreviewRequest>) => void this.controller.previewContribution(event.detail)}

--- a/utils/measure/frontend/src/components/combobox.test.ts
+++ b/utils/measure/frontend/src/components/combobox.test.ts
@@ -1,0 +1,64 @@
+import type { Combobox } from "./combobox";
+import "./combobox";
+
+function createCombobox(allowCustom = false): { form: HTMLFormElement; picker: Combobox } {
+  const form = document.createElement("form");
+  const picker = document.createElement("measure-combobox");
+  picker.name = "device";
+  picker.label = "Device";
+  picker.placeholder = "Search devices";
+  picker.required = true;
+  picker.allowCustom = allowCustom;
+  picker.options = [
+    { value: "sensor.office", label: "Office plug · sensor.office" },
+    { value: "sensor.kitchen", label: "Kitchen plug · sensor.kitchen" },
+  ];
+  const fallback = document.createElement("input");
+  fallback.type = "hidden";
+  fallback.name = "device";
+  fallback.slot = "value";
+  picker.append(fallback);
+  form.append(picker);
+  document.body.append(form);
+  return { form, picker };
+}
+
+describe("combobox", () => {
+  it("filters, supports keyboard selection, and contributes the selected value to its form", async () => {
+    const { form, picker } = createCombobox();
+    await picker.updateComplete;
+    const input = picker.shadowRoot?.querySelector("input") as HTMLInputElement;
+
+    input.focus();
+    input.value = "kitchen";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await picker.updateComplete;
+
+    expect([...picker.shadowRoot?.querySelectorAll(".option") ?? []].map((option) => option.textContent?.trim())).toEqual([
+      "Kitchen plug · sensor.kitchen",
+    ]);
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    await picker.updateComplete;
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await picker.updateComplete;
+
+    expect(picker.value).toBe("sensor.kitchen");
+    expect(input.value).toBe("Kitchen plug · sensor.kitchen");
+    expect(new FormData(form).get("device")).toBe("sensor.kitchen");
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("accepts a custom value when enabled", async () => {
+    const { form, picker } = createCombobox(true);
+    await picker.updateComplete;
+    const input = picker.shadowRoot?.querySelector("input") as HTMLInputElement;
+
+    input.value = "My calibrated meter";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await picker.updateComplete;
+
+    expect(picker.value).toBe("My calibrated meter");
+    expect(picker.shadowRoot?.textContent).toContain("saved as a custom entry");
+    expect(new FormData(form).get("device")).toBe("My calibrated meter");
+  });
+});

--- a/utils/measure/frontend/src/components/combobox.ts
+++ b/utils/measure/frontend/src/components/combobox.ts
@@ -1,0 +1,245 @@
+import { LitElement, css, html, nothing, type PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { sharedStyles } from "../styles";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+@customElement("measure-combobox")
+export class Combobox extends LitElement {
+  static readonly formAssociated = true;
+
+  @property({ type: String }) name = "";
+  @property({ type: String }) label = "";
+  @property({ type: String }) value = "";
+  @property({ type: String }) placeholder = "";
+  @property({ type: String }) hint = "";
+  @property({ attribute: false }) options: ComboboxOption[] = [];
+  @property({ type: Boolean }) required = false;
+  @property({ type: Boolean }) allowCustom = false;
+  @property({ type: Boolean }) disabled = false;
+
+  @state() private query = "";
+  @state() private filter = "";
+  @state() private open = false;
+  @state() private active = -1;
+
+  private readonly internals = this.createInternals();
+
+  static readonly styles = [sharedStyles, css`
+    :host { display: grid; gap: 0.4rem; min-width: 0; }
+    .control { position: relative; min-width: 0; }
+    input { padding-right: 2.75rem; }
+    .toggle {
+      position: absolute; inset: 1px 1px 1px auto; width: 2.65rem; min-height: 0; padding: 0; border: 0;
+      border-radius: 0 8px 8px 0; background: transparent; color: var(--muted); font-size: 0.8rem;
+    }
+    .toggle:hover:not(:disabled) { border: 0; background: color-mix(in srgb, var(--signal) 10%, transparent); transform: none; }
+    .menu {
+      position: absolute; z-index: 20; top: calc(100% + 0.35rem); right: 0; left: 0; max-height: 260px;
+      overflow-y: auto; padding: 0.35rem; border: 1px solid var(--line); border-radius: 10px;
+      background: var(--surface-raised); box-shadow: 0 14px 34px rgb(0 0 0 / 38%);
+    }
+    .option { padding: 0.62rem 0.7rem; border-radius: 7px; color: var(--ink); cursor: pointer; font-size: 0.82rem; line-height: 1.25; }
+    .option:hover, .option.active { background: color-mix(in srgb, var(--signal) 18%, transparent); color: var(--signal-strong); }
+    .option.disabled { opacity: 0.45; cursor: not-allowed; }
+    .empty { margin: 0; padding: 0.7rem; color: var(--muted); font-size: 0.78rem; line-height: 1.4; }
+  `];
+
+  protected willUpdate(changed: PropertyValues<this>) {
+    if (changed.has("value") || changed.has("options")) this.query = this.displayValue(this.value);
+  }
+
+  protected updated(): void {
+    this.syncFormControl();
+  }
+
+  render() {
+    const options = this.filteredOptions();
+    return html`
+      <label for="combobox-input"><span>${this.label}</span></label>
+      <div class="control" @focusout=${this.focusOut}>
+        <input
+          id="combobox-input"
+          .value=${this.query}
+          ?required=${this.required}
+          ?disabled=${this.disabled}
+          autocomplete="off"
+          placeholder=${this.placeholder}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls="combobox-options"
+          aria-expanded=${this.open ? "true" : "false"}
+          aria-activedescendant=${this.active >= 0 ? `combobox-option-${this.active}` : nothing}
+          @focus=${this.openOptions}
+          @input=${this.inputChanged}
+          @keydown=${this.keydown}
+        />
+        <button class="toggle" type="button" aria-label=${`Show ${this.label.toLowerCase()} options`} ?disabled=${this.disabled} @click=${this.toggle}>
+          ${this.open ? "▲" : "▼"}
+        </button>
+        ${this.open ? html`
+          <div id="combobox-options" class="menu" role="listbox" aria-label=${`${this.label} options`}>
+            ${options.length
+              ? options.map((option, index) => html`
+                  <div
+                    id=${`combobox-option-${index}`}
+                    class=${this.optionClass(option, index)}
+                    role="option"
+                    aria-selected=${index === this.active ? "true" : "false"}
+                    aria-disabled=${option.disabled ? "true" : "false"}
+                    @mousedown=${(event: MouseEvent) => event.preventDefault()}
+                    @mousemove=${() => this.activateOption(option, index)}
+                    @click=${() => this.select(option)}
+                  >${option.label}</div>
+                `)
+              : html`<p class="empty">${this.allowCustom
+                ? "No existing option matches. This value will be saved as a custom entry."
+                : "No matching options."}</p>`}
+          </div>
+        ` : nothing}
+      </div>
+      ${this.hint ? html`<small class="field-hint">${this.hint}</small>` : nothing}
+      <slot name="value" hidden></slot>
+    `;
+  }
+
+  private filteredOptions(): ComboboxOption[] {
+    const terms = this.filter.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+    if (!terms.length) return this.options;
+    return this.options.filter((option) => {
+      const text = `${option.label} ${option.value}`.toLocaleLowerCase();
+      return terms.every((term) => text.includes(term));
+    });
+  }
+
+  private displayValue(value: string): string {
+    return this.options.find((option) => option.value === value)?.label ?? value;
+  }
+
+  private hiddenInput(): HTMLInputElement | null {
+    return this.querySelector('input[slot="value"]');
+  }
+
+  private createInternals(): ElementInternals | undefined {
+    if (typeof this.attachInternals !== "function") return undefined;
+    const internals = this.attachInternals();
+    return typeof internals.setFormValue === "function" ? internals : undefined;
+  }
+
+  private syncFormControl(): void {
+    this.internals?.setFormValue(this.disabled || !this.name ? null : this.value);
+    const input = this.renderRoot.querySelector<HTMLInputElement>("input");
+    const missing = !this.disabled && this.required && !this.value;
+    this.internals?.setValidity(
+      missing ? { valueMissing: true } : {},
+      missing ? `Select or enter ${this.label.toLowerCase()}.` : "",
+      input ?? undefined,
+    );
+    const hidden = this.hiddenInput();
+    if (hidden) {
+      hidden.value = this.value;
+      hidden.disabled = Boolean(this.internals) || this.disabled;
+    }
+  }
+
+  private openOptions() {
+    this.filter = "";
+    this.open = true;
+    this.active = -1;
+  }
+
+  private toggle() {
+    this.open = !this.open;
+    if (this.open) this.renderRoot.querySelector<HTMLInputElement>("input")?.focus();
+  }
+
+  private inputChanged(event: Event) {
+    this.query = (event.currentTarget as HTMLInputElement).value;
+    this.filter = this.query;
+    this.open = true;
+    this.active = -1;
+    if (this.allowCustom) this.commit(this.query, false);
+  }
+
+  private keydown(event: KeyboardEvent) {
+    const options = this.filteredOptions();
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      this.open = true;
+      const available = options.map((option, index) => ({ option, index })).filter(({ option }) => !option.disabled);
+      if (!available.length) return;
+      const current = available.findIndex(({ index }) => index === this.active);
+      const increment = event.key === "ArrowDown" ? 1 : -1;
+      const next = current < 0
+        ? (event.key === "ArrowDown" ? 0 : available.length - 1)
+        : (current + increment + available.length) % available.length;
+      this.active = available[next]!.index;
+      void this.updateComplete.then(() => this.renderRoot.querySelector(`#combobox-option-${this.active}`)?.scrollIntoView?.({ block: "nearest" }));
+      return;
+    }
+    if (event.key === "Enter" && this.open && this.active >= 0) {
+      event.preventDefault();
+      const option = options[this.active];
+      if (option) this.select(option);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.closeAndRestore();
+    }
+  }
+
+  private select(option: ComboboxOption) {
+    if (option.disabled) return;
+    this.query = option.label;
+    this.filter = "";
+    this.commit(option.value, true);
+    this.open = false;
+    this.active = -1;
+    this.renderRoot.querySelector<HTMLInputElement>("input")?.focus();
+  }
+
+  private activateOption(option: ComboboxOption, index: number): void {
+    if (!option.disabled) this.active = index;
+  }
+
+  private commit(value: string, emitChange: boolean) {
+    this.value = value;
+    const hidden = this.hiddenInput();
+    if (hidden) {
+      hidden.value = value;
+      if (emitChange) hidden.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+    }
+    this.syncFormControl();
+    this.dispatchEvent(new CustomEvent("combobox-change", { detail: { value }, bubbles: true, composed: true }));
+  }
+
+  private focusOut(event: FocusEvent) {
+    if (event.relatedTarget instanceof Node && this.containsFocusTarget(event.relatedTarget)) return;
+    this.closeAndRestore();
+  }
+
+  private containsFocusTarget(target: Node): boolean {
+    return this.renderRoot.contains(target);
+  }
+
+  private closeAndRestore() {
+    this.open = false;
+    this.active = -1;
+    if (!this.allowCustom) this.query = this.displayValue(this.value);
+  }
+
+  private optionClass(option: ComboboxOption, index: number): string {
+    return ["option", index === this.active ? "active" : "", option.disabled ? "disabled" : ""].filter(Boolean).join(" ");
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "measure-combobox": Combobox;
+  }
+}

--- a/utils/measure/frontend/src/components/fields.ts
+++ b/utils/measure/frontend/src/components/fields.ts
@@ -1,5 +1,7 @@
 import { html, nothing } from "lit";
 import type { EntityDescriptor } from "../types";
+import type { ComboboxOption } from "./combobox";
+import "./combobox";
 
 /**
  * Form controls shared by the views that render inputs. They are plain functions rather than a
@@ -60,11 +62,22 @@ export interface EntitySelectOptions {
 
 export function entitySelect(name: string, label: string, entities: EntityDescriptor[], options: EntitySelectOptions = {}) {
   const { selected = "", required = false, onChange = null } = options;
+  const comboboxOptions: ComboboxOption[] = entities.map((entity) => ({
+    value: entity.entity_id,
+    label: `${entity.name} · ${entity.entity_id}`,
+  }));
+  if (!required) comboboxOptions.unshift({ value: "", label: "None" });
   return html`
-    <label><span>${label}</span><select name=${name} ?required=${required} @change=${onChange}>
-      <option value="">${required ? "Select an entity" : "None"}</option>
-      ${entities.map((entity) => entityOption(entity, entity.entity_id === selected))}
-    </select></label>
+    <measure-combobox
+      name=${name}
+      label=${label}
+      .value=${selected}
+      .options=${comboboxOptions}
+      placeholder=${`Search ${label.toLowerCase()} entities`}
+      ?required=${required}
+    >
+      <input slot="value" type="hidden" name=${name} .value=${selected} @change=${onChange} />
+    </measure-combobox>
   `;
 }
 

--- a/utils/measure/frontend/src/components/result-view.test.ts
+++ b/utils/measure/frontend/src/components/result-view.test.ts
@@ -1,4 +1,4 @@
-import type { SessionSnapshot } from "../types";
+import type { ContributionPreview, SessionSnapshot } from "../types";
 import "./result-view";
 
 describe("result view", () => {
@@ -100,6 +100,7 @@ describe("result view", () => {
         base_branch: string;
         manufacturer_name: string;
         manufacturer_directory: string;
+        manufacturer_library_url?: string;
         model_id: string;
         product_name: string;
         contributor: string;
@@ -129,6 +130,7 @@ describe("result view", () => {
       base_branch: "master",
       manufacturer_name: "Signify",
       manufacturer_directory: "signify",
+      manufacturer_library_url: "https://library.powercalc.nl/manufacturers/signify",
       model_id: "LCT010",
       product_name: "Hue lamp",
       contributor: "octocat",
@@ -164,6 +166,9 @@ describe("result view", () => {
     expect(automatic?.textContent).toContain("profile_library/signify/LCT010/model.json");
     expect(automatic?.textContent).toContain("Add Signify LCT010");
     expect(automatic?.textContent).not.toContain("aliases");
+    const manufacturerLink = element.shadowRoot.querySelector(".manufacturer-library-link") as HTMLAnchorElement;
+    expect(manufacturerLink.href).toBe("https://library.powercalc.nl/manufacturers/signify");
+    expect(element.shadowRoot.textContent).toContain("without repeating the manufacturer");
 
     const previewed = new Promise<unknown>((resolve) => element.addEventListener("contribution-preview", (event) => resolve((event as CustomEvent).detail)));
     (element.shadowRoot.querySelector('input[name="manufacturer_directory"]') as HTMLInputElement).value = "philips";
@@ -185,6 +190,48 @@ describe("result view", () => {
     await element.updateComplete;
     expect(element.shadowRoot.querySelector(".contribution-auto")).toBeNull();
     expect(element.shadowRoot.querySelector(".contribution-next")?.textContent).toContain("Read the contribution guide");
+  });
+
+  it("shows product-name contribution errors beside the naming guidance", async () => {
+    const element = document.createElement("measure-result-view") as HTMLElement & {
+      snapshot: SessionSnapshot;
+      contributionAuth: { connected: boolean; identity: { login: string } };
+      contributionDraft: ContributionPreview;
+      contributionError: string;
+      contributionErrorField: string;
+      updateComplete: Promise<boolean>;
+      shadowRoot: ShadowRoot;
+    };
+    element.snapshot = { state: "completed" };
+    element.contributionAuth = { connected: true, identity: { login: "octocat" } };
+    element.contributionDraft = {
+      eligible: true,
+      repository: "bramstroker/homeassistant-powercalc",
+      base_branch: "master",
+      manufacturer_name: "Signify",
+      manufacturer_directory: "",
+      model_id: "LCT010",
+      product_name: "Signify Hue lamp",
+      contributor: "octocat",
+      device_info: {},
+      home_assistant: {},
+      notes: "",
+      files: [],
+      commit_message: "",
+      pr_title: "",
+      pr_body: "",
+      branch_name: "",
+      warnings: [],
+    };
+    element.contributionError = "Product name must not start with the manufacturer";
+    element.contributionErrorField = "product_name";
+    document.body.append(element);
+    await element.updateComplete;
+
+    const productName = element.shadowRoot.querySelector('input[name="product_name"]') as HTMLInputElement;
+    expect(productName.getAttribute("aria-invalid")).toBe("true");
+    expect(productName.parentElement?.textContent).toContain(element.contributionError);
+    expect(element.shadowRoot.querySelector(".manufacturer-library-link")).toBeNull();
   });
 
   it("asks to open settings on the GitHub section when GitHub is not connected", async () => {

--- a/utils/measure/frontend/src/components/result-view.ts
+++ b/utils/measure/frontend/src/components/result-view.ts
@@ -114,6 +114,9 @@ export class ResultView extends LitElement {
   @property({ type: String })
   contributionError = "";
 
+  @property({ type: String })
+  contributionErrorField?: string;
+
   @state()
   contributionMethod?: ContributionMethodId;
 
@@ -166,6 +169,7 @@ export class ResultView extends LitElement {
     .confirm-row { display: flex; align-items: flex-start; gap: 0.55rem; color: var(--muted); font-size: 0.82rem; }
     .confirm-row input { width: auto; margin-top: 0.2rem; }
     .success-link { display: inline-flex; margin-top: 0.75rem; color: var(--good); font-weight: 700; }
+    .manufacturer-library-link { justify-self: start; font-size: 0.8rem; }
     .auth-shortcut { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; justify-content: space-between; padding: 0.8rem; border: 1px solid var(--line); border-radius: 10px; background: var(--well); }
     ul { list-style: none; margin: 0.65rem 0 0; padding: 0; border-top: 1px solid var(--line); }
     li { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 1rem; padding: 0.8rem 0; border-bottom: 1px solid var(--line); }
@@ -362,9 +366,15 @@ export class ResultView extends LitElement {
               placeholder: "Derived from the manufacturer when left empty",
             })}
             ${this.input("model_id", "Model ID", draft.model_id)}
-            ${this.input("product_name", "Product name", draft.product_name)}
+            ${this.input("product_name", "Product name", draft.product_name, {
+              hint: "Enter the marketed model name without repeating the manufacturer, for example “Hue White Ambiance GU10” rather than “Signify Hue White Ambiance GU10”.",
+              error: this.contributionErrorField === "product_name" ? this.contributionError : "",
+            })}
             ${this.input("contributor", "Contributor display", draft.contributor)}
           </div>
+          ${draft.manufacturer_library_url
+            ? html`<a class="manufacturer-library-link" href=${draft.manufacturer_library_url} target="_blank" rel="noopener noreferrer">View existing manufacturer profiles <span aria-hidden="true">↗</span></a>`
+            : nothing}
           <label class="notes-field">
             <span>Notes</span>
             <textarea name="notes" .value=${draft.notes}></textarea>
@@ -379,7 +389,9 @@ export class ResultView extends LitElement {
         ${this.contributionPreview
           ? this.renderPreview(this.contributionPreview)
           : html`<p class="muted">Refresh the preview to validate the profile against the latest Powercalc library before confirming.</p>`}
-        ${this.contributionError ? html`<p class="notice error" role="alert">${this.contributionError}</p>` : nothing}
+        ${this.contributionError && this.contributionErrorField !== "product_name"
+          ? html`<p class="notice error" role="alert">${this.contributionError}</p>`
+          : nothing}
         ${this.renderContributionResult()}
       </div>
     `;
@@ -484,10 +496,17 @@ ${preview.pr_body}</pre>
     name: keyof ContributionPreviewRequest,
     label: string,
     value: string,
-    options: { required?: boolean; placeholder?: string } = {},
+    options: { required?: boolean; placeholder?: string; hint?: string; error?: string } = {},
   ) {
-    const { required = true, placeholder = "" } = options;
-    return html`<label><span>${label}</span><input name=${name} .value=${value} ?required=${required} placeholder=${placeholder} autocomplete="off" /></label>`;
+    const { required = true, placeholder = "", hint = "", error = "" } = options;
+    return html`
+      <label>
+        <span>${label}</span>
+        <input name=${name} .value=${value} ?required=${required} placeholder=${placeholder} autocomplete="off" aria-invalid=${error ? "true" : "false"} />
+        ${hint ? html`<small class="field-hint">${hint}</small>` : nothing}
+        ${error ? html`<small class="field-hint error" role="alert">${error}</small>` : nothing}
+      </label>
+    `;
   }
 
   private collectContribution(): ContributionPreviewRequest | null {

--- a/utils/measure/frontend/src/components/settings-view.test.ts
+++ b/utils/measure/frontend/src/components/settings-view.test.ts
@@ -7,11 +7,13 @@ describe("settings view", () => {
     const element = document.createElement("measure-settings-view") as HTMLElement & {
       powers: EntityDescriptor[];
       settings: AppSettings;
+      measureDevices: string[];
       updateComplete: Promise<boolean>;
       shadowRoot: ShadowRoot;
     };
     element.powers = [{ entity_id: "sensor.plug_power", name: "Plug power", unit: "W" }];
     element.settings = defaultSettings;
+    element.measureDevices = ["Shelly Plug S", "TP-Link Kasa KP115"];
     document.body.append(element);
     await element.updateComplete;
 
@@ -25,22 +27,63 @@ describe("settings view", () => {
     expect(sectionButtons[1]?.classList.contains("active")).toBe(true);
     expect(element.shadowRoot.querySelector<HTMLElement>('[aria-labelledby="power-meter-title"]')?.hidden).toBe(true);
     expect(element.shadowRoot.querySelector<HTMLElement>('[aria-labelledby="measure-tuning-title"]')?.hidden).toBe(false);
+    sectionButtons[0]?.click();
+    await element.updateComplete;
 
     const saved = new Promise<AppSettings>((resolve) => {
       element.addEventListener("save", (event) => resolve((event as CustomEvent<AppSettings>).detail));
     });
-    const select = element.shadowRoot.querySelector('select[name="default_power_entity_id"]') as HTMLSelectElement;
-    const measureDevice = element.shadowRoot.querySelector('input[name="default_measure_device"]') as HTMLInputElement;
+    const powerSensor = element.shadowRoot.querySelector('measure-combobox[name="default_power_entity_id"]') as HTMLElement;
+    const measureDevicePicker = element.shadowRoot.querySelector('measure-combobox[name="default_measure_device"]') as HTMLElement & { updateComplete: Promise<boolean>; shadowRoot: ShadowRoot };
+    const measureDevice = measureDevicePicker.shadowRoot.querySelector("input") as HTMLInputElement;
     expect(measureDevice.required).toBe(true);
-    measureDevice.value = "Shelly Plug S";
-    expect(select.required).toBe(true);
-    expect(select.options[0]?.textContent).toBe("Select a power sensor");
-    select.value = "sensor.plug_power";
+    measureDevice.focus();
+    await measureDevicePicker.updateComplete;
+    expect([...measureDevicePicker.shadowRoot.querySelectorAll(".option")].map((option) => option.textContent?.trim())).toEqual([
+      "Shelly Plug S",
+      "TP-Link Kasa KP115",
+    ]);
+    measureDevice.value = "shelly";
+    measureDevice.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await measureDevicePicker.updateComplete;
+    expect(measureDevicePicker.shadowRoot.querySelectorAll(".option")).toHaveLength(1);
+    measureDevice.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    await measureDevicePicker.updateComplete;
+    measureDevice.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await measureDevicePicker.updateComplete;
+    expect(measureDevice.value).toBe("Shelly Plug S");
+    expect(measureDevicePicker.shadowRoot.querySelector(".menu")).toBeNull();
+    expect((powerSensor.shadowRoot?.querySelector("input") as HTMLInputElement).required).toBe(true);
+    powerSensor.dispatchEvent(new CustomEvent("combobox-change", {
+      detail: { value: "sensor.plug_power" }, bubbles: true, composed: true,
+    }));
+    await element.updateComplete;
     (element.shadowRoot.querySelector("form") as HTMLFormElement).requestSubmit();
 
     const settings = await saved;
     expect(settings.default_power_entity_id).toBe("sensor.plug_power");
+    expect(settings.default_measure_device).toBe("Shelly Plug S");
     expect(settings.measurement_defaults).toEqual(measurementDefaults);
+  });
+
+  it("keeps manual measurement-device entry available when library suggestions fail", async () => {
+    const element = document.createElement("measure-settings-view") as HTMLElement & {
+      settings: AppSettings;
+      measureDevicesError: string;
+      updateComplete: Promise<boolean>;
+      shadowRoot: ShadowRoot;
+    };
+    element.settings = defaultSettings;
+    element.measureDevicesError = "Library unavailable";
+    document.body.append(element);
+    await element.updateComplete;
+
+    const picker = element.shadowRoot.querySelector('measure-combobox[name="default_measure_device"]') as HTMLElement & { shadowRoot: ShadowRoot };
+    const input = picker.shadowRoot.querySelector("input") as HTMLInputElement;
+    input.value = "My calibrated meter";
+
+    expect(input.disabled).toBe(false);
+    expect(element.shadowRoot.textContent).toContain("manual entry still works");
   });
 
   it("shows fast test mode only in developer mode and saves the toggle", async () => {
@@ -424,9 +467,10 @@ describe("settings power meter test", () => {
     document.body.append(element);
     await element.updateComplete;
 
-    const powerSensor = element.shadowRoot.querySelector('select[name="default_power_entity_id"]') as HTMLSelectElement;
-    powerSensor.value = "sensor.other_power";
-    powerSensor.dispatchEvent(new Event("change"));
+    const powerSensor = element.shadowRoot.querySelector('measure-combobox[name="default_power_entity_id"]') as HTMLElement;
+    powerSensor.dispatchEvent(new CustomEvent("combobox-change", {
+      detail: { value: "sensor.other_power" }, bubbles: true, composed: true,
+    }));
     await element.updateComplete;
     expect(element.shadowRoot.querySelector("measure-power-meter-diagnostic")).toBeNull();
 

--- a/utils/measure/frontend/src/components/settings-view.ts
+++ b/utils/measure/frontend/src/components/settings-view.ts
@@ -1,4 +1,4 @@
-import { LitElement, css, html, nothing, svg } from "lit";
+import { LitElement, css, html, nothing, svg, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createRef, ref } from "lit/directives/ref.js";
 import type { AppSettings, AppSettingsUpdate, Capabilities, ContributionAuthDeviceStatus, ContributionAuthState, ContributionDeviceFlow, EntityDescriptor, MeasureParameterName, PowerMeterDiagnostic, PowerMeterType, SettingsSection, ShellyDiscoveryDevice } from "../types";
@@ -6,6 +6,8 @@ import { DEFAULT_SHELLY_USERNAME, POWER_METER_LIST, meterFor, settingsFromForm }
 import { formRaw, formText, formTextOrNull } from "../form";
 import { emit } from "../events";
 import { sharedStyles } from "../styles";
+import type { ComboboxOption } from "./combobox";
+import "./combobox";
 import "./power-meter-diagnostic";
 
 interface SettingsSectionDescriptor {
@@ -49,6 +51,15 @@ export class SettingsView extends LitElement {
 
   @property({ attribute: false })
   capabilities?: Capabilities;
+
+  @property({ attribute: false })
+  measureDevices: string[] = [];
+
+  @property({ type: Boolean })
+  measureDevicesLoading = false;
+
+  @property({ type: String })
+  measureDevicesError = "";
 
   @state()
   meter?: PowerMeterType;
@@ -123,6 +134,12 @@ export class SettingsView extends LitElement {
 
   private readonly form = createRef<HTMLFormElement>();
 
+  @state()
+  private measureDeviceValue = "";
+
+  @state()
+  private hassPowerEntity = "";
+
   static readonly styles = [sharedStyles, css`
     :host { display: block; min-width: 0; max-width: 100%; }
     form { display: grid; gap: 1rem; min-width: 0; max-width: 100%; margin-top: 1rem; }
@@ -181,7 +198,11 @@ export class SettingsView extends LitElement {
     }
   `];
 
-  willUpdate() {
+  willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has("settings")) {
+      this.measureDeviceValue = this.settings?.default_measure_device ?? "";
+      this.hassPowerEntity = this.settings?.default_power_entity_id ?? "";
+    }
     // Honour a requested section (e.g. opened from the GitHub contribution shortcut) once,
     // while still letting the user switch sections afterwards.
     if (!this.appliedInitialSection && this.initialSection) {
@@ -215,10 +236,24 @@ export class SettingsView extends LitElement {
               <h3 id="power-meter-title">Power meter</h3>
               <p class="muted">Choose where readings come from and set the default measurement hardware.</p>
               <div class="section-fields">
-                <label>
-                  <span>Measurement device name</span>
-                  <input name="default_measure_device" .value=${this.settings?.default_measure_device ?? ""} required autocomplete="off" placeholder="e.g. Shelly Plug S" />
-                </label>
+                <measure-combobox
+                  name="default_measure_device"
+                  label="Measurement device name"
+                  .value=${this.measureDeviceValue}
+                  .options=${this.measureDeviceOptions()}
+                  placeholder="e.g. Shelly Plug S"
+                  .hint=${this.measureDevicesLoading
+                    ? "Loading names used by existing Powercalc profiles…"
+                    : "Choose an existing name for consistent profile metadata, or type a name when your meter is not listed."}
+                  required
+                  allowCustom
+                  @combobox-change=${this.measureDeviceChanged}
+                >
+                  <input slot="value" type="hidden" name="default_measure_device" .value=${this.measureDeviceValue} />
+                </measure-combobox>
+                ${this.measureDevicesError
+                  ? html`<small class="field-hint error" role="status">Library suggestions are unavailable; manual entry still works.</small>`
+                  : nothing}
                 <label>
                   <span>Type</span>
                   <select name="power_meter" @change=${this.powerMeterChanged}>
@@ -282,6 +317,20 @@ export class SettingsView extends LitElement {
     `;
   }
 
+  private measureDeviceOptions(): ComboboxOption[] {
+    if (this.measureDevicesLoading || this.measureDevicesError) return [];
+    return this.measureDevices.map((device) => ({ value: device, label: device }));
+  }
+
+  private measureDeviceChanged(event: CustomEvent<{ value: string }>): void {
+    this.measureDeviceValue = event.detail.value;
+  }
+
+  private hassPowerEntityChanged(event: CustomEvent<{ value: string }>): void {
+    this.hassPowerEntity = event.detail.value;
+    this.powerMeterSettingsChanged();
+  }
+
   /**
    * The inputs each meter needs. Kept here rather than in the registry because they are bound to
    * this view's handlers and credential state; the record's type still names any meter left out.
@@ -297,16 +346,22 @@ export class SettingsView extends LitElement {
   }
 
   private renderHassFields() {
-    const selected = this.settings?.default_power_entity_id ?? "";
-    return html`<label>
-      <span>Power sensor</span>
-      <select name="default_power_entity_id" required @change=${this.powerMeterSettingsChanged}>
-        <option value="">Select a power sensor</option>
-        ${this.powers.map((entity) => html`
-          <option value=${entity.entity_id} ?selected=${entity.entity_id === selected}>${entity.name} · ${entity.entity_id}</option>
-        `)}
-      </select>
-    </label>`;
+    const options = this.powers.map((entity) => ({
+      value: entity.entity_id,
+      label: `${entity.name} · ${entity.entity_id}`,
+    }));
+    return html`
+      <measure-combobox
+        name="default_power_entity_id"
+        label="Power sensor"
+        .value=${this.hassPowerEntity}
+        .options=${options}
+        placeholder="Search power sensors"
+        required
+        @combobox-change=${this.hassPowerEntityChanged}
+      >
+        <input slot="value" type="hidden" name="default_power_entity_id" .value=${this.hassPowerEntity} />
+      </measure-combobox>`;
   }
 
   private renderTestRow() {

--- a/utils/measure/frontend/src/components/setup-view.test.ts
+++ b/utils/measure/frontend/src/components/setup-view.test.ts
@@ -2,6 +2,23 @@ import type { MeasureDefinition, MeasureParameter, MeasurementRequest } from "..
 import "./setup-view";
 import { SetupViewElement, capabilities, definitions, lightDefinition, lights } from "./test-fixtures";
 
+interface TestCombobox extends HTMLElement {
+  label: string;
+  options: Array<{ value: string; label: string }>;
+  updateComplete: Promise<boolean>;
+  shadowRoot: ShadowRoot;
+}
+
+function entityCombobox(element: SetupViewElement, name: string): TestCombobox {
+  return element.shadowRoot.querySelector(`measure-combobox[name="${name}"]`) as TestCombobox;
+}
+
+function selectEntity(picker: TestCombobox, value: string): void {
+  const input = picker.querySelector('input[slot="value"]') as HTMLInputElement;
+  input.value = value;
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
 describe("setup view", () => {
   it("renders dynamic entities, mode choices, and collapsed advanced settings", async () => {
     const element = document.createElement("measure-setup-view") as SetupViewElement;
@@ -15,7 +32,9 @@ describe("setup view", () => {
     document.body.append(element);
     await element.updateComplete;
 
-    expect(element.shadowRoot.textContent).toContain("Desk lamp · light.desk");
+    const light = entityCombobox(element, "light_entity_id");
+    await light.updateComplete;
+    expect((light.shadowRoot.querySelector("input") as HTMLInputElement).value).toBe("Desk lamp · light.desk");
     expect(element.shadowRoot.textContent).toContain("Brightness");
     expect(element.shadowRoot.querySelector("details")?.open).toBe(false);
     expect(element.shadowRoot.querySelectorAll('input[name="modes"]')).toHaveLength(1);
@@ -26,9 +45,7 @@ describe("setup view", () => {
     const unsupported = ["ct_bri_steps", "ct_mired_steps", "hs_bri_steps", "hs_hue_steps", "hs_sat_steps", "effect_bri_steps", "measure_time_effect"];
     expect(unsupported.filter((name) => element.shadowRoot.querySelector(`input[name="${name}"]`))).toEqual([]);
 
-    const light = element.shadowRoot.querySelector('select[name="light_entity_id"]') as HTMLSelectElement;
-    light.value = "light.desk";
-    light.dispatchEvent(new Event("change"));
+    selectEntity(light, "light.desk");
     await element.updateComplete;
     expect(element.shadowRoot.querySelectorAll('input[name="modes"]')).toHaveLength(1);
   });
@@ -188,7 +205,7 @@ describe("setup view", () => {
 
     expect(element.shadowRoot.querySelector(".add-entity")).toBeNull();
     expect(element.shadowRoot.querySelector('input[name="multiple_light_count"][type="number"]')).toBeNull();
-    expect(element.shadowRoot.querySelectorAll('select[name="light_entity_id"]')).toHaveLength(1);
+    expect(element.shadowRoot.querySelectorAll('measure-combobox[name="light_entity_id"]')).toHaveLength(1);
     expect(element.shadowRoot.querySelector(".multiple-lights")?.textContent).toContain("very low power use");
 
     element.shadowRoot.querySelector<HTMLInputElement>('input[name="measure_multiple_lights"]')!.click();
@@ -530,9 +547,9 @@ describe("setup type picker", () => {
     document.body.append(element);
     await element.updateComplete;
 
-    const fanSelect = element.shadowRoot.querySelector('select[name="fan_entity_id"]') as HTMLSelectElement;
+    const fanSelect = entityCombobox(element, "fan_entity_id");
     expect(fanSelect).toBeTruthy();
-    expect(fanSelect.textContent).toContain("Bedroom fan · fan.bedroom");
+    expect(fanSelect.options.map((option) => option.label)).toContain("Bedroom fan · fan.bedroom");
   });
 
   it.each([
@@ -641,12 +658,11 @@ describe("setup type picker", () => {
     // lives inside a shadow root, so those selectors match nothing under the app's
     // shadow DOM even though browsers resolve them fine.
     const profileGrid = profileSection?.querySelector(".profile-grid");
-    const fields = [...(profileGrid?.querySelectorAll<HTMLInputElement | HTMLSelectElement>("[name]") ?? [])];
+    const fields = [...(profileGrid?.querySelectorAll<HTMLInputElement | HTMLSelectElement>("[name]") ?? [])]
+      .filter((field) => field.getAttribute("slot") !== "value");
     expect(fields.map((field) => field.name)).toEqual(expectedFields);
 
-    const entity = element.shadowRoot.querySelector(`select[name="${entityField}"]`) as HTMLSelectElement;
-    entity.value = entityId;
-    entity.dispatchEvent(new Event("change"));
+    selectEntity(entityCombobox(element, entityField), entityId);
     await element.updateComplete;
 
     expect((element.shadowRoot.querySelector('input[name="model_id"]') as HTMLInputElement).value).toBe(modelId);
@@ -709,18 +725,18 @@ describe("setup type picker", () => {
     document.body.append(element);
     await element.updateComplete;
 
-    const entity = element.shadowRoot.querySelector('[name="charging_entity_id"]') as HTMLSelectElement;
-    expect(entity.textContent).toContain("Downstairs vacuum");
-    expect(entity.textContent).not.toContain("Garden mower");
+    const entity = entityCombobox(element, "charging_entity_id");
+    expect(entity.options.map((option) => option.label)).toContain("Downstairs vacuum · vacuum.downstairs");
+    expect(entity.options.map((option) => option.label)).not.toContain("Garden mower · lawn_mower.garden");
 
     const type = element.shadowRoot.querySelector('[name="charging_device_type"]') as HTMLSelectElement;
     type.value = "lawn_mower_robot";
     type.dispatchEvent(new Event("change"));
     await element.updateComplete;
 
-    const updated = element.shadowRoot.querySelector('[name="charging_entity_id"]') as HTMLSelectElement;
-    expect(updated.textContent).toContain("Garden mower");
-    expect(updated.textContent).not.toContain("Downstairs vacuum");
+    const updated = entityCombobox(element, "charging_entity_id");
+    expect(updated.options.map((option) => option.label)).toContain("Garden mower · lawn_mower.garden");
+    expect(updated.options.map((option) => option.label)).not.toContain("Downstairs vacuum · vacuum.downstairs");
   });
 });
 
@@ -783,9 +799,7 @@ describe("setup view defaults", () => {
     document.body.append(element);
     await element.updateComplete;
 
-    const light = element.shadowRoot.querySelector('select[name="light_entity_id"]') as HTMLSelectElement;
-    light.value = "light.desk";
-    light.dispatchEvent(new Event("change"));
+    selectEntity(entityCombobox(element, "light_entity_id"), "light.desk");
     await element.updateComplete;
 
     const modelId = element.shadowRoot.querySelector('input[name="model_id"]') as HTMLInputElement;
@@ -812,14 +826,14 @@ describe("setup view defaults", () => {
     // the assertion scoped to the profile fields and excludes the nested advanced
     // timing grid, exactly as the `:scope > .grid > label` selector intended.
     const profileFields = [...(profileGrid?.children ?? [])].filter(
-      (child): child is HTMLLabelElement => child.tagName === "LABEL",
+      (child): child is TestCombobox => child.tagName === "MEASURE-COMBOBOX",
     );
-    const labels = profileFields.map(
-      (field) => [...field.children].find((child) => child.tagName === "SPAN")?.textContent?.trim(),
-    );
+    const labels = profileFields.map((field) => field.label);
     expect(labels).toEqual(["Light"]);
     expect([...element.shadowRoot.querySelectorAll(".profile-fields > label > span")].map((label) => label.textContent?.trim()))
       .toEqual(["Model ID", "Full product name"]);
+    expect((element.shadowRoot.querySelector('input[name="product_name"]') as HTMLInputElement).placeholder)
+      .toBe("Hue White Ambiance A60 E27");
     expect(element.shadowRoot.querySelector(".field-hint")?.textContent).toContain("complete marketed name");
   });
 });

--- a/utils/measure/frontend/src/components/setup-view.ts
+++ b/utils/measure/frontend/src/components/setup-view.ts
@@ -44,7 +44,7 @@ import {
 } from "./setup-chrome";
 import { errorHelpLink } from "./error-help-link";
 
-const FULL_PRODUCT_NAME_HINT = "Enter the complete marketed name, including the series and variant shown on the product or packaging.";
+const FULL_PRODUCT_NAME_HINT = "Enter the complete marketed name, including the series and variant shown on the product or packaging. Do not repeat the manufacturer name.";
 const MULTIPLE_LIGHTS_GUIDE_URL = "https://docs.powercalc.nl/contributing/measure/lights/#multiple-identical-lights";
 
 @customElement("measure-setup-view")

--- a/utils/measure/frontend/src/components/test-fixtures.ts
+++ b/utils/measure/frontend/src/components/test-fixtures.ts
@@ -82,7 +82,7 @@ export const lightDefinition: MeasureDefinition = {
   description: "Build a lookup-table power profile for a light.",
   icon: "💡",
   model_id_example: "LWA017",
-  product_name_example: "Philips Hue White Ambiance A60 E27",
+  product_name_example: "Hue White Ambiance A60 E27",
   parameters: [
     { name: "sleep_time", label: "Settle time (seconds)", hint: "Wait after changing the light before reading power.", step: "0.1", group: "Sampling" },
     { name: "sample_count", label: "Samples per point", hint: "More samples reduce noise but increase measurement time.", group: "Sampling" },

--- a/utils/measure/frontend/src/types.ts
+++ b/utils/measure/frontend/src/types.ts
@@ -44,6 +44,10 @@ export interface EntityCatalog {
   voltages: EntityDescriptor[];
 }
 
+export interface MeasureDeviceCatalog {
+  devices: string[];
+}
+
 export interface MeasurementParameters {
   sleep_time: number;
   sample_count: number;
@@ -421,6 +425,7 @@ export interface ContributionDraft {
   base_sha?: string | null;
   manufacturer_name: string;
   manufacturer_directory: string;
+  manufacturer_library_url?: string | null;
   model_id: string;
   product_name: string;
   contributor: string;

--- a/utils/measure/measure/contribution/models.py
+++ b/utils/measure/measure/contribution/models.py
@@ -128,6 +128,7 @@ class ContributionPreview(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     manufacturer_directory: str
+    manufacturer_library_url: str | None = None
     model_directory: str
     files: tuple[ContributionPreparedFile, ...]
     warnings: tuple[str, ...] = ()

--- a/utils/measure/measure/contribution/prepare.py
+++ b/utils/measure/measure/contribution/prepare.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass
 import gzip
 import hashlib
 import json
@@ -12,10 +13,27 @@ JsonValidator = Callable[[dict[str, Any], dict[str, Any]], None]
 
 MODEL_JSON = "model.json"
 MANUFACTURER_JSON = "manufacturer.json"
+LIBRARY_URL = "https://library.powercalc.nl"
 
 
 class ProfilePreparationError(ValueError):
-    pass
+    def __init__(self, message: str, *, field: str | None = None) -> None:
+        super().__init__(message)
+        self.field = field
+
+
+@dataclass(frozen=True)
+class ManufacturerResolution:
+    directory: str
+    names: frozenset[str]
+    exists: bool
+
+    @property
+    def library_url(self) -> str | None:
+        if not self.exists:
+            return None
+        slug = re.sub(r"[^a-z0-9]+", "-", self.directory.casefold()).strip("-")
+        return f"{LIBRARY_URL}/manufacturers/{slug}" if slug else None
 
 
 class ProfilePreparer:
@@ -42,22 +60,22 @@ class ProfilePreparer:
         artifact_directory = artifact_directory.resolve()
         csv_names = self._artifact_csv_names(artifact_directory)
         model = self._apply_metadata(self._read_object(artifact_directory / MODEL_JSON), metadata)
+        manufacturer = self._resolve_manufacturer(metadata.manufacturer, metadata.manufacturer_directory)
+        self._validate_product_name(str(model.get("name", "")), metadata.manufacturer, manufacturer.names)
         if model.get("calculation_strategy") == "lut" and not csv_names:
             raise ProfilePreparationError("At least one .csv.gz artifact is required for LUT profiles")
         self.validator(model, self._read_object(self.model_schema_path))
 
-        manufacturer_directory = self._resolve_manufacturer_directory(
-            metadata.manufacturer,
-            metadata.manufacturer_directory,
-        )
+        manufacturer_directory = manufacturer.directory
         profile_directory = Path("profile_library") / manufacturer_directory / metadata.model_id
         relative_files = [profile_directory / name for name in (MODEL_JSON, *csv_names)]
-        if not self._manufacturer_exists(manufacturer_directory):
+        if not manufacturer.exists:
             relative_files.append(profile_directory.parent / MANUFACTURER_JSON)
         self._block_collisions(relative_files)
 
         return ContributionPreview(
             manufacturer_directory=manufacturer_directory,
+            manufacturer_library_url=manufacturer.library_url,
             model_directory=metadata.model_id,
             files=tuple(
                 self._build_prepared_file(relative_path, artifact_directory, model, metadata)
@@ -105,21 +123,46 @@ class ProfilePreparer:
         ]
         return model
 
-    def _resolve_manufacturer_directory(self, manufacturer: str, requested_directory: str | None) -> str:
+    def _resolve_manufacturer(self, manufacturer: str, requested_directory: str | None) -> ManufacturerResolution:
         requested = self._normalize(manufacturer)
         for directory, manifest in self._manufacturer_manifests():
             if requested in self._known_names(manifest, "name"):
-                return directory
+                return ManufacturerResolution(
+                    directory=directory,
+                    names=frozenset(self._known_name_values(manifest, "name")),
+                    exists=True,
+                )
         for entry in self._manufacturers_in_index():
             dir_name = entry.get("dir_name")
             if isinstance(dir_name, str) and dir_name and requested in self._known_names(entry, "name", "full_name"):
-                return dir_name
-        return requested_directory or self._slugify(manufacturer)
-
-    def _manufacturer_exists(self, directory: str) -> bool:
-        return (self.library_root / directory).is_dir() or any(
-            entry.get("dir_name") == directory for entry in self._manufacturers_in_index()
+                return ManufacturerResolution(
+                    directory=dir_name,
+                    names=frozenset(self._known_name_values(entry, "name", "full_name")),
+                    exists=True,
+                )
+        return ManufacturerResolution(
+            directory=requested_directory or self._slugify(manufacturer),
+            names=frozenset({manufacturer}),
+            exists=False,
         )
+
+    @classmethod
+    def _validate_product_name(cls, product_name: str, entered_manufacturer: str, known_names: frozenset[str]) -> None:
+        normalized_product = cls._normalize_words(product_name)
+        manufacturer_names = {cls._normalize_words(name) for name in (*known_names, entered_manufacturer)}
+        repeated = next(
+            (
+                name
+                for name in sorted(manufacturer_names, key=len, reverse=True)
+                if name and (normalized_product == name or normalized_product.startswith(f"{name} "))
+            ),
+            None,
+        )
+        if repeated is not None:
+            raise ProfilePreparationError(
+                "Product name must not start with the manufacturer; enter only the marketed model name",
+                field="product_name",
+            )
 
     def _block_collisions(self, relative_files: Sequence[Path]) -> None:
         # Casefolded: GitHub hosting is case-sensitive, but "LCT001" and "lct001"
@@ -194,11 +237,15 @@ class ProfilePreparer:
     @classmethod
     def _known_names(cls, entry: dict[str, Any], *keys: str) -> set[str]:
         """All normalized names an entry answers to: the values of ``keys`` plus its aliases."""
+        return {cls._normalize(name) for name in cls._known_name_values(entry, *keys)}
+
+    @staticmethod
+    def _known_name_values(entry: dict[str, Any], *keys: str) -> set[str]:
         names = [entry.get(key) for key in keys]
         aliases = entry.get("aliases")
         if isinstance(aliases, list):
             names.extend(aliases)
-        return {cls._normalize(str(name)) for name in names if name}
+        return {str(name).strip() for name in names if name and str(name).strip()}
 
     def _build_prepared_file(
         self,
@@ -251,6 +298,10 @@ class ProfilePreparer:
     @staticmethod
     def _normalize(value: str) -> str:
         return re.sub(r"\s+", " ", value.strip()).casefold()
+
+    @staticmethod
+    def _normalize_words(value: str) -> str:
+        return re.sub(r"[\W_]+", " ", value.casefold()).strip()
 
     @staticmethod
     def _slugify(value: str) -> str:

--- a/utils/measure/measure/contribution/prepare.py
+++ b/utils/measure/measure/contribution/prepare.py
@@ -25,7 +25,10 @@ class ProfilePreparationError(ValueError):
 @dataclass(frozen=True)
 class ManufacturerResolution:
     directory: str
-    names: frozenset[str]
+    #: Only the manufacturer's own name(s), never its aliases: aliases are commonly
+    #: sub-brands or product lines ("FRITZ!", "Tapo", "Kasa") that legitimately start
+    #: a product name, so they must not be rejected as a repeated manufacturer.
+    primary_names: frozenset[str]
     exists: bool
 
     @property
@@ -61,7 +64,7 @@ class ProfilePreparer:
         csv_names = self._artifact_csv_names(artifact_directory)
         model = self._apply_metadata(self._read_object(artifact_directory / MODEL_JSON), metadata)
         manufacturer = self._resolve_manufacturer(metadata.manufacturer, metadata.manufacturer_directory)
-        self._validate_product_name(str(model.get("name", "")), metadata.manufacturer, manufacturer.names)
+        self._validate_product_name(str(model.get("name", "")), metadata.manufacturer, manufacturer.primary_names)
         if model.get("calculation_strategy") == "lut" and not csv_names:
             raise ProfilePreparationError("At least one .csv.gz artifact is required for LUT profiles")
         self.validator(model, self._read_object(self.model_schema_path))
@@ -129,7 +132,7 @@ class ProfilePreparer:
             if requested in self._known_names(manifest, "name"):
                 return ManufacturerResolution(
                     directory=directory,
-                    names=frozenset(self._known_name_values(manifest, "name")),
+                    primary_names=frozenset(self._name_values(manifest, "name")),
                     exists=True,
                 )
         for entry in self._manufacturers_in_index():
@@ -137,13 +140,23 @@ class ProfilePreparer:
             if isinstance(dir_name, str) and dir_name and requested in self._known_names(entry, "name", "full_name"):
                 return ManufacturerResolution(
                     directory=dir_name,
-                    names=frozenset(self._known_name_values(entry, "name", "full_name")),
+                    primary_names=frozenset(self._name_values(entry, "name", "full_name")),
                     exists=True,
                 )
+        directory = requested_directory or self._slugify(manufacturer)
         return ManufacturerResolution(
-            directory=requested_directory or self._slugify(manufacturer),
-            names=frozenset({manufacturer}),
-            exists=False,
+            directory=directory,
+            primary_names=frozenset({manufacturer}),
+            # The entered name matched nothing, but the directory it resolves to may
+            # still be an existing manufacturer (the directory is user-editable), and
+            # overwriting its manifest would drop the upstream name and aliases.
+            exists=self._manufacturer_directory_exists(directory),
+        )
+
+    def _manufacturer_directory_exists(self, directory: str) -> bool:
+        """Whether ``directory`` is already a manufacturer in the checkout or the index."""
+        return (self.library_root / directory).is_dir() or any(
+            entry.get("dir_name") == directory for entry in self._manufacturers_in_index()
         )
 
     @classmethod
@@ -239,13 +252,19 @@ class ProfilePreparer:
         """All normalized names an entry answers to: the values of ``keys`` plus its aliases."""
         return {cls._normalize(name) for name in cls._known_name_values(entry, *keys)}
 
-    @staticmethod
-    def _known_name_values(entry: dict[str, Any], *keys: str) -> set[str]:
-        names = [entry.get(key) for key in keys]
+    @classmethod
+    def _known_name_values(cls, entry: dict[str, Any], *keys: str) -> set[str]:
         aliases = entry.get("aliases")
-        if isinstance(aliases, list):
-            names.extend(aliases)
-        return {str(name).strip() for name in names if name and str(name).strip()}
+        return cls._name_values(entry, *keys) | (
+            {str(alias).strip() for alias in aliases if alias and str(alias).strip()}
+            if isinstance(aliases, list)
+            else set()
+        )
+
+    @staticmethod
+    def _name_values(entry: dict[str, Any], *keys: str) -> set[str]:
+        """The entry's own name(s) under ``keys``, without its aliases."""
+        return {str(entry[key]).strip() for key in keys if entry.get(key) and str(entry[key]).strip()}
 
     def _build_prepared_file(
         self,

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -38,6 +38,7 @@ from measure.ha_app.contribution import (
 )
 from measure.ha_app.coordinator import MeasurementCoordinator, SessionConflictError
 from measure.ha_app.diagnostics import DIAGNOSTIC_EVENT_LIMIT, build_session_diagnostics
+from measure.ha_app.library_catalog import LibraryCatalogError, MeasureDeviceCatalog
 from measure.ha_app.light_probe import (
     LightLoadProbe,
     LightLoadProbeError,
@@ -135,6 +136,10 @@ class EntityCatalogResponse(BaseModel):
     lights: list[EntityDescriptor]
     powers: list[EntityDescriptor]
     voltages: list[EntityDescriptor]
+
+
+class MeasureDeviceCatalogResponse(BaseModel):
+    devices: list[str]
 
 
 class SessionFile(BaseModel):
@@ -238,6 +243,7 @@ class AppContext:
         self.trusted_ingress_only = trusted_ingress_only
         self.developer_mode = developer_mode
         self.storage = SessionStorage(data_root)
+        self.measure_device_catalog = MeasureDeviceCatalog()
         self.power_meter_diagnostics = PowerMeterDiagnostics(self.build_power_meter)
         self.light_load_probe = LightLoadProbe(
             lambda: app_measurement_assembler(
@@ -400,7 +406,7 @@ def _register_error_handlers(app: FastAPI) -> None:
         status_code = _CONTRIBUTION_STATUS_CODES.get(error.code, 500)
         return JSONResponse(
             status_code=status_code,
-            content=ErrorResponse(code=error.code.value, message=str(error)).model_dump(),
+            content=ErrorResponse(code=error.code.value, message=str(error), field=error.field).model_dump(),
         )
 
     @app.exception_handler(Exception)
@@ -440,6 +446,15 @@ def _register_measurement_routes(router: APIRouter) -> None:  # noqa: C901
     @router.get("/measure-definitions")
     async def measure_definitions() -> list[MeasureDefinition]:
         return _measure_definitions()
+
+    @router.get("/library/measure-devices", responses={503: _ERROR})
+    async def measure_devices(request: Request, response: Response) -> MeasureDeviceCatalogResponse:
+        try:
+            devices = await run_in_threadpool(_context(request).measure_device_catalog.devices)
+        except LibraryCatalogError as error:
+            raise HTTPException(status_code=503, detail=str(error)) from error
+        response.headers["Cache-Control"] = "public, max-age=600"
+        return MeasureDeviceCatalogResponse(devices=list(devices))
 
     @router.get("/settings")
     async def get_settings(request: Request) -> AppSettingsResponse:

--- a/utils/measure/measure/ha_app/contribution/models.py
+++ b/utils/measure/measure/ha_app/contribution/models.py
@@ -50,9 +50,10 @@ class ContributionApiErrorCode(StrEnum):
 
 
 class ContributionApiError(Exception):
-    def __init__(self, code: ContributionApiErrorCode, message: str) -> None:
+    def __init__(self, code: ContributionApiErrorCode, message: str, *, field: str | None = None) -> None:
         super().__init__(message)
         self.code = code
+        self.field = field
 
 
 class ContributionIdentity(BaseModel):
@@ -140,6 +141,7 @@ class ContributionPreviewResponse(BaseModel):
     base_sha: str | None = None
     manufacturer_name: str
     manufacturer_directory: str
+    manufacturer_library_url: str | None = None
     model_id: str
     product_name: str
     contributor: str

--- a/utils/measure/measure/ha_app/contribution/service.py
+++ b/utils/measure/measure/ha_app/contribution/service.py
@@ -176,7 +176,12 @@ class SharedContributionService:
         try:
             job = self._build_coordinator(preparer, client).create_job(artifact_root, metadata, base_sha=base_sha)
         except ProfilePreparationError as error:
-            raise ContributionApiError(ContributionApiErrorCode.ARTIFACTS_REQUIRED, str(error)) from error
+            code = (
+                ContributionApiErrorCode.INVALID_METADATA
+                if error.field
+                else ContributionApiErrorCode.ARTIFACTS_REQUIRED
+            )
+            raise ContributionApiError(code, str(error), field=error.field) from error
         contents = preparer.render_contents(artifact_root, metadata, job.preview)
         return _preview_from_job(
             session_id=session_id,
@@ -212,7 +217,12 @@ class SharedContributionService:
         try:
             latest_preview = preparer.prepare(artifact_root, job_before_submit.metadata)
         except ProfilePreparationError as error:
-            raise ContributionApiError(ContributionApiErrorCode.ARTIFACTS_REQUIRED, str(error)) from error
+            code = (
+                ContributionApiErrorCode.INVALID_METADATA
+                if error.field
+                else ContributionApiErrorCode.ARTIFACTS_REQUIRED
+            )
+            raise ContributionApiError(code, str(error), field=error.field) from error
         _validate_latest_preview(job_before_submit, latest_preview, base_sha)
         try:
             job = self._build_coordinator(preparer, client).submit(job_id, artifact_root)
@@ -353,6 +363,7 @@ class _PreviewContent:
 
     manufacturer_name: str
     manufacturer_directory: str
+    manufacturer_library_url: str | None
     model_id: str
     product_name: str
     contributor: str
@@ -386,6 +397,7 @@ def draft_from_request(
     content = _PreviewContent(
         manufacturer_name="",
         manufacturer_directory="",
+        manufacturer_library_url=None,
         model_id=request.model_id,
         product_name=request.product_name,
         contributor=auth.username or "",
@@ -433,6 +445,7 @@ def _preview_from_job(
     content = _PreviewContent(
         manufacturer_name=job.metadata.manufacturer,
         manufacturer_directory=job.preview.manufacturer_directory,
+        manufacturer_library_url=job.preview.manufacturer_library_url,
         model_id=job.metadata.model_id,
         product_name=job.metadata.product_name or request.product_name,
         contributor=job.metadata.author.name,
@@ -493,6 +506,7 @@ def _build_preview_response(
         base_sha=base_sha,
         manufacturer_name=content.manufacturer_name,
         manufacturer_directory=content.manufacturer_directory,
+        manufacturer_library_url=content.manufacturer_library_url,
         model_id=content.model_id,
         product_name=content.product_name,
         contributor=content.contributor,

--- a/utils/measure/measure/ha_app/library_catalog.py
+++ b/utils/measure/measure/ha_app/library_catalog.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable
+from typing import cast
+
+import requests
+
+LIBRARY_ENDPOINT = "https://api.powercalc.nl/library"
+LIBRARY_TIMEOUT_SECONDS = 15
+
+_NON_DEVICE_VALUES = frozenset(
+    {
+        "from manufacturer specifications",
+        "n/a",
+        "see linked profile",
+    },
+)
+
+
+class LibraryCatalogError(RuntimeError):
+    """Raised when the published profile library cannot provide a usable catalog."""
+
+
+LibraryLoader = Callable[[], object]
+
+
+class MeasureDeviceCatalog:
+    """Load canonical measurement-device names from the published profile library."""
+
+    def __init__(
+        self,
+        *,
+        loader: LibraryLoader | None = None,
+    ) -> None:
+        self._loader = loader or _load_published_library
+
+    def devices(self) -> tuple[str, ...]:
+        try:
+            return extract_measure_devices(self._loader())
+        except Exception as error:
+            raise LibraryCatalogError("Could not load measurement devices from the Powercalc library") from error
+
+
+def extract_measure_devices(library: object) -> tuple[str, ...]:
+    if not isinstance(library, dict):
+        raise LibraryCatalogError("Powercalc library response must be a JSON object")
+    manufacturers = library.get("manufacturers")
+    if not isinstance(manufacturers, list):
+        raise LibraryCatalogError("Powercalc library response has no manufacturers list")
+
+    devices: dict[str, str] = {}
+    for manufacturer in manufacturers:
+        if not isinstance(manufacturer, dict):
+            continue
+        models = manufacturer.get("models")
+        if not isinstance(models, list):
+            continue
+        for model in models:
+            if not isinstance(model, dict):
+                continue
+            value = model.get("measure_device")
+            if not isinstance(value, str):
+                continue
+            name = value.strip()
+            key = name.casefold()
+            if name and key not in _NON_DEVICE_VALUES:
+                devices.setdefault(key, name)
+    return tuple(sorted(devices.values(), key=str.casefold))
+
+
+def _load_published_library() -> object:
+    response = requests.get(LIBRARY_ENDPOINT, timeout=LIBRARY_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return cast(object, response.json())

--- a/utils/measure/measure/ha_app/registry.py
+++ b/utils/measure/measure/ha_app/registry.py
@@ -262,7 +262,7 @@ MEASUREMENT_REGISTRY: dict[MeasureType, MeasurementDefinition] = {
         description="Build a lookup-table power profile for a light.",
         icon="💡",
         model_id_example="LWA017",
-        product_name_example="Philips Hue White Ambiance A60 E27",
+        product_name_example="Hue White Ambiance A60 E27",
         parameters=LIGHT_PARAMETERS,
         fields=(
             POWER_FIELD,

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -28,6 +28,7 @@ from measure.ha_app.contribution import (
     SharedContributionService,
 )
 from measure.ha_app.coordinator import MeasurementCoordinator, SessionExecutionContext, SessionMeasurementService
+from measure.ha_app.library_catalog import MeasureDeviceCatalog
 from measure.ha_app.light_probe import LightLoadProbeError, LightLoadProbePoint, LightLoadProbeResult
 from measure.ha_app.session import SessionControl, SessionEvent, SessionEventType, SessionSnapshot, SessionState
 from measure.ha_app.storage import SessionStorage
@@ -358,6 +359,35 @@ def test_app_metadata_uses_the_runtime_measure_version(tmp_path: Path) -> None:
     assert test_client.app.version == measure_version()
     assert test_client.get("/openapi.json").json()["info"]["version"] == measure_version()
     assert test_client.get("/api/capabilities").json()["runtime_version"] == measure_version()
+
+
+def test_measure_device_catalog_uses_published_values_and_http_caching(tmp_path: Path) -> None:
+    test_client = client(tmp_path)
+    test_client.app.state.context.measure_device_catalog = MeasureDeviceCatalog(
+        loader=lambda: {
+            "manufacturers": [
+                {"models": [{"measure_device": "Shelly Plug S"}, {"measure_device": "N/A"}]},
+            ],
+        },
+    )
+
+    response = test_client.get("/api/library/measure-devices")
+
+    assert response.status_code == 200
+    assert response.json() == {"devices": ["Shelly Plug S"]}
+    assert response.headers["cache-control"] == "public, max-age=600"
+
+
+def test_measure_device_catalog_failure_returns_service_unavailable(tmp_path: Path) -> None:
+    test_client = client(tmp_path)
+    test_client.app.state.context.measure_device_catalog = MeasureDeviceCatalog(
+        loader=lambda: (_ for _ in ()).throw(OSError("offline")),
+    )
+
+    response = test_client.get("/api/library/measure-devices")
+
+    assert response.status_code == 503
+    assert response.json()["message"] == "Could not load measurement devices from the Powercalc library"
 
 
 def test_index_is_not_cached(tmp_path: Path) -> None:
@@ -915,6 +945,7 @@ def test_openapi_contract_contains_the_supported_app_endpoints(tmp_path: Path) -
     paths = app.openapi()["paths"]
 
     assert set(paths["/api/sessions"]) == {"get", "post"}
+    assert set(paths["/api/library/measure-devices"]) == {"get"}
     assert set(paths["/api/sessions/{session_id}"]) == {"get", "delete"}
     assert set(paths["/api/sessions/{session_id}/cancel"]) == {"post"}
     assert set(paths["/api/sessions/{session_id}/confirm"]) == {"post"}

--- a/utils/measure/tests/test_contribution_prepare.py
+++ b/utils/measure/tests/test_contribution_prepare.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import gzip
 import json
 from pathlib import Path
@@ -12,11 +13,13 @@ def metadata(
     manufacturer: str = "Philips",
     model_id: str = "LCT999",
     product_name: str | None = None,
+    manufacturer_directory: str | None = None,
 ) -> ContributionMetadata:
     return ContributionMetadata(
         manufacturer=manufacturer,
         model_id=model_id,
         product_name=product_name,
+        manufacturer_directory=manufacturer_directory,
         author=ContributionAuthor(name="Test User", github="test-user", email="test@example.com"),
     )
 
@@ -231,6 +234,42 @@ def test_new_manufacturer_has_no_library_url_and_still_cannot_prefix_product_nam
 
     with pytest.raises(ProfilePreparationError, match="must not start with the manufacturer"):
         preparer.prepare(artifacts, metadata("Acme", product_name="Acme Smart Bulb A19"))
+
+
+def test_preparer_allows_product_names_starting_with_a_sub_brand_alias(tmp_path: Path) -> None:
+    """Aliases are often product lines ("Philips" for Signify, "FRITZ!" for AVM) that
+    legitimately open a marketed product name, so only the canonical manufacturer name
+    and the name the contributor actually entered may be rejected as a repetition."""
+    artifacts = tmp_path / "artifacts"
+    write_library(tmp_path)
+    write_profile_artifacts(artifacts)
+
+    preview = make_preparer(tmp_path).prepare(
+        artifacts,
+        metadata(EXISTING_MANUFACTURER, product_name=f"{EXISTING_ALIAS} Hue Go"),
+    )
+
+    assert preview.manufacturer_directory == EXISTING_DIRECTORY
+
+
+@pytest.mark.parametrize("seed_library", [write_library, write_library_index])
+def test_preparer_keeps_existing_manufacturer_manifest_when_only_the_directory_matches(
+    tmp_path: Path,
+    seed_library: Callable[[Path], None],
+) -> None:
+    """The manufacturer directory is user-editable, so an unrecognised manufacturer name
+    can still point at an existing manufacturer whose manifest must not be overwritten."""
+    artifacts = tmp_path / "artifacts"
+    seed_library(tmp_path)
+    write_profile_artifacts(artifacts)
+
+    preview = make_preparer(tmp_path).prepare(
+        artifacts,
+        metadata("Unrecognised Brand", manufacturer_directory=EXISTING_DIRECTORY),
+    )
+
+    assert preview.manufacturer_directory == EXISTING_DIRECTORY
+    assert f"profile_library/{EXISTING_DIRECTORY}/manufacturer.json" not in {file.path for file in preview.files}
 
 
 def test_preparer_accepts_raw_csv_alongside_gzip_and_rejects_unrelated_artifacts(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_contribution_prepare.py
+++ b/utils/measure/tests/test_contribution_prepare.py
@@ -179,9 +179,58 @@ def test_preparer_uses_downloaded_library_index_for_aliases_and_collisions(tmp_p
     preview = preparer.prepare(artifacts, metadata(model_id="LCT999"))
 
     assert preview.manufacturer_directory == "signify"
+    assert preview.manufacturer_library_url == "https://library.powercalc.nl/manufacturers/signify"
     collision_metadata = metadata(model_id="LCT010")
     with pytest.raises(ProfilePreparationError, match="Refusing to overwrite"):
         preparer.prepare(artifacts, collision_metadata)
+
+
+@pytest.mark.parametrize(
+    "manufacturer, product_name",
+    [
+        ("Signify", "Signify Hue test lamp"),
+        ("Philips", "philips-hue test lamp"),
+        ("Philips", "Philips_Hue test lamp"),
+    ],
+)
+def test_preparer_rejects_product_names_prefixed_with_manufacturer_or_alias(
+    tmp_path: Path,
+    manufacturer: str,
+    product_name: str,
+) -> None:
+    artifacts = tmp_path / "artifacts"
+    write_library(tmp_path)
+    write_profile_artifacts(artifacts)
+
+    with pytest.raises(ProfilePreparationError, match="must not start with the manufacturer") as error:
+        make_preparer(tmp_path).prepare(artifacts, metadata(manufacturer, product_name=product_name))
+
+    assert error.value.field == "product_name"
+
+
+def test_preparer_allows_manufacturer_words_outside_the_product_name_prefix(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    write_library(tmp_path)
+    write_profile_artifacts(artifacts)
+
+    preview = make_preparer(tmp_path).prepare(
+        artifacts,
+        metadata(product_name="Mijia Philips Desk Lamp 3"),
+    )
+
+    assert preview.manufacturer_directory == "signify"
+
+
+def test_new_manufacturer_has_no_library_url_and_still_cannot_prefix_product_name(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    write_profile_artifacts(artifacts)
+    preparer = make_preparer(tmp_path)
+
+    preview = preparer.prepare(artifacts, metadata("Acme", product_name="Smart Bulb A19"))
+    assert preview.manufacturer_library_url is None
+
+    with pytest.raises(ProfilePreparationError, match="must not start with the manufacturer"):
+        preparer.prepare(artifacts, metadata("Acme", product_name="Acme Smart Bulb A19"))
 
 
 def test_preparer_accepts_raw_csv_alongside_gzip_and_rejects_unrelated_artifacts(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_library_catalog.py
+++ b/utils/measure/tests/test_library_catalog.py
@@ -1,0 +1,48 @@
+from measure.ha_app.library_catalog import LibraryCatalogError, MeasureDeviceCatalog, extract_measure_devices
+import pytest
+
+
+def test_extract_measure_devices_returns_canonical_unique_hardware_names() -> None:
+    library = {
+        "manufacturers": [
+            {
+                "models": [
+                    {"measure_device": " Shelly Plug S "},
+                    {"measure_device": "shelly plug s"},
+                    {"measure_device": "N/A"},
+                    {"measure_device": "From manufacturer specifications"},
+                    {"measure_device": "TP-Link Kasa KP115"},
+                    {"measure_device": None},
+                ],
+            },
+            {"models": [{"measure_device": "See linked profile"}]},
+            {"models": "invalid"},
+            "invalid",
+        ],
+    }
+
+    assert extract_measure_devices(library) == ("Shelly Plug S", "TP-Link Kasa KP115")
+
+
+@pytest.mark.parametrize("library", [None, [], {}, {"manufacturers": {}}])
+def test_extract_measure_devices_rejects_invalid_library_shapes(library: object) -> None:
+    with pytest.raises(LibraryCatalogError):
+        extract_measure_devices(library)
+
+
+def test_catalog_translates_loader_failures_without_application_caching() -> None:
+    calls = 0
+
+    def load() -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {"manufacturers": [{"models": [{"measure_device": "Shelly Plug S"}]}]}
+        raise OSError("offline")
+
+    catalog = MeasureDeviceCatalog(loader=load)
+
+    assert catalog.devices() == ("Shelly Plug S",)
+    with pytest.raises(LibraryCatalogError, match="Could not load measurement devices"):
+        catalog.devices()
+    assert calls == 2

--- a/utils/measure/tests/test_registry.py
+++ b/utils/measure/tests/test_registry.py
@@ -36,3 +36,7 @@ def test_light_definition_allows_multiple_entities_and_explains_the_physical_cou
 
     assert fields["light_entity_id"].multiple is True
     assert "physical lights" in fields["multiple_light_count"].hint
+
+
+def test_light_product_name_example_does_not_repeat_the_manufacturer() -> None:
+    assert MEASUREMENT_REGISTRY[MeasureType.LIGHT].product_name_example == "Hue White Ambiance A60 E27"

--- a/utils/measure/tests/test_visualization_cli.py
+++ b/utils/measure/tests/test_visualization_cli.py
@@ -7,10 +7,10 @@ import pytest
 
 
 def test_resolve_plot_input_finds_profile_library_path() -> None:
-    path = cli.resolve_plot_input("ledvance/4058075729223/brightness.csv.gz")
+    path = cli.resolve_plot_input("ledvance/AC41293/brightness.csv.gz")
 
     assert path.name == "brightness.csv.gz"
-    assert path.parent.name == "4058075729223"
+    assert path.parent.name == "AC41293"
 
 
 def test_generate_directory_plots_writes_supported_artifacts(


### PR DESCRIPTION
## Summary

- add a library-backed measurement-device catalog and a reusable searchable combobox while preserving manual device-name entry
- use the shared combobox for power sensors and single Home Assistant entity selections such as lights, fans, speakers, and charging devices
- prevent manufacturer names from being repeated in product names and link to the matching manufacturer page for consistency checks
- align product-name examples and contribution documentation with the updated validation rules
- proxy the library catalog with the standard upstream cache headers used by the API

## Testing

- npm test (171 passed)
- npm run typecheck
- npm run lint
- npm run test:e2e (6 passed)
- uv run --extra dev --extra cli pytest tests/test_registry.py tests/test_api.py tests/test_library_catalog.py tests/test_contribution_prepare.py (83 passed)
- uv run --extra dev --extra cli ruff check measure tests prepare_app_release.py
- pre-commit hooks

Closes #4608