### PR TITLE
Fix tests after profile identifier releases

### DIFF
--- a/tests/config_flow/test_discovery.py
+++ b/tests/config_flow/test_discovery.py
@@ -172,7 +172,7 @@ async def test_discovery_flow_with_subprofile_selection(
         hass,
         "light.test",
         "lifx",
-        "LIFX Z",
+        "LZHC2M4INUC07",
         unique_id=DEFAULT_UNIQUE_ID,
     )
 
@@ -195,7 +195,7 @@ async def test_discovery_flow_with_subprofile_selection(
         CONF_ENTITY_ID: DEFAULT_ENTITY_ID,
         CONF_SENSOR_TYPE: SensorType.VIRTUAL_POWER,
         CONF_MANUFACTURER: "lifx",
-        CONF_MODEL: "LIFX Z/length_6",
+        CONF_MODEL: "LZHC2M4INUC07/length_6",
         CONF_NAME: "test",
     }
 

--- a/tests/power_profile/test_library.py
+++ b/tests/power_profile/test_library.py
@@ -57,7 +57,7 @@ async def test_model_listing_sorted(hass: HomeAssistant) -> None:
     models = await library.get_model_listing("signify")
 
     expected = [
-        "1740193P0",
+        "915005561201",
         "9290030514",
         "LCA007",
         "LCT010",


### PR DESCRIPTION
## Summary
- update the LIFX subprofile discovery fixture to canonical model LZHC2M4INUC07
- update the Signify model sorting fixture to canonical model 915005561201
- restore the master test workflow after the profile migrations

## Validation
- uv run pytest tests: 1184 passed
- uv run prek run --all-files: passed