### PR TITLE
Add missing manufacturer metadata

### DIFF
--- a/profile_library/3a smarthome/manufacturer.json
+++ b/profile_library/3a smarthome/manufacturer.json
@@ -4,5 +4,7 @@
     "3a smarthome",
     "3A Smart Home DE",
     "3a Smarthome"
-  ]
+  ],
+  "country": "AU",
+  "description": "Australian smart-home company behind Nue Zigbee lighting, switches and power controls."
 }

--- a/profile_library/ajax online/manufacturer.json
+++ b/profile_library/ajax online/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Ajax Online",
-  "aliases": []
+  "aliases": [],
+  "website": "https://zignito.com",
+  "country": "GB",
+  "description": "British home-automation supplier offering Zigbee and Wi-Fi lighting, plugs and controls."
 }

--- a/profile_library/anko/manufacturer.json
+++ b/profile_library/anko/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Anko",
-  "aliases": []
+  "aliases": [],
+  "website": "https://anko.com",
+  "country": "AU",
+  "description": "Kmart Australia's home and lifestyle brand, covering appliances, lighting and smart-home products."
 }

--- a/profile_library/apc/manufacturer.json
+++ b/profile_library/apc/manufacturer.json
@@ -3,5 +3,8 @@
   "aliases": [
     "American Power Conversion",
     "Schneider Electric"
-  ]
+  ],
+  "website": "https://www.se.com/ww/en/brands/apc/",
+  "country": "US",
+  "description": "American power-protection brand of Schneider Electric, best known for uninterruptible power supplies."
 }

--- a/profile_library/athom/manufacturer.json
+++ b/profile_library/athom/manufacturer.json
@@ -3,5 +3,8 @@
   "aliases": [
     "Athom_Technology",
     "China Athom Technology"
-  ]
+  ],
+  "website": "https://www.athom.tech",
+  "country": "CN",
+  "description": "Chinese smart-home manufacturer offering devices preflashed with open-source firmware such as ESPHome and Tasmota."
 }

--- a/profile_library/bang olufsen/manufacturer.json
+++ b/profile_library/bang olufsen/manufacturer.json
@@ -3,5 +3,8 @@
   "aliases": [
     "B&O",
     "Beoplay"
-  ]
+  ],
+  "website": "https://www.bang-olufsen.com",
+  "country": "DK",
+  "description": "Danish luxury-audio manufacturer known for distinctive speakers, televisions and headphones."
 }

--- a/profile_library/belkin/manufacturer.json
+++ b/profile_library/belkin/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Belkin",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.belkin.com",
+  "country": "US",
+  "description": "American consumer-electronics brand producing connectivity accessories and smart-home devices."
 }

--- a/profile_library/blitzwolf/manufacturer.json
+++ b/profile_library/blitzwolf/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "BlitzWolf",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.blitzwolf.com",
+  "country": "CN",
+  "description": "Chinese consumer-electronics brand whose range includes connected lighting and smart-home devices."
 }

--- a/profile_library/bseed/manufacturer.json
+++ b/profile_library/bseed/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "BSEED",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.bseed.com",
+  "country": "CN",
+  "description": "Chinese brand of wall switches, sockets and connected electrical controls."
 }

--- a/profile_library/casalux/manufacturer.json
+++ b/profile_library/casalux/manufacturer.json
@@ -1,4 +1,6 @@
 {
   "name": "Casalux",
-  "aliases": []
+  "aliases": [],
+  "country": "DE",
+  "description": "Aldi lighting label used for products supplied by German manufacturers and importers."
 }

--- a/profile_library/cree/manufacturer.json
+++ b/profile_library/cree/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Cree",
   "aliases": [
     "Tuya"
-  ]
+  ],
+  "website": "https://www.creelighting.com",
+  "country": "US",
+  "description": "American lighting company specializing in energy-efficient LED lamps and luminaires."
 }

