### PR TITLE
Add appliance device types

### DIFF
--- a/custom_components/powercalc/power_profile/power_profile.py
+++ b/custom_components/powercalc/power_profile/power_profile.py
@@ -12,12 +12,14 @@ from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
 from homeassistant.components.lawn_mower import DOMAIN as LAWN_MOWER_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import translation
 from homeassistant.helpers.entity_registry import RegistryEntry
@@ -47,6 +49,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class DeviceType(StrEnum):
+    AIR_CONDITIONER = "air_conditioner"
+    AIR_PURIFIER = "air_purifier"
     CAMERA = "camera"
     COVER = "cover"
     FAN = "fan"
@@ -63,7 +67,9 @@ class DeviceType(StrEnum):
     VACUUM_ROBOT = "vacuum_robot"
     LAWN_MOWER_ROBOT = "lawn_mower_robot"
     HEATING = "heating"
+    HUMIDIFIER = "humidifier"
     UPS = "ups"
+    WATER_HEATER = "water_heater"
 
 
 class DiscoveryBy(StrEnum):
@@ -83,6 +89,8 @@ class CustomField:
 
 
 DEVICE_TYPE_DOMAIN: dict[DeviceType, str | set[str]] = {
+    DeviceType.AIR_CONDITIONER: CLIMATE_DOMAIN,
+    DeviceType.AIR_PURIFIER: FAN_DOMAIN,
     DeviceType.CAMERA: CAMERA_DOMAIN,
     DeviceType.COVER: COVER_DOMAIN,
     DeviceType.FAN: FAN_DOMAIN,
@@ -99,7 +107,9 @@ DEVICE_TYPE_DOMAIN: dict[DeviceType, str | set[str]] = {
     DeviceType.VACUUM_ROBOT: VACUUM_DOMAIN,
     DeviceType.LAWN_MOWER_ROBOT: LAWN_MOWER_DOMAIN,
     DeviceType.HEATING: CLIMATE_DOMAIN,
+    DeviceType.HUMIDIFIER: HUMIDIFIER_DOMAIN,
     DeviceType.UPS: SENSOR_DOMAIN,
+    DeviceType.WATER_HEATER: WATER_HEATER_DOMAIN,
 }
 
 SUPPORTED_DOMAINS: set[str] = {

--- a/docs/source/library/device-types/air-conditioner.md
+++ b/docs/source/library/device-types/air-conditioner.md
@@ -1,0 +1,25 @@
+# Air conditioner
+
+Air conditioners are represented by a Home Assistant `climate` entity.
+
+Use a fixed or composite calculation strategy when consumption depends on the HVAC mode or other entity attributes.
+
+## JSON
+
+```json
+{
+  "calculation_strategy": "fixed",
+  "device_type": "air_conditioner",
+  "fixed_config": {
+    "states_power": {
+      "cool": 750,
+      "fan_only": 35
+    }
+  },
+  "standby_power": 1.2
+}
+```
+
+!!! note
+    Required fields are omitted in this example for brevity. For the full list of required fields see the
+    [model structure](../structure.md).

--- a/docs/source/library/device-types/air-purifier.md
+++ b/docs/source/library/device-types/air-purifier.md
@@ -1,0 +1,26 @@
+# Air purifier
+
+Air purifiers are represented by a Home Assistant `fan` entity.
+
+Use the linear calculation strategy when power consumption follows the configured fan percentage.
+
+## JSON
+
+```json
+{
+  "calculation_strategy": "linear",
+  "device_type": "air_purifier",
+  "linear_config": {
+    "calibrate": [
+      "0 -> 2.0",
+      "50 -> 12.0",
+      "100 -> 35.0"
+    ]
+  },
+  "standby_power": 0.5
+}
+```
+
+!!! note
+    Required fields are omitted in this example for brevity. For the full list of required fields see the
+    [model structure](../structure.md).

--- a/docs/source/library/device-types/humidifier.md
+++ b/docs/source/library/device-types/humidifier.md
@@ -1,0 +1,22 @@
+# Humidifier
+
+Humidifiers are represented by a Home Assistant `humidifier` entity.
+
+Profiles can use a fixed calculation strategy for devices whose active power consumption is constant.
+
+## JSON
+
+```json
+{
+  "calculation_strategy": "fixed",
+  "device_type": "humidifier",
+  "fixed_config": {
+    "power": 25
+  },
+  "standby_power": 0.4
+}
+```
+
+!!! note
+    Required fields are omitted in this example for brevity. For the full list of required fields see the
+    [model structure](../structure.md).

--- a/docs/source/library/device-types/index.md
+++ b/docs/source/library/device-types/index.md
@@ -2,11 +2,17 @@
 
 Here you can find information about how to setup specific device types for the library.
 
+## :material-air-conditioner: [Air conditioner](air-conditioner.md)
+
+## :material-air-purifier: [Air purifier](air-purifier.md)
+
 ## :material-camera: [Camera](camera.md)
 
 ## :material-blinds-horizontal: [Cover](cover.md)
 
 ## :material-access-point: [Generic IoT](generic-iot.md)
+
+## :material-air-humidifier: [Humidifier](humidifier.md)
 
 ## :material-lightbulb: [Light](light.md)
 
@@ -33,3 +39,5 @@ Used for smart plugs / smart switches which can toggle a connected device on or 
 ## :material-ip-network: [Network](network.md)
 
 ## :material-robot-vacuum: Vacuum robot
+
+## :material-water-boiler: [Water heater](water-heater.md)

--- a/docs/source/library/device-types/water-heater.md
+++ b/docs/source/library/device-types/water-heater.md
@@ -1,0 +1,25 @@
+# Water heater
+
+Water heaters are represented by a Home Assistant `water_heater` entity.
+
+Use a fixed or composite calculation strategy when consumption depends on the operation mode or other entity attributes.
+
+## JSON
+
+```json
+{
+  "calculation_strategy": "fixed",
+  "device_type": "water_heater",
+  "fixed_config": {
+    "states_power": {
+      "electric": 2000,
+      "heat_pump": 500
+    }
+  },
+  "standby_power": 1.0
+}
+```
+
+!!! note
+    Required fields are omitted in this example for brevity. For the full list of required fields see the
+    [model structure](../structure.md).

--- a/profile_library/library_schema.json
+++ b/profile_library/library_schema.json
@@ -136,11 +136,14 @@
     "device_type": {
       "type": "string",
       "enum": [
+        "air_conditioner",
+        "air_purifier",
         "camera",
         "cover",
         "fan",
         "generic_iot",
         "heating",
+        "humidifier",
         "lawn_mower_robot",
         "light",
         "power_meter",
@@ -152,7 +155,8 @@
         "television",
         "network",
         "ups",
-        "vacuum_robot"
+        "vacuum_robot",
+        "water_heater"
       ],
       "description": "Type of device"
     }

--- a/profile_library/model_schema.json
+++ b/profile_library/model_schema.json
@@ -97,7 +97,10 @@
       "if": {
         "properties": {
           "device_type": {
-            "const": "fan"
+            "enum": [
+              "air_purifier",
+              "fan"
+            ]
           }
         },
         "required": [
@@ -311,10 +314,13 @@
     "device_type": {
       "type": "string",
       "enum": [
+        "air_conditioner",
+        "air_purifier",
         "camera",
         "cover",
         "fan",
         "generic_iot",
+        "humidifier",
         "light",
         "power_meter",
         "printer",
@@ -327,7 +333,8 @@
         "vacuum_robot",
         "lawn_mower_robot",
         "heating",
-        "ups"
+        "ups",
+        "water_heater"
       ],
       "description": "Type of device"
     },

--- a/tests/power_profile/test_power_profile.py
+++ b/tests/power_profile/test_power_profile.py
@@ -232,6 +232,26 @@ def test_media_player_domain_supported_for_set_top_box_device_type() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "device_type,entity_id",
+    [
+        (DeviceType.AIR_CONDITIONER, "climate.test"),
+        (DeviceType.AIR_PURIFIER, "fan.test"),
+        (DeviceType.HUMIDIFIER, "humidifier.test"),
+        (DeviceType.WATER_HEATER, "water_heater.test"),
+    ],
+)
+def test_entity_domain_supported_for_device_type(device_type: DeviceType, entity_id: str) -> None:
+    assert is_device_type_supported_for_entity(
+        device_type,
+        RegistryEntryWithDefaults(
+            entity_id=entity_id,
+            unique_id="1234",
+            platform="test",
+        ),
+    )
+
+
 async def test_discovery_does_not_break_when_unknown_device_type(hass: HomeAssistant) -> None:
     library = await ProfileLibrary.factory(hass)
     power_profile = await library.get_profile(


### PR DESCRIPTION
## Summary
- add air conditioner, air purifier, humidifier, and water heater device types
- map each type to its corresponding Home Assistant entity domain
- reuse fan device specifications for air purifier profiles
- document the new profile types and test their domain compatibility

## Testing
- uv run pytest tests -q
- uv run --group library python -m utils.library.validate_model_json
- uv run --group docs zensical build --clean
- commit hooks, including Ruff, mypy, ty, and codespell