### PR TITLE
Add smartmi zhimi.fan.za5 power profile

### DIFF
--- a/profile_library/smartmi/manufacturer.json
+++ b/profile_library/smartmi/manufacturer.json
@@ -1,0 +1,4 @@
+{
+  "aliases": [],
+  "name": "Smartmi"
+}

--- a/profile_library/smartmi/zhimi.fan.za5/model.json
+++ b/profile_library/smartmi/zhimi.fan.za5/model.json
@@ -1,0 +1,49 @@
+{
+  "authors": [
+    {
+      "github": "yatil",
+      "name": "Eric Eggert"
+    }
+  ],
+  "calculation_strategy": "linear",
+  "created_at": "2026-08-30T05:49:04Z",
+  "device_type": "fan",
+  "linear_config": {
+    "calibrate": [
+      "5 -> 3.30",
+      "10 -> 3.30",
+      "15 -> 3.30",
+      "20 -> 3.30",
+      "25 -> 3.30",
+      "30 -> 4.30",
+      "35 -> 4.30",
+      "40 -> 4.30",
+      "45 -> 4.30",
+      "50 -> 4.30",
+      "55 -> 8.14",
+      "60 -> 8.40",
+      "65 -> 8.40",
+      "70 -> 8.40",
+      "75 -> 8.40",
+      "80 -> 12.23",
+      "85 -> 12.50",
+      "90 -> 12.50",
+      "95 -> 12.50",
+      "100 -> 12.50"
+    ]
+  },
+  "measure_description": "Measured with utils/measure script",
+  "measure_device": "Measurement",
+  "measure_method": "script",
+  "measure_settings": {
+    "SAMPLE_COUNT": 1,
+    "SLEEP_TIME": 2.0,
+    "VERSION": "v0.5.0:app"
+  },
+  "name": "Fan 3",
+  "standby_power": 1.2,
+  "voltage_range": {
+    "max": 237.0,
+    "min": 237.0
+  }
+}


### PR DESCRIPTION
## Device information

- Manufacturer: Smartmi
- Model ID: zhimi.fan.za5
- Product name: Fan 3
- Measurement device: Measurement

## Home Assistant Device information

- Measure type: fan
- Integration: xiaomi_home

## Checklist

- [x] I have created a single PR per device.
- [x] For lights, only generated gzipped lookup tables are included.
- [x] I reviewed the generated files and JSON in Powercalc Measure.

## Additional info

Generated and validated by Powercalc Measure.

### Generated files

- `profile_library/smartmi/zhimi.fan.za5/model.json`
- `profile_library/smartmi/manufacturer.json`

### Duplicate warnings

- None
