### PR TITLE
Restrict profile downloads to the library repository

### DIFF
--- a/custom_components/powercalc/power_profile/loader/remote.py
+++ b/custom_components/powercalc/power_profile/loader/remote.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import shutil
 import tempfile
 from typing import Any, NotRequired, TypedDict, cast
-from urllib.parse import urlsplit
+from urllib.parse import SplitResult, unquote, urlsplit
 
 import aiohttp
 from aiohttp import ClientError
@@ -39,10 +39,30 @@ TIMEOUT_SECONDS = 30
 MODEL_JSON_RETRY_LIMIT = 2
 
 ALLOWED_RESOURCE_HOSTS = frozenset({"github.com", "raw.githubusercontent.com"})
+# Profile resources are only ever served from the profile library of the Powercalc repository.
+# The download API names the URL for every file, so without this the API could point an install
+# at any repository on GitHub. The model hash cannot stand in for this check: it is a digest of
+# the library.json metadata entry, not of the files that get downloaded.
+LIBRARY_REPOSITORY_SEGMENTS = ("bramstroker", "homeassistant-powercalc")
+LIBRARY_RESOURCE_DIRECTORY = "profile_library"
+MAX_RESOURCE_SIZE = 10 * 1024 * 1024
+MAX_MANIFEST_SIZE = 1024 * 1024
+DOWNLOAD_CHUNK_SIZE = 64 * 1024
+
+
+def _is_library_repository_url(parsed_url: SplitResult) -> bool:
+    """Check that a resource URL addresses the profile library of the Powercalc repository."""
+    segments = [segment for segment in unquote(parsed_url.path).split("/") if segment]
+    if any(segment in {".", ".."} for segment in segments):
+        return False
+    repository_depth = len(LIBRARY_REPOSITORY_SEGMENTS)
+    if tuple(segments[:repository_depth]) != LIBRARY_REPOSITORY_SEGMENTS:
+        return False
+    return LIBRARY_RESOURCE_DIRECTORY in segments[repository_depth:]
 
 
 def _validate_resource_url(url: object) -> str:
-    """Validate that a resource URL points to an allowed HTTPS host."""
+    """Validate that a resource URL points to the profile library on an allowed HTTPS host."""
     if not isinstance(url, str):
         raise ProfileDownloadError("Remote profile resource has an invalid URL")
 
@@ -54,6 +74,7 @@ def _validate_resource_url(url: object) -> str:
             and parsed_url.username is None
             and parsed_url.password is None
             and parsed_url.port in (None, 443)
+            and _is_library_repository_url(parsed_url)
         )
     except ValueError as err:
         raise ProfileDownloadError(f"Remote profile resource has an invalid URL: {url}") from err
@@ -61,6 +82,26 @@ def _validate_resource_url(url: object) -> str:
     if not is_allowed:
         raise ProfileDownloadError(f"Remote profile resource URL is not allowed: {url}")
     return url
+
+
+async def _read_capped(response: aiohttp.ClientResponse, limit: int, description: str) -> bytes:
+    """Read a response body, refusing anything larger than `limit` bytes.
+
+    Downloads land in memory before they are written, so an oversized response would otherwise
+    be able to exhaust the memory of the Home Assistant instance.
+    """
+    too_large = ProfileDownloadError(f"{description} is larger than the maximum of {limit} bytes")
+    if response.content_length is not None and response.content_length > limit:
+        raise too_large
+
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in response.content.iter_chunked(DOWNLOAD_CHUNK_SIZE):
+        size += len(chunk)
+        if size > limit:
+            raise too_large
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _resolve_resource_path(storage_path: str, resource_path: object) -> Path:
@@ -612,7 +653,14 @@ class RemoteLoader(Loader):
                 async with session.get(endpoint, params={"hash": model_hash}) as resp:
                     if resp.status != 200:
                         raise ProfileDownloadError(f"Failed to download profile: {manufacturer}/{model}")