--- a/profile_library/dreame/manufacturer.json
+++ b/profile_library/dreame/manufacturer.json
@@ -3,5 +3,8 @@
   "aliases": [
     "Dreametech",
     "Dreametech™"
-  ]
+  ],
+  "website": "https://www.dreametech.com",
+  "country": "CN",
+  "description": "Chinese home-appliance company known for robotic vacuums and other smart cleaning devices."
 }

--- a/profile_library/dygsm/manufacturer.json
+++ b/profile_library/dygsm/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "DYGSM",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.dygsm.com",
+  "country": "CN",
+  "description": "Dongguan-based manufacturer of GSM and smart-home power sockets and alarms."
 }

--- a/profile_library/dyson/manufacturer.json
+++ b/profile_library/dyson/manufacturer.json
@@ -1,3 +1,6 @@
 {
-  "name": "Dyson"
+  "name": "Dyson",
+  "website": "https://www.dyson.com",
+  "country": "SG",
+  "description": "Singapore-headquartered technology company founded in Britain, known for vacuum cleaners and air-treatment appliances."
 }

--- a/profile_library/ecodim/manufacturer.json
+++ b/profile_library/ecodim/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Ecodim",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.ecodim.nl",
+  "country": "NL",
+  "description": "Dutch manufacturer of LED dimmers and connected lighting controls."
 }

--- a/profile_library/elgin/manufacturer.json
+++ b/profile_library/elgin/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Elgin",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.elgin.com.br",
+  "country": "BR",
+  "description": "Brazilian electronics company whose portfolio includes lighting, appliances and smart-home products."
 }

--- a/profile_library/emos/manufacturer.json
+++ b/profile_library/emos/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Emos",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.emos.eu",
+  "country": "CZ",
+  "description": "Czech supplier of electrical and lighting products, including the GoSmart connected-home range."
 }

--- a/profile_library/everspring/manufacturer.json
+++ b/profile_library/everspring/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Everspring",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.everspring.com",
+  "country": "TW",
+  "description": "Taiwanese manufacturer of security, automation and smart-home devices, including Z-Wave products."
 }

--- a/profile_library/ewelight/manufacturer.json
+++ b/profile_library/ewelight/manufacturer.json
@@ -1,4 +1,6 @@
 {
   "name": "eWeLight",
-  "aliases": []
+  "aliases": [],
+  "country": "CN",
+  "description": "Smart-lighting brand used on Wi-Fi lamps made by Zhongshan Julun Technology Lighting."
 }

--- a/profile_library/ge/manufacturer.json
+++ b/profile_library/ge/manufacturer.json
@@ -3,5 +3,8 @@
   "aliases": [
     "GE Appliances",
     "GE_Appliances"
-  ]
+  ],
+  "website": "https://www.gelighting.com",
+  "country": "US",
+  "description": "American lighting brand, now part of Savant, whose connected products include Link and Cync lamps."
 }

--- a/profile_library/genio/manufacturer.json
+++ b/profile_library/genio/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Genio",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.mirabella.com.au/collections/genio",
+  "country": "AU",
+  "description": "Mirabella's Australian smart-home range of lighting, plugs, cameras and other connected devices."
 }

--- a/profile_library/gosund/manufacturer.json
+++ b/profile_library/gosund/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Gosund",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.gosund.com",
+  "country": "CN",
+  "description": "Chinese smart-home brand offering connected plugs, switches, lighting and related devices."
 }

--- a/profile_library/greenwave/manufacturer.json
+++ b/profile_library/greenwave/manufacturer.json
@@ -2,5 +2,7 @@
   "name": "GreenWave",
   "aliases": [
     "GreenWave Reality Inc."
-  ]
+  ],
+  "country": "US",
+  "description": "American smart-energy company behind PowerNode connected plugs and home energy-management systems."
 }

--- a/profile_library/hampton bay/manufacturer.json
+++ b/profile_library/hampton bay/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Hampton Bay",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.homedepot.com/b/Hampton-Bay/N-5yc1vZp4",
+  "country": "US",
+  "description": "The Home Depot's American house brand for lighting, ceiling fans and outdoor furnishings."
 }

