### PR TITLE
Regenerate the library when a manufacturer.json changes

### DIFF
--- a/.github/workflows/update-profile-library.yml
+++ b/.github/workflows/update-profile-library.yml
@@ -14,6 +14,7 @@ on:
   push:
     paths:
       - '**/model.json'
+      - '**/manufacturer.json'
       - '**/*.csv.gz'
     branches:
       - master


### PR DESCRIPTION
Merging #4634 added a website, a country and a description to 66 manufacturers, and none of it reached `library.json`: the index on master still has 0 manufacturers carrying a website.

The workflow that regenerates the index watches only what a profile is made of:

```yaml
push:
  paths:
    - '**/model.json'
    - '**/*.csv.gz'
```

`manufacturer.json` has been an input to `generate_library_json` since #4631, which taught the generator about brand details, but it was never added to this list. So a change to a manufacturer file validates, merges, and then sits there doing nothing.

Adding it is the whole fix. Verified by regenerating locally against current master: 65 of 123 manufacturers come out carrying their brand details, and `signify` reads

```json
{"name": "signify", "full_name": "Signify", "website": "https://www.signify.com",
 "country": "NL", "description": "Dutch lighting company, formerly Philips Lighting, and the maker of Philips Hue."}
```

65 rather than 66 because one enriched directory has no profiles of its own, so the index emits no entry for it.

I checked the other inputs while here: `*.csv.gz` covers every LUT file in the repo — 848 of them, and no uncompressed `.csv` — so `model.json`, `manufacturer.json` and `*.csv.gz` is now the complete set of what the generator reads.

**One manual run is needed after merging.** A push that only touches the workflow file does not match the new filter, so the index will not rebuild by itself: dispatch *Update profile library* once, or let the next profile change trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C91G8vNA9QmR6kmS8gauZe