### PR TITLE
Add set-top box device type

### DIFF
--- a/custom_components/powercalc/power_profile/power_profile.py
+++ b/custom_components/powercalc/power_profile/power_profile.py
@@ -54,6 +54,7 @@ class DeviceType(StrEnum):
     LIGHT = "light"
     POWER_METER = "power_meter"
     PRINTER = "printer"
+    SET_TOP_BOX = "set_top_box"
     SMART_DIMMER = "smart_dimmer"
     SMART_SWITCH = "smart_switch"
     SMART_SPEAKER = "smart_speaker"
@@ -88,6 +89,7 @@ DEVICE_TYPE_DOMAIN: dict[DeviceType, str | set[str]] = {
     DeviceType.GENERIC_IOT: {SENSOR_DOMAIN, MEDIA_PLAYER_DOMAIN},
     DeviceType.LIGHT: LIGHT_DOMAIN,
     DeviceType.POWER_METER: SENSOR_DOMAIN,
+    DeviceType.SET_TOP_BOX: MEDIA_PLAYER_DOMAIN,
     DeviceType.SMART_DIMMER: LIGHT_DOMAIN,
     DeviceType.SMART_SWITCH: {SWITCH_DOMAIN, LIGHT_DOMAIN},
     DeviceType.SMART_SPEAKER: MEDIA_PLAYER_DOMAIN,

--- a/docs/source/library/device-types/index.md
+++ b/docs/source/library/device-types/index.md
@@ -16,6 +16,10 @@ Smart power meter. Powercalc profiles can be used to define the self usage of th
 
 ## :material-printer: [Printer](printer.md)
 
+## :material-set-top-box: [Set-top box](set-top-box.md)
+
+Set-top boxes and streaming media players represented by a Home Assistant `media_player` entity.
+
 ## :material-arrow-up-down-bold: [Smart dimmer](smart-dimmer.md)
 
 Smart dimmers are devices that can control the brightness of a light. They are often used in combination with LED lights.

--- a/docs/source/library/device-types/set-top-box.md
+++ b/docs/source/library/device-types/set-top-box.md
@@ -1,0 +1,23 @@
+# Set-top box
+
+Set-top boxes and streaming media players are represented by a Home Assistant `media_player` entity.
+
+Profiles commonly use a fixed calculation strategy with a measured active power and standby power. When the
+device offers multiple standby modes, define them as subprofiles so the user can select the configured mode.
+
+## JSON
+
+```json
+{
+  "calculation_strategy": "fixed",
+  "device_type": "set_top_box",
+  "fixed_config": {
+    "power": 3.3
+  },
+  "standby_power": 0.3
+}
+```
+
+!!! note
+    Required fields are omitted in this example for brevity. For the full list of required fields see the
+    [model structure](../structure.md).

--- a/profile_library/library_schema.json
+++ b/profile_library/library_schema.json
@@ -145,6 +145,7 @@
         "light",
         "power_meter",
         "printer",
+        "set_top_box",
         "smart_dimmer",
         "smart_switch",
         "smart_speaker",

--- a/profile_library/model_schema.json
+++ b/profile_library/model_schema.json
@@ -318,6 +318,7 @@
         "light",
         "power_meter",
         "printer",
+        "set_top_box",
         "smart_dimmer",
         "smart_switch",
         "smart_speaker",

--- a/tests/power_profile/test_power_profile.py
+++ b/tests/power_profile/test_power_profile.py
@@ -29,6 +29,7 @@ from custom_components.powercalc.power_profile.library import ModelInfo, Profile
 from custom_components.powercalc.power_profile.power_profile import (
     DeviceType,
     PowerProfile,
+    is_device_type_supported_for_entity,
 )
 from tests.common import assert_entity_state, get_test_profile_dir, run_powercalc_setup, set_states
 
@@ -217,6 +218,17 @@ async def test_light_domain_supported_for_smart_switch_device_type(hass: HomeAss
     )
     assert power_profile.is_entity_domain_supported(
         SourceEntity("light.test", "test", "light"),
+    )
+
+
+def test_media_player_domain_supported_for_set_top_box_device_type() -> None:
+    assert is_device_type_supported_for_entity(
+        DeviceType.SET_TOP_BOX,
+        RegistryEntryWithDefaults(
+            entity_id="media_player.test",
+            unique_id="1234",
+            platform="cast",
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- add the set_top_box device type for media_player entities
- allow the type in profile and generated-library schemas
- document the new device type and cover its domain mapping

## Validation
- uv run pytest tests (1199 passed)
- uv run prek run --files <changed files>
- uv run --group docs zensical build --clean