--- a/profile_library/hornbach/manufacturer.json
+++ b/profile_library/hornbach/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Hornbach",
   "aliases": [
     "HORNBACH Baumarkt AG"
-  ]
+  ],
+  "website": "https://www.hornbach-holding.de/en",
+  "country": "DE",
+  "description": "German home-improvement retailer whose range includes lighting and electrical products."
 }

--- a/profile_library/hp/manufacturer.json
+++ b/profile_library/hp/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "HP",
   "aliases": [
     "Hewlett-Packard"
-  ]
+  ],
+  "website": "https://www.hp.com",
+  "country": "US",
+  "description": "American technology company producing personal computers, printers and related devices."
 }

--- a/profile_library/intelbras/manufacturer.json
+++ b/profile_library/intelbras/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Intelbras",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.intelbras.com",
+  "country": "BR",
+  "description": "Brazilian technology manufacturer producing security, networking, communication and smart-home devices."
 }

--- a/profile_library/jbl/manufacturer.json
+++ b/profile_library/jbl/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "JBL",
   "aliases": [
     "HARMAN International Industries"
-  ]
+  ],
+  "website": "https://www.jbl.com",
+  "country": "US",
+  "description": "American audio brand of HARMAN producing speakers, headphones and other sound equipment."
 }

--- a/profile_library/kauf/manufacturer.json
+++ b/profile_library/kauf/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Kauf",
-  "aliases": []
+  "aliases": [],
+  "website": "https://kaufha.com",
+  "country": "US",
+  "description": "American home-automation brand offering locally controlled ESPHome-native bulbs and plugs."
 }

--- a/profile_library/kogan/manufacturer.json
+++ b/profile_library/kogan/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Kogan",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.kogan.com",
+  "country": "AU",
+  "description": "Australian online retailer offering consumer electronics and Kogan-branded smart-home products."
 }

--- a/profile_library/ledworks/manufacturer.json
+++ b/profile_library/ledworks/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Ledworks",
-  "aliases": []
+  "aliases": [],
+  "website": "https://twinkly.com",
+  "country": "IT",
+  "description": "Italian company behind Twinkly app-controlled decorative lighting."
 }

--- a/profile_library/lexman/manufacturer.json
+++ b/profile_library/lexman/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Lexman",
   "aliases": [
     "ADEO"
-  ]
+  ],
+  "website": "https://www.leroymerlin.fr/marques/lexman/",
+  "country": "FR",
+  "description": "ADEO's French house brand for lighting and electrical products, sold through retailers such as Leroy Merlin."
 }

--- a/profile_library/lightinginside/manufacturer.json
+++ b/profile_library/lightinginside/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Lightinginside",
   "aliases": [
     "LIGHTINGINSIDE by Launray"
-  ]
+  ],
+  "website": "https://lightinginside.com",
+  "country": "US",
+  "description": "California-based smart-lighting brand offering Wi-Fi lamps, switches and decorative fixtures."
 }

--- a/profile_library/lindby/manufacturer.json
+++ b/profile_library/lindby/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Lindby",
   "aliases": [
     "tuya"
-  ]
+  ],
+  "website": "https://www.lampenwelt.de/c/marken/lindby",
+  "country": "DE",
+  "description": "Lighting brand of the German LUQOM Group, covering decorative and smart luminaires."
 }

--- a/profile_library/luedd/manufacturer.json
+++ b/profile_library/luedd/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Luedd",
   "aliases": [
     "tuya"
-  ]
+  ],
+  "website": "https://www.luedd.com",
+  "country": "NL",
+  "description": "Dutch lighting brand offering decorative and smart LED lamps."
 }

--- a/profile_library/lumiman/manufacturer.json
+++ b/profile_library/lumiman/manufacturer.json
@@ -1,4 +1,6 @@
 {
   "name": "Lumiman",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.lumiman.com",
+  "description": "Smart-lighting brand offering Wi-Fi lamps controlled through the PlusMinus app."
 }

--- a/profile_library/malmbergs/manufacturer.json
+++ b/profile_library/malmbergs/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Malmbergs",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.malmbergs.com",
+  "country": "SE",
+  "description": "Swedish electrical wholesaler and supplier with its own lighting and smart-home products."
 }