-                    resources = await resp.json()
+                    manifest = await _read_capped(resp, MAX_MANIFEST_SIZE, "Remote profile resource manifest")
+
+                try:
+                    resources = json.loads(manifest)
+                except JSONDecodeError as err:
+                    raise ProfileDownloadError(
+                        f"Remote profile response is not valid JSON: {manufacturer}/{model}",
+                    ) from err
 
                 validated_resources = await self.hass.async_add_executor_job(
                     _validate_resources,
@@ -629,7 +677,7 @@ class RemoteLoader(Loader):
                         if resp.status != 200:
                             raise ProfileDownloadError(f"Failed to download github URL: {url}")
 
-                        contents = await resp.read()
+                        contents = await _read_capped(resp, MAX_RESOURCE_SIZE, f"Remote profile resource {url}")
                         downloaded_resources.append((contents, destination))
 
                 await self.hass.async_add_executor_job(_save_resources, downloaded_resources)

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -310,6 +310,22 @@ async def test_download_rejects_invalid_resource_manifest(
         await remote_loader.download_profile("test", "model", str(tmp_path / "profiles"), "test_download")
 
 
+async def test_download_rejects_a_manifest_that_is_not_json(
+    remote_loader: RemoteLoader,
+    mock_aioresponse: aioresponses,
+    tmp_path: Path,
+) -> None:
+    """A manifest that is not JSON must surface as a download error rather than a decoding crash."""
+    mock_aioresponse.get(
+        f"{ENDPOINT_DOWNLOAD}/test/model?hash=test_download",
+        status=200,
+        body=b"<html>gateway error</html>",
+    )
+
+    with pytest.raises(ProfileDownloadError, match="not valid JSON"):
+        await remote_loader.download_profile("test", "model", str(tmp_path / "profiles"), "test_download")
+
+
 async def test_download_rejects_absolute_resource_path(
     remote_loader: RemoteLoader,
     mock_aioresponse: aioresponses,

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import AsyncIterator
 import contextlib
 from functools import partial
 import json
@@ -7,10 +8,11 @@ import os
 from pathlib import Path
 import re
 import shutil
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientResponse
 from aioresponses import aioresponses
 from awesomeversion import AwesomeVersion
 from homeassistant.core import HomeAssistant
@@ -26,12 +28,17 @@ from custom_components.powercalc.power_profile.loader.remote import (
     ENDPOINT_LIBRARY,
     LibraryModel,
     RemoteLoader,
+    _read_capped,
     _save_resource,
 )
 from custom_components.powercalc.power_profile.power_profile import DeviceType, DiscoveryBy
 from tests.common import get_test_config_dir, get_test_profile_dir
 
 pytestmark = pytest.mark.skip_remote_loader_mocking
+
+LIBRARY_URL_PREFIX = "https://raw.githubusercontent.com/bramstroker/homeassistant-powercalc/master/profile_library"
+LIBRARY_RESOURCE_URL = f"{LIBRARY_URL_PREFIX}/test/model/model.json"
+LIBRARY_CSV_RESOURCE_URL = f"{LIBRARY_URL_PREFIX}/test/model/data.csv.gz"
 
 
 @pytest.fixture
@@ -127,11 +134,11 @@ async def test_download_keeps_existing_resources_when_a_later_download_fails(
     resources = [
         {
             "path": "model.json",
-            "url": "https://raw.githubusercontent.com/example/profile/model.json",
+            "url": LIBRARY_RESOURCE_URL,
         },
         {
             "path": "data.csv.gz",
-            "url": "https://raw.githubusercontent.com/example/profile/data.csv.gz",
+            "url": LIBRARY_CSV_RESOURCE_URL,
         },
     ]
     mock_aioresponse.get(
@@ -221,6 +228,11 @@ async def test_download_with_parenthesis(remote_loader: RemoteLoader, mock_aiore
         "https://github.com@127.0.0.1/profile/model.json",
         "https://github.com:444/profile/model.json",
         "https://github.com:invalid/profile/model.json",
+        # Allowed host, but outside the profile library of the Powercalc repository.
+        "https://raw.githubusercontent.com/attacker/evil/master/profile_library/test/model/model.json",
+        "https://raw.githubusercontent.com/bramstroker/homeassistant-powercalc/master/README.md",
+        "https://raw.githubusercontent.com/bramstroker/homeassistant-powercalc/master/profile_library/../../a/b/c.json",
+        "https://raw.githubusercontent.com/bramstroker/homeassistant-powercalc/master/profile_library/%2e%2e/%2e%2e/a/b.json",
         None,
     ],
 )
@@ -253,7 +265,7 @@ async def test_download_rejects_invalid_resource_path(
         payload=[
             {
                 "path": resource_path,
-                "url": "https://raw.githubusercontent.com/example/profile/model.json",
+                "url": LIBRARY_RESOURCE_URL,
             },
         ],
     )
@@ -272,7 +284,7 @@ async def test_download_rejects_invalid_storage_path(
         payload=[
             {
                 "path": "model.json",
-                "url": "https://raw.githubusercontent.com/example/profile/model.json",
+                "url": LIBRARY_RESOURCE_URL,
             },
         ],
     )
@@ -309,7 +321,7 @@ async def test_download_rejects_absolute_resource_path(
         payload=[
             {
                 "path": str(tmp_path / "outside.json"),
-                "url": "https://raw.githubusercontent.com/example/profile/model.json",
+                "url": LIBRARY_RESOURCE_URL,
             },
         ],
     )
@@ -336,7 +348,7 @@ async def test_download_rejects_resource_path_through_symlink(
         payload=[
             {
                 "path": "linked/model.json",
-                "url": "https://raw.githubusercontent.com/example/profile/model.json",
+                "url": LIBRARY_RESOURCE_URL,
             },
         ],
     )
@@ -352,7 +364,7 @@ async def test_download_does_not_follow_resource_redirects(
     mock_aioresponse: aioresponses,
     tmp_path: Path,
 ) -> None:
-    resource_url = "https://raw.githubusercontent.com/example/profile/model.json"
+    resource_url = LIBRARY_RESOURCE_URL
     redirected_url = "http://192.168.1.1/model.json"
     mock_aioresponse.get(
         f"{ENDPOINT_DOWNLOAD}/test/model?hash=test_download",
@@ -367,6 +379,60 @@ async def test_download_does_not_follow_resource_redirects(
         await remote_loader.download_profile("test", "model", str(storage_path), "test_download")
 
     assert not (storage_path / "model.json").exists()
+
+
+async def test_download_rejects_oversized_resource(
+    remote_loader: RemoteLoader,
+    mock_aioresponse: aioresponses,
+    tmp_path: Path,
+) -> None:
+    """A resource larger than the cap must be refused instead of buffered and written."""
+    mock_aioresponse.get(
+        f"{ENDPOINT_DOWNLOAD}/test/model?hash=test_download",
+        status=200,
+        payload=[{"path": "model.json", "url": LIBRARY_RESOURCE_URL}],
+    )
+    mock_aioresponse.get(LIBRARY_RESOURCE_URL, status=200, body=b"x" * 64)
+    storage_path = tmp_path / "profiles"
+
+    with (
+        patch("custom_components.powercalc.power_profile.loader.remote.MAX_RESOURCE_SIZE", 16),
+        pytest.raises(ProfileDownloadError, match="larger than the maximum"),
+    ):
+        await remote_loader.download_profile("test", "model", str(storage_path), "test_download")
+
+    assert not (storage_path / "model.json").exists()
+
+
+async def _async_chunks(chunks: list[bytes]) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
+
+
+def _streamed_response(chunks: list[bytes], content_length: int | None) -> ClientResponse:
+    """Build a minimal stand-in for a streamed aiohttp response."""
+    response = SimpleNamespace(
+        content_length=content_length,
+        content=SimpleNamespace(iter_chunked=lambda _size: _async_chunks(chunks)),
+    )
+    return cast(ClientResponse, response)
+
+
+async def test_read_capped_returns_a_body_within_the_limit() -> None:
+    assert await _read_capped(_streamed_response([b"abc", b"def"], 6), 16, "resource") == b"abcdef"
+
+
+@pytest.mark.parametrize(
+    "chunks, content_length",
+    [
+        ([b"x" * 32], 32),  # the server declares an oversized body up front
+        ([b"x" * 32], None),  # the server declares no length and streams an oversized body
+        ([b"x" * 8] * 4, 4),  # the server understates the body it then streams
+    ],
+)
+async def test_read_capped_rejects_an_oversized_body(chunks: list[bytes], content_length: int | None) -> None:
+    with pytest.raises(ProfileDownloadError, match="larger than the maximum"):
+        await _read_capped(_streamed_response(chunks, content_length), 16, "resource")
 
 
 async def test_get_manufacturer_listing(remote_loader: RemoteLoader) -> None:


### PR DESCRIPTION
## Problem

The download API names the URL for every profile resource, and `_validate_resource_url` only required the URL to sit on an allowed GitHub host (`github.com` / `raw.githubusercontent.com`). Any repository on GitHub satisfied that. A compromised or hostile `api.powercalc.nl` could point an install at, say, `raw.githubusercontent.com/attacker/evil/main/model.json` and the loader would fetch it and cache it as a profile.

The model hash cannot stand in for this check. `create_model_hash` is a digest of the `library.json` metadata entry (minus derived fields), not of the files that get downloaded, and the manifest carries no per-file digest — so there is nothing to compare downloaded bytes against without an API change.

The resource and manifest reads were also unbounded and buffered in full before being written.

## Change

- Resource URLs must now address the profile library of this repository: the path has to start with `bramstroker/homeassistant-powercalc` and carry a `profile_library` segment. The path is unquoted first and any `.` / `..` segment is rejected, so a plain or percent-encoded traversal cannot walk out of the repository. This slots into the existing scheme / host / credential / port conjunction.
- `_read_capped` replaces the unbounded reads. It rejects an oversized declared `Content-Length` up front and counts bytes while streaming, so a server that understates or omits the length is caught too. Caps: 10 MiB per resource, 1 MiB for the manifest. The largest file a profile download can pull today is ~660 KB.

## Verification

- Full suite: 1212 passed. Ruff and mypy clean.
- Checked against the live API rather than only fixtures — `signify/LCA001`, `signify/LCT010`, `avm/FRITZ!Box 5690 Pro` (percent-encoded spaces and `!`) and `aqara/CL-L02D` (nested `rgb/`, `white/` sub-profile paths) all return manifests that pass the new rule.
- Existing path-traversal, symlink and redirect tests used placeholder URLs (`raw.githubusercontent.com/example/profile/...`) that the new rule rejects before reaching the logic under test, so those now use real library URLs via two module constants.
- Added: four URL rejection cases (foreign repo, in-repo file outside `profile_library`, plain and percent-encoded traversal), an end-to-end oversize test asserting nothing is written, and three `_read_capped` cases covering declared-oversize, no-length-streamed-oversize, and understated-length.

## Notes

- This binds downloads to the repository, not to a specific profile — the API could still serve one profile's files under another profile's name. Closing that needs per-file digests in the manifest, which is an API-side change.
- `library.json` itself is still read unbounded (`load_library_json`, `remote.py:375`). At 1.2 MB it exceeds `MAX_MANIFEST_SIZE`, so it needs its own limit rather than reusing that one. Left out of scope here.

Found during a security review of the repository, alongside #4671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBf53BHBgPq5k6CquF2aZ9
