### PR TITLE
Ignore localtuya fork work mode labels (Default, Mode Color) in LUT strategy

### DIFF
--- a/custom_components/powercalc/strategy/lut.py
+++ b/custom_components/powercalc/strategy/lut.py
@@ -232,7 +232,7 @@ class LutStrategy(PowerCalculationStrategyInterface):
             return None
 
         effect = attrs.get(ATTR_EFFECT)
-        if effect and str(effect).lower() not in ("off", "none", "white"):
+        if effect and str(effect).lower() not in ("off", "none", "white", "default", "mode color"):
             return await self._calculate_effect_power(entity_state, str(effect), brightness)
 
         lut_mode = LookupMode.from_color_mode(color_mode)

--- a/tests/strategy/test_lut.py
+++ b/tests/strategy/test_lut.py
@@ -231,6 +231,8 @@ async def test_effect_not_found_logs_warning(hass: HomeAssistant, caplog: pytest
         "Off",
         "White",
         "None",
+        "Default",
+        "Mode Color",
     ],
 )
 async def test_lut_effect_is_ignored(


### PR DESCRIPTION
## What happens

Users of the [xZetsubou localtuya fork](https://github.com/xZetsubou/hass-localtuya) (the maintained replacement for the original localtuya, which broke on HA 2026.3) get an `unavailable` power sensor whenever a LUT bulb is on.

The fork exposes a Tuya bulb's work modes through the HA effect list, so a bulb in plain white mode reports `effect: Default` and a bulb showing a static colour reports `effect: Mode Color` (labels come from xZetsubou/hass-localtuya#405). Neither is an animation. The LUT strategy treats any effect not named `off`, `none` or `white` as a real effect, finds no effect table in the profile, and gives up:

```
WARNING [custom_components.powercalc.strategy.lut] light.bulb000: Effects not supported for this power profile
```

## Fix

Add `default` and `mode color` to the ignored effect names, next to `off`, `none` and `white`. Same approach as #4028. Comparison is case insensitive. White mode then falls through to the `color_temp` table and colour mode to the `hs` table, which is the right power for a static colour.

`Mode Scene`, the fork's third label, is left alone on purpose. That one is a running animation and the warning is correct when the profile has no data for it.

## Library impact

One profile is affected: `lsc/970714` has `Default` and `Mode Color` measured as effects (that contributor hit this same issue). Those rows become unused and the profile falls through to its own `color_temp` and `hs` tables instead, which hold more data. Its real scenes still resolve through its effect table. No other profile uses either name.

## Testing

- `Default` and `Mode Color` added to `test_lut_effect_is_ignored`.
- Reproduced on a Sylvania `40A19FILCCLWIFI` on the fork with HA 2026.8.3. Sensor is `unavailable` with the fork's effect attribute present and returns the expected LUT value once it is gone, so the fallthrough works for that light.
- Patch not yet run on a live install; relying on CI for the suite.