--- a/profile_library/mammotion/manufacturer.json
+++ b/profile_library/mammotion/manufacturer.json
@@ -1,3 +1,6 @@
 {
-  "name": "Mammotion"
+  "name": "Mammotion",
+  "website": "https://mammotion.com",
+  "country": "CN",
+  "description": "Chinese outdoor-robotics company known for wire-free robotic lawn mowers."
 }

--- a/profile_library/melitec/manufacturer.json
+++ b/profile_library/melitec/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "MeLiTec",
   "aliases": [
     "LightZone"
-  ]
+  ],
+  "website": "https://www.melitec.de",
+  "country": "DE",
+  "description": "German lighting company offering LED luminaires and smart-home lighting under MeLiTec and related labels."
 }

--- a/profile_library/mercator ikuu/manufacturer.json
+++ b/profile_library/mercator ikuu/manufacturer.json
@@ -5,5 +5,8 @@
     "Mercator",
     "_TZ3000_xr5m6kfg",
     "_TZ3210_xr5m6kfg"
-  ]
+  ],
+  "website": "https://www.ikuu.com.au",
+  "country": "AU",
+  "description": "Smart-home range from Australian lighting and fan supplier Mercator."
 }

--- a/profile_library/neo-coolcam/manufacturer.json
+++ b/profile_library/neo-coolcam/manufacturer.json
@@ -4,6 +4,7 @@
     "neo-coolcam",
     "Shenzhen Neo Electronics Co., Ltd."
   ],
+  "website": "https://www.szneo.com",
   "country": "CN",
   "description": "Shenzhen NEO, making Zigbee and Wi-Fi sensors, plugs and sirens."
 }

--- a/profile_library/netgear/manufacturer.json
+++ b/profile_library/netgear/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "NETGEAR",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.netgear.com",
+  "country": "US",
+  "description": "American networking company producing routers, switches, access points and connected-home equipment."
 }

--- a/profile_library/nodon/manufacturer.json
+++ b/profile_library/nodon/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "NodOn",
   "aliases": [
     "ID-RF"
-  ]
+  ],
+  "website": "https://nodon.fr",
+  "country": "FR",
+  "description": "French manufacturer of wireless sensors and actuators for smart homes and buildings."
 }

--- a/profile_library/oz smart things/manufacturer.json
+++ b/profile_library/oz smart things/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Oz Smart Things",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.ozsmartthings.com.au",
+  "country": "AU",
+  "description": "Australian home-automation retailer and supplier of Zigbee and Z-Wave devices."
 }

--- a/profile_library/philips/manufacturer.json
+++ b/profile_library/philips/manufacturer.json
@@ -1,3 +1,6 @@
 {
-  "name": "Philips"
+  "name": "Philips",
+  "website": "https://www.philips.com",
+  "country": "NL",
+  "description": "Dutch health-technology company producing personal-care and household appliances, including air purifiers."
 }

--- a/profile_library/robb/manufacturer.json
+++ b/profile_library/robb/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "ROBB",
   "aliases": [
     "ROBB smarrt"
-  ]
+  ],
+  "website": "https://www.robbshop.nl/robb-smarrt-ontdek-jouw-vervolgstap-in-smart-home",
+  "country": "NL",
+  "description": "ROBBshop's Dutch smart-home brand of Zigbee dimmers, switches, plugs and other accessories."
 }

--- a/profile_library/rye/manufacturer.json
+++ b/profile_library/rye/manufacturer.json
@@ -1,4 +1,6 @@
 {
   "name": "Rye",
-  "aliases": []
+  "aliases": [],
+  "country": "CN",
+  "description": "Smart-lighting brand used on Wi-Fi lamps made by Shenzhen Bling Lighting Technologies."
 }

--- a/profile_library/smarthomeshop/manufacturer.json
+++ b/profile_library/smarthomeshop/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "SmartHomeShop",
-  "aliases": []
+  "aliases": [],
+  "website": "https://smarthomeshop.io",
+  "country": "NL",
+  "description": "Dutch maker of locally controlled, open-source hardware designed for Home Assistant."
 }

