### PR TITLE
Add Sagemcom KPN DIW7022 power profile

### DIFF
--- a/profile_library/library.json
+++ b/profile_library/library.json
@@ -21577,6 +21577,62 @@
     },
     {
       "aliases": [],
+      "name": "sagemcom",
+      "full_name": "Sagemcom",
+      "dir_name": "sagemcom",
+      "website": "https://www.sagemcom.com",
+      "country": "FR",
+      "description": "French manufacturer of broadband, telecom and connected entertainment equipment.",
+      "models": [
+        {
+          "aliases": [
+            "KPN TV Box+",
+            "KPN DIW7022"
+          ],
+          "calculation_strategy": "fixed",
+          "compatible_integrations": [
+            "cast"
+          ],
+          "created_at": "2026-08-31T14:18:12Z",
+          "device_type": "set_top_box",
+          "device_specs": {
+            "connectivity": [
+              "wifi",
+              "ethernet"
+            ]
+          },
+          "measure_description": "Each state was measured for one hour. Average power was calculated by dividing the measured energy in kWh by the measurement duration.",
+          "measure_device": "Zhurui PR10",
+          "measure_method": "manual",
+          "mains_voltage": 230,
+          "min_version": "v1.26.0",
+          "name": "KPN TV Box+",
+          "authors": [
+            {
+              "name": "Bram Gerritsen",
+              "email": "bgerritsen@gmail.com",
+              "github": "bramstroker"
+            }
+          ],
+          "id": "DIW7022",
+          "manufacturer": "sagemcom",
+          "updated_at": "1970-01-01T00:00:00",
+          "max_power": 3.22,
+          "sub_profile_count": 2,
+          "power_range": {
+            "min": 3.22,
+            "max": 3.22
+          },
+          "standby_power": 2.45,
+          "hash": "e95cd853b8e3a9128909393118e0a444"
+        }
+      ],
+      "device_types": [
+        "set_top_box"
+      ]
+    },
+    {
+      "aliases": [],
       "name": "sengled",
       "full_name": "Sengled",
       "dir_name": "sengled",

--- a/profile_library/sagemcom/DIW7022/eco/model.json
+++ b/profile_library/sagemcom/DIW7022/eco/model.json
@@ -1,0 +1,8 @@
+{
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 3.22
+  },
+  "name": "Eco standby (0.3 W)",
+  "standby_power": 0.3
+}

--- a/profile_library/sagemcom/DIW7022/model.json
+++ b/profile_library/sagemcom/DIW7022/model.json
@@ -1,0 +1,32 @@
+{
+  "aliases": [
+    "KPN TV Box+",
+    "KPN DIW7022"
+  ],
+  "calculation_strategy": "fixed",
+  "compatible_integrations": [
+    "cast"
+  ],
+  "config_flow_sub_profile_remarks": "Select the standby mode configured on the KPN TV Box+ under Settings > Energy saving. Both modes use 3.22 W while the box is on; only the standby consumption differs.",
+  "created_at": "2026-08-31T14:18:12Z",
+  "device_type": "set_top_box",
+  "device_specs": {
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ]
+  },
+  "measure_description": "Each state was measured for one hour. Average power was calculated by dividing the measured energy in kWh by the measurement duration.",
+  "measure_device": "Zhurui PR10",
+  "measure_method": "manual",
+  "mains_voltage": 230,
+  "min_version": "v1.26.0",
+  "name": "KPN TV Box+",
+  "authors": [
+    {
+      "name": "Bram Gerritsen",
+      "email": "bgerritsen@gmail.com",
+      "github": "bramstroker"
+    }
+  ]
+}

--- a/profile_library/sagemcom/DIW7022/normal/model.json
+++ b/profile_library/sagemcom/DIW7022/normal/model.json
@@ -1,0 +1,8 @@
+{
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 3.22
+  },
+  "name": "Normal standby (2.45 W)",
+  "standby_power": 2.45
+}

--- a/profile_library/sagemcom/manufacturer.json
+++ b/profile_library/sagemcom/manufacturer.json
@@ -1,0 +1,7 @@
+{
+  "name": "Sagemcom",
+  "aliases": [],
+  "website": "https://www.sagemcom.com",
+  "country": "FR",
+  "description": "French manufacturer of broadband, telecom and connected entertainment equipment."
+}


### PR DESCRIPTION
## Summary
- add the Sagemcom DIW7022 / KPN TV Box+ profile for Google Cast media players
- provide manually selectable Eco standby (0.3 W) and Normal standby (2.45 W) subprofiles
- use 3.22 W active consumption in both modes
- document the Zhurui PR10 one-hour-per-state measurement method and guide users to Settings > Energy saving

## Dependency
- stacked on #4663, which introduces the set_top_box device type
- retarget this PR to master after #4663 is merged

## Validation
- full profile library schema validation
- generated profile_library/library.json via utils.library.update_library
- uv run prek run --files <changed files>
- uv run pytest tests (1199 passed)