### PR TITLE
fix(test): follow the model renames from the M-O normalization

### DIFF
--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -394,11 +394,12 @@ async def test_get_model_listing(remote_loader: RemoteLoader) -> None:
 async def test_get_model_listing_manual_profile(remote_loader: RemoteLoader) -> None:
     """Manual profiles are listed only when explicitly requested."""
     manual_models = await remote_loader.get_model_listing("netgear", None, DiscoveryBy.MANUAL)
+    entity_models = await remote_loader.get_model_listing("netgear", None, DiscoveryBy.ENTITY)
 
-    assert ("GS110MX", "Netgear GS110MX") in manual_models
-    assert ("GS110MX", "Netgear GS110MX") not in await remote_loader.get_model_listing(
-        "netgear", None, DiscoveryBy.ENTITY
-    )
+    # Matched on the model id alone: the display name beside it is profile metadata, and gets
+    # rewritten whenever a manufacturer's profiles are normalized.
+    assert "GS110MX" in {model_id for model_id, _name in manual_models}
+    assert "GS110MX" not in {model_id for model_id, _name in entity_models}
 
 
 async def test_get_model_metadata_rejects_invalid_device_type(remote_loader: RemoteLoader) -> None:

--- a/tests/power_profile/user_scenarios/test_lightify_plug.py
+++ b/tests/power_profile/user_scenarios/test_lightify_plug.py
@@ -42,4 +42,6 @@ async def test_lightify_plug_selectable(
     data_schema = result["data_schema"]
     model_select: SelectSelector = data_schema.schema["model"]
     model_options = model_select.config["options"]
-    assert {"value": "LIGHTIFY Plug 01", "label": "LIGHTIFY Plug 01 (Osram Lightify Plug 01)"} in model_options
+    # The profile lives under its real model id; "LIGHTIFY Plug 01" is what the integration
+    # reports, and survives as an alias and a legacy id on the profile.
+    assert {"value": "AB3257001NJ", "label": "AB3257001NJ (LIGHTIFY Smart Plug)"} in model_options


### PR DESCRIPTION
`master` is red: two tests assert on profile metadata that the M-O normalization (#4630) rewrote.

| Test | What changed under it |
|---|---|
| `test_lightify_plug_selectable` | The OSRAM Lightify plug moved to its real model id — `LIGHTIFY Plug 01` became `AB3257001NJ` — and is now named "LIGHTIFY Smart Plug" |
| `test_get_model_listing_manual_profile` | NETGEAR's GS110MX lost its brand prefix and is named after the product: "8-Port Gigabit Unmanaged Switch with 10G/Multi-Gig Uplinks" |

The plug test keeps reporting `LIGHTIFY Plug 01` as the device model, because that is what the Osram integration reports and the profile still carries it as an alias and a legacy id. Only the option the config flow offers has changed, so that is all the assertion updates.

The NETGEAR test is about manual profiles being listed only when they are asked for; the display name beside the id is incidental to that. It now matches on the model id alone, so the next time a manufacturer's profiles are normalized this test does not need touching.

Verified with the full suite: 1184 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C91G8vNA9QmR6kmS8gauZe