--- a/profile_library/snooz/manufacturer.json
+++ b/profile_library/snooz/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "SNOOZ",
-  "aliases": []
+  "aliases": [],
+  "website": "https://getsnooz.com",
+  "country": "US",
+  "description": "Sleep-technology company known for app-controlled white-noise machines."
 }

--- a/profile_library/sylvania/manufacturer.json
+++ b/profile_library/sylvania/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Sylvania",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.ledvance.com/en-us",
+  "country": "US",
+  "description": "North American lighting brand licensed to LEDVANCE, including the SYLVANIA SMART+ range."
 }

--- a/profile_library/teckin/manufacturer.json
+++ b/profile_library/teckin/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Teckin",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.teckinhome.com",
+  "country": "CN",
+  "description": "Chinese smart-home brand offering connected plugs, lighting, cameras and household devices."
 }

--- a/profile_library/telefunken/manufacturer.json
+++ b/profile_library/telefunken/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Telefunken",
-  "aliases": []
+  "aliases": [],
+  "website": "https://telefunken.com",
+  "country": "DE",
+  "description": "German electronics brand licensed across consumer products, including televisions and lighting."
 }

--- a/profile_library/third reality/manufacturer.json
+++ b/profile_library/third reality/manufacturer.json
@@ -4,5 +4,6 @@
     "Third Reality, Inc"
   ],
   "website": "https://www.thirdreality.com",
+  "country": "CN",
   "description": "Maker of inexpensive Zigbee and Matter sensors, plugs and switches."
 }

--- a/profile_library/treatlife/manufacturer.json
+++ b/profile_library/treatlife/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Treatlife",
   "aliases": [
     "Tuya"
-  ]
+  ],
+  "website": "https://www.treatlife.tech",
+  "country": "CN",
+  "description": "Chinese smart-home brand offering Wi-Fi and Zigbee switches, dimmers, plugs and lighting."
 }

--- a/profile_library/tripp lite/manufacturer.json
+++ b/profile_library/tripp lite/manufacturer.json
@@ -2,5 +2,8 @@
   "name": "Tripp Lite",
   "aliases": [
     "Tripplite"
-  ]
+  ],
+  "website": "https://tripplite.eaton.com",
+  "country": "US",
+  "description": "American Eaton brand producing power protection, connectivity and infrastructure equipment."
 }

--- a/profile_library/trust/manufacturer.json
+++ b/profile_library/trust/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Trust",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.trust.com",
+  "country": "NL",
+  "description": "Dutch digital-lifestyle brand offering computer accessories, gaming products and smart-home devices."
 }

--- a/profile_library/ynoa/manufacturer.json
+++ b/profile_library/ynoa/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Ynoa",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.ledlampenkopen.nu/slimme-verlichting",
+  "country": "NL",
+  "description": "Smart-lighting brand of LEDlampenkopen.nu, offering Zigbee lamps and controls."
 }

--- a/profile_library/zemismart/manufacturer.json
+++ b/profile_library/zemismart/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Zemismart",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.zemismart.com",
+  "country": "CN",
+  "description": "Chinese smart-home manufacturer specializing in connected lighting, sensors, switches and motorized shades."
 }

--- a/profile_library/zipato/manufacturer.json
+++ b/profile_library/zipato/manufacturer.json
@@ -1,4 +1,7 @@
 {
   "name": "Zipato",
-  "aliases": []
+  "aliases": [],
+  "website": "https://www.zipato.com",
+  "country": "HR",
+  "description": "Croatian smart-home brand offering controllers and devices using Z-Wave, Zigbee and other protocols."
 }


### PR DESCRIPTION
## Summary

- audit all 123 manufacturer metadata files
- add verified country, description, and website metadata to 59 manufacturers
- ensure every manufacturer has a description and bring 114 manufacturers to complete metadata
- leave unverifiable or ambiguous fields empty instead of guessing

## Validation

- `uv run python -m utils.library.validate_model_json`
- manufacturer schema validation via commit hooks
- `codespell`
- `git diff --check`