### PR TITLE
Add sub profiles to vesync Core200S for the 37 W and 45 W hardware variants

### DIFF
--- a/profile_library/vesync/Core200S/model.json
+++ b/profile_library/vesync/Core200S/model.json
@@ -17,20 +17,19 @@
   "mains_voltage": 230,
   "name": "Smart Air Purifier",
   "product_url": "https://levoit.com/products/core-200s-p-smart-air-purifier",
-  "standby_power": 0.6,
-  "fixed_config": {
-    "states_power": {
-      "preset_mode|sleep": 17,
-      "percentage|33": 21,
-      "percentage|66": 27,
-      "percentage|100": 39
-    }
+  "config_flow_sub_profile_remarks": "Levoit ships more than one hardware rating as Core 200S (also branded Core 200S-P) and Home Assistant reports all of them as Core200S. Check the Rated Power on the label on the back of the unit:\n\"rated_37w\": 37 W (US) or 38 W (EU), units from at least 2021 on.\n\"rated_45w\": 45 W, Core 200S-P units made from late 2025.",
+  "sub_profile_select": {
+    "default": "rated_37w"
   },
   "authors": [
     {
       "name": "SH1FT-W",
       "github": "SH1FT-W",
       "email": "danielvizzino@outlook.com"
+    },
+    {
+      "name": "Ryan Ronnander",
+      "github": "ryan-ronnander"
     }
   ]
 }

--- a/profile_library/vesync/Core200S/rated_37w/model.json
+++ b/profile_library/vesync/Core200S/rated_37w/model.json
@@ -1,0 +1,22 @@
+{
+  "name": "Rated 37 W (US) / 38 W (EU)",
+  "device_specs": {
+    "form_factor": "air_purifier",
+    "rated_power": 37,
+    "connectivity": [
+      "wifi"
+    ]
+  },
+  "measure_device": "SONOFF S60ZBTPF",
+  "measure_description": "Measured manually on a 230 V unit rated 38 W. Original flat profile values. Levoit's 2021 US manual lists the same generation at 37 W.",
+  "mains_voltage": 230,
+  "standby_power": 0.6,
+  "fixed_config": {
+    "states_power": {
+      "preset_mode|sleep": 17,
+      "percentage|33": 21,
+      "percentage|66": 27,
+      "percentage|100": 39
+    }
+  }
+}

--- a/profile_library/vesync/Core200S/rated_45w/model.json
+++ b/profile_library/vesync/Core200S/rated_45w/model.json
@@ -1,0 +1,22 @@
+{
+  "name": "Rated 45 W (Core 200S-P, late 2025 units)",
+  "device_specs": {
+    "form_factor": "air_purifier",
+    "rated_power": 45,
+    "connectivity": [
+      "wifi"
+    ]
+  },
+  "measure_device": "P3 P4400 Kill A Watt Usage Monitor",
+  "measure_description": "US 120 V Core 200S-P, label rated 45 W, date code 1225.",
+  "mains_voltage": 120,
+  "standby_power": 0.8,
+  "fixed_config": {
+    "states_power": {
+      "preset_mode|sleep": 7.7,
+      "percentage|33": 16.1,
+      "percentage|66": 23.7,
+      "percentage|100": 45.4
+    }
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

Levoit Core 200S smart air purifier, https://levoit.com/products/core-200s-p-smart-air-purifier

**The problem this solves.** The Home Assistant VeSync integration exposes only the base model string `Core200S`. No hardware revision, no edition (`200S-P`), no `hw_version`. But Levoit has shipped two, possibly three, hardware variants under the "200S" base model, and the label's own "Model" line says `Core 200S` on all of them:

| Hardware | Sold as | Label says | Notes |
|---|---|---|---|
| 2021 onward (LAP-C201S-AUSR) | Core 200S / Core 200S-P | Rated Power 37W (US), 38W (EU) | Levoit's 2021 US manual lists 37 W; the existing library profile was measured on a 38 W EU unit |
| late 2025 production | Core 200S-P | Rated Power 45W | this PR, measured on a unit with date code 1225 |
| 2020 original (LAP-C201S-WUS)? | Core 200S | unconfirmed | reviews of 2020/2021 units measured 25 to 28 W at high; whether that is a separately rated variant or just the 37 W unit's real draw is unconfirmed, not covered |

Even the "-P" branding does not help: Levoit's current Core 200S-P product page specifies 37 W, while my Core 200S-P label says 45 W. So autodiscovery matches all of them to the same profile, and any single set of values is wrong for the others by 20 to 50 % at high speed. The only thing a user can actually check is the Rated Power printed on the label on the back of the unit.

This PR turns the flat profile into sub profiles keyed on that label value, so the config flow asks the user which one they have:

| Sub profile | Label says | Values |
|---|---|---|
| `rated_37w` (default) | 37W / 38W | the existing profile values, unchanged |
| `rated_45w` | 45W | new measurements, this PR |

The two labels, identical apart from rated power, ETL number and production data (both carry FCC ID 2ARBY-CORE-200SB):

- 45 W unit (mine, date code 1225):  <br /><br /><img width="1702" height="1244" alt="image" src="https://github.com/user-attachments/assets/7e02c9ff-8e5d-4a90-b3a0-28a4575c4039" />

- 37 W unit (date code 0823, from https://www.reddit.com/r/AirPurifiers/comments/1ss0txw/help_finding_correct_replacement_filter/): <br /><br /><img width="1080" height="950" alt="image" src="https://github.com/user-attachments/assets/534c5162-1c35-4913-8067-a9ba0c4239ec" />

Levoit's product pages and manuals don't even appear to list 45 W ratings. It exists only on the label of the newer units so far based on my own purchase from a few months ago (Amazon, USA).

Existing users are unaffected: the default sub profile carries the current values, so a configured entry keeps producing the same numbers.

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

```
Core 200S Series
by VeSync
Model: Core200S
Firmware: 2.0.01
```

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] The model name does not repeat the manufacturer name.
- [x] I have checked existing profiles for this manufacturer for consistent naming and metadata.
- [x] I have reused the existing `measure_device` value when my measurement device is already in the library.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->

`rated_45w` measurements, P3 Kill A Watt on a US 120 V unit, each speed held for several minutes before reading:

| Mode | HA state | Power |
|---|---|---|
| Sleep | `preset_mode: sleep` | 7.7 W |
| Low | `percentage: 33` | 16.1 W |
| Medium | `percentage: 66` | 23.7 W |
| High | `percentage: 100` | 45.4 W |
| Standby | `off` | 0.8 W |

High matches the label's 45 W rating. The night light adds about 0.05 W dimmed and 0.2 W bright on top of any mode; it lives on a separate select entity and is not modelled. The `rated_37w` sub profile is the original profile by @SH1FT-W moved unchanged into a subdirectory; `measure_device`, `mains_voltage` and `standby_power` travel with it.
