### PR TITLE
fix(ci): exclude unsupported Home Assistant prereleases

### DIFF
--- a/.github/scripts/ha_version_matrix.py
+++ b/.github/scripts/ha_version_matrix.py
@@ -21,7 +21,7 @@ PLUGIN_URL = "https://pypi.org/pypi/pytest-homeassistant-custom-component/json"
 CONST_FILE = "custom_components/powercalc/const.py"
 STABLE_VERSION = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 PYTHON_FLOOR = re.compile(r">=\s*(\d+)\.(\d+)")
-PLUGIN_HA_PIN = re.compile(r"^homeassistant\s*==\s*(\d+)\.(\d+)\.(\d+)")
+PLUGIN_HA_PIN = re.compile(r"^homeassistant\s*==\s*(\d+)\.(\d+)\.(\d+)([^\s;]*)\s*(?:;.*)?$")
 
 
 def read_min_version() -> tuple[int, int]:
@@ -65,17 +65,18 @@ def fetch_releases() -> dict[str, str]:
 def fetch_max_supported_version() -> tuple[int, int, int]:
     """Return the newest Home Assistant release the test plugin can be installed against.
 
-    pytest-homeassistant-custom-component pins one exact Home Assistant release, so its newest
-    release names the newest one that has a matching plugin. A Home Assistant release published
-    before the plugin catches up has none, and asking for both together does not fail: the
-    resolver walks back to a plugin old enough to pin no Home Assistant at all, quietly bringing
-    a pytest that predates the Python we run on. Leave those releases out until the plugin lands.
+    pytest-homeassistant-custom-component pins one exact Home Assistant release. During a beta,
+    its newest release may pin a prerelease such as 2026.9.0b6. In that case, cap the matrix below
+    that patch so the stable release is not tested until a plugin that supports it is published.
     """
     info = fetch_pypi_json(PLUGIN_URL)["info"]
     for requirement in info.get("requires_dist") or []:
         pin = PLUGIN_HA_PIN.match(requirement)
         if pin:
-            return int(pin.group(1)), int(pin.group(2)), int(pin.group(3))
+            patch = int(pin.group(3))
+            if pin.group(4):
+                patch -= 1
+            return int(pin.group(1)), int(pin.group(2)), patch
 
     raise RuntimeError(f"pytest-homeassistant-custom-component {info['version']} does not pin a Home Assistant release")
 

--- a/.github/scripts/tests/__init__.py
+++ b/.github/scripts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for standalone repository scripts."""

--- a/.github/scripts/tests/conftest.py
+++ b/.github/scripts/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make the scripts directory importable for script unit tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/.github/scripts/tests/test_ha_version_matrix.py
+++ b/.github/scripts/tests/test_ha_version_matrix.py
@@ -1,0 +1,46 @@
+"""Tests for the Home Assistant compatibility matrix."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import ha_version_matrix
+import pytest
+
+
+@pytest.mark.parametrize(
+    "home_assistant_pin,expected",
+    [
+        ("2026.9.0", (2026, 9, 0)),
+        ("2026.9.0b6", (2026, 9, -1)),
+        ("2026.9.1rc2", (2026, 9, 0)),
+    ],
+)
+def test_fetch_max_supported_version_caps_prereleases(
+    monkeypatch: pytest.MonkeyPatch,
+    home_assistant_pin: str,
+    expected: tuple[int, int, int],
+) -> None:
+    """A prerelease plugin pin must not enable its corresponding stable release."""
+    response: dict[str, Any] = {
+        "info": {
+            "version": "0.13.362",
+            "requires_dist": [f"homeassistant=={home_assistant_pin}"],
+        },
+    }
+    monkeypatch.setattr(ha_version_matrix, "fetch_pypi_json", lambda _url: response)
+
+    assert ha_version_matrix.fetch_max_supported_version() == expected
+
+
+def test_fetch_max_supported_version_accepts_environment_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment markers after an exact stable pin remain supported."""
+    response: dict[str, Any] = {
+        "info": {
+            "version": "0.13.362",
+            "requires_dist": ['homeassistant==2026.8.3; python_version >= "3.14"'],
+        },
+    }
+    monkeypatch.setattr(ha_version_matrix, "fetch_pypi_json", lambda _url: response)
+
+    assert ha_version_matrix.fetch_max_supported_version() == (2026, 8, 3)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - '.github/scripts/ha_version_matrix.py'
+      - '.github/scripts/tests/**'
       - '.github/scripts/profile_library/**'
       - '.github/scripts/release_draft/**'
       - '.github/workflows/test.yml'
@@ -16,6 +17,7 @@ on:
   pull_request:
     paths:
       - '.github/scripts/ha_version_matrix.py'
+      - '.github/scripts/tests/**'
       - '.github/scripts/profile_library/**'
       - '.github/scripts/release_draft/**'
       - '.github/workflows/test.yml'
@@ -56,6 +58,8 @@ jobs:
         run: bash tests/setup.sh
       - name: Run release draft engine tests
         run: uv run --locked pytest .github/scripts/release_draft/tests -qq
+      - name: Run workflow script tests
+        run: uv run --locked pytest .github/scripts/tests -qq
       - name: Run profile library script tests
         run: uv run --locked pytest .github/scripts/profile_library/tests -qq
       - name: Run tests


### PR DESCRIPTION
## Summary

- distinguish stable Home Assistant pins from beta and RC pins in the compatibility matrix
- cap prerelease pins below their corresponding stable patch
- add regression tests and run them in CI

## Why

The latest pytest-homeassistant-custom-component currently pins Home Assistant 2026.9.0b6. The matrix parser interpreted that as stable 2026.9.0, causing dependency resolution to fail before pytest started.

## Validation

- 4 matrix unit tests passed
- live PyPI matrix ends at Home Assistant 2026.8.3
- all pre-commit hooks passed, including workflow validation, Ruff, mypy, ty, actionlint and zizmor