### PR TITLE
Batch release draft API requests

### DIFF
--- a/.github/scripts/release_draft/github_client.py
+++ b/.github/scripts/release_draft/github_client.py
@@ -1,4 +1,4 @@
-"""Minimal GitHub REST client used by the draft entry points.
+"""Minimal GitHub API client used by the draft entry points.
 
 Standard library only, so the entry points run with a bare ``python3`` on the
 runner without any dependency install, exactly like the previous scripts.
@@ -11,7 +11,9 @@ from typing import Any, cast
 import urllib.request
 
 API_ROOT = "https://api.github.com"
+GRAPHQL_URL = f"{API_ROOT}/graphql"
 PAGE_SIZE = 100
+COMMIT_LOOKUP_BATCH_SIZE = 50
 type JsonObject = dict[str, Any]
 type JsonResponse = JsonObject | list[JsonObject] | None
 
@@ -56,12 +58,75 @@ class GitHubClient:
             page += 1
 
     def merged_pull_requests(self, commit_shas: list[str]) -> list[dict[str, Any]]:
-        """Resolve pushed commits to the merged pull requests they belong to."""
+        """Resolve pushed commits to merged pull requests in batched queries."""
         pull_requests: dict[int, dict[str, Any]] = {}
-        for sha in commit_shas:
-            for pull_request in self._request_list("GET", f"/repos/{self.repository}/commits/{sha}/pulls"):
-                if pull_request.get("merged_at") is not None:
-                    pull_requests.setdefault(int(pull_request["number"]), pull_request)
+        owner, name = self.repository.split("/", maxsplit=1)
+        for offset in range(0, len(commit_shas), COMMIT_LOOKUP_BATCH_SIZE):
+            batch = commit_shas[offset : offset + COMMIT_LOOKUP_BATCH_SIZE]
+            commit_fields = "\n".join(
+                f"""
+                commit{index}: object(oid: {json.dumps(sha)}) {{
+                  ... on Commit {{
+                    associatedPullRequests(first: 10) {{
+                      nodes {{
+                        number
+                        title
+                        mergedAt
+                        author {{ login }}
+                        labels(first: 100) {{ nodes {{ name }} }}
+                      }}
+                    }}
+                  }}
+                }}
+                """
+                for index, sha in enumerate(batch)
+            )
+            response = self._request(
+                "POST",
+                GRAPHQL_URL,
+                {
+                    "query": f"""
+                        query($owner: String!, $name: String!) {{
+                          repository(owner: $owner, name: $name) {{
+                            {commit_fields}
+                          }}
+                        }}
+                    """,
+                    "variables": {"owner": owner, "name": name},
+                },
+            )
+            if not isinstance(response, dict):
+                raise RuntimeError("GitHub GraphQL commit lookup returned no data")
+            if response.get("errors"):
+                raise RuntimeError(f"GitHub GraphQL commit lookup failed: {response['errors']}")
+            data = response.get("data")
+            if not isinstance(data, dict) or not isinstance(repository := data.get("repository"), dict):
+                raise RuntimeError("GitHub GraphQL commit lookup returned no repository data")
+            for index in range(len(batch)):
+                git_object = repository.get(f"commit{index}")
+                if not isinstance(git_object, dict):
+                    continue
+                associated = git_object.get("associatedPullRequests")
+                if not isinstance(associated, dict) or not isinstance(nodes := associated.get("nodes"), list):
+                    continue
+                for node in nodes:
+                    if not isinstance(node, dict) or node.get("mergedAt") is None:
+                        continue
+                    labels = node.get("labels")
+                    label_nodes = labels.get("nodes", []) if isinstance(labels, dict) else []
+                    author = node.get("author")
+                    pull_request = {
+                        "number": int(node["number"]),
+                        "title": str(node["title"]),
+                        "merged_at": node["mergedAt"],
+                        "user": {"login": str(author.get("login", "ghost")) if isinstance(author, dict) else "ghost"},
+                        "labels": [
+                            {"name": str(label["name"])}
+                            for label in label_nodes
+                            if isinstance(label, dict) and "name" in label
+                        ],
+                    }
+                    pull_requests.setdefault(pull_request["number"], pull_request)
         return [pull_requests[number] for number in sorted(pull_requests)]
 
     def pull_request_files(self, number: int) -> list[str]:

--- a/.github/scripts/release_draft/tests/test_github_client.py
+++ b/.github/scripts/release_draft/tests/test_github_client.py
@@ -1,9 +1,71 @@
-"""Tests for the GitHub REST client helpers."""
+"""Tests for the GitHub API client helpers."""
 
 from typing import Any
 
 from github_client import GitHubClient
 import pytest
+
+
+def test_merged_pull_requests_uses_one_batched_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = GitHubClient("token", "owner/repo")
+    requests: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def request(method: str, url: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        requests.append((method, url, payload))
+        pull_request = {
+            "number": 42,
+            "title": "fix: make drafting fast",
+            "mergedAt": "2026-09-02T12:00:00Z",
+            "author": {"login": "octocat"},
+            "labels": {"nodes": [{"name": "bugfix"}]},
+        }
+        return {
+            "data": {
+                "repository": {
+                    "commit0": {"associatedPullRequests": {"nodes": [pull_request]}},
+                    "commit1": {"associatedPullRequests": {"nodes": [pull_request]}},
+                    "commit2": {"associatedPullRequests": {"nodes": []}},
+                },
+            },
+        }
+
+    monkeypatch.setattr(client, "_request", request)
+
+    assert client.merged_pull_requests(["sha1", "sha2", "sha3"]) == [
+        {
+            "number": 42,
+            "title": "fix: make drafting fast",
+            "merged_at": "2026-09-02T12:00:00Z",
+            "user": {"login": "octocat"},
+            "labels": [{"name": "bugfix"}],
+        },
+    ]
+    assert len(requests) == 1
+    assert requests[0][0:2] == ("POST", "https://api.github.com/graphql")
+    assert requests[0][2] is not None
+    assert requests[0][2]["variables"] == {"owner": "owner", "name": "repo"}
+
+
+def test_merged_pull_requests_splits_large_histories_into_batches(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = GitHubClient("token", "owner/repo")
+    requests = 0
+
+    def request(_method: str, _url: str, _payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        nonlocal requests
+        requests += 1
+        commit_count = 50 if requests == 1 else 1
+        return {
+            "data": {
+                "repository": {
+                    f"commit{index}": {"associatedPullRequests": {"nodes": []}} for index in range(commit_count)
+                },
+            },
+        }
+
+    monkeypatch.setattr(client, "_request", request)
+
+    assert client.merged_pull_requests([f"sha{index}" for index in range(51)]) == []
+    assert requests == 2
 
 
 def test_pull_request_file_details_preserve_status(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/.github/scripts/release_draft/tests/test_integration_draft.py
+++ b/.github/scripts/release_draft/tests/test_integration_draft.py
@@ -25,8 +25,10 @@ class FakeClient:
         self._files_by_pull_request = files_by_pull_request or {}
         self.created: list[dict[str, Any]] = []
         self.updated: list[tuple[int, dict[str, Any]]] = []
+        self.release_requests = 0
 
     def releases(self) -> list[dict[str, Any]]:
+        self.release_requests += 1
         return self._releases
 
     def commit_sha(self, ref: str) -> str:
@@ -89,6 +91,7 @@ def test_stable_creates_draft_and_resolves_minor(monkeypatch: pytest.MonkeyPatch
     assert payload["draft"] is True
     assert "### 🚀 Features" in payload["body"]
     assert "- #10 feat: add sensor @octocat" in payload["body"]
+    assert client.release_requests == 1
 
 
 def test_stable_updates_existing_draft(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/.github/scripts/release_draft/update_integration_draft.py
+++ b/.github/scripts/release_draft/update_integration_draft.py
@@ -84,11 +84,11 @@ def _qualifies(pull_request: dict[str, Any]) -> bool:
     return not _labels(pull_request) & EXCLUDE_LABELS
 
 
-def _latest_stable_release(client: GitHubClient) -> dict[str, Any] | None:
+def _latest_stable_release(releases: list[dict[str, Any]]) -> dict[str, Any] | None:
     """The highest published, non-prerelease ``vX.Y.Z`` release."""
     best: dict[str, Any] | None = None
     best_version: tuple[int, int, int] | None = None
-    for release in client.releases():
+    for release in releases:
         if release["draft"] or release["prerelease"]:
             continue
         match = STABLE_TAG.match(release["tag_name"])
@@ -101,11 +101,11 @@ def _latest_stable_release(client: GitHubClient) -> dict[str, Any] | None:
     return best
 
 
-def _next_beta_number(client: GitHubClient, core: tuple[int, int, int]) -> int:
+def _next_beta_number(releases: list[dict[str, Any]], core: tuple[int, int, int]) -> int:
     prefix = f"v{format_version(core)}-beta."
     numbers = [
         int(release["tag_name"][len(prefix) :])
-        for release in client.releases()
+        for release in releases
         if not release["draft"]
         and release["tag_name"].startswith(prefix)
         and release["tag_name"][len(prefix) :].isdigit()
@@ -113,7 +113,7 @@ def _next_beta_number(client: GitHubClient, core: tuple[int, int, int]) -> int:
     return max(numbers) + 1 if numbers else 0
 
 
-def _find_draft(client: GitHubClient, *, prerelease: bool) -> dict[str, Any] | None:
+def _find_draft(releases: list[dict[str, Any]], *, prerelease: bool) -> dict[str, Any] | None:
     """The existing integration draft for the given channel, if any.
 
     Matched on the prerelease flag and a ``v`` tag, which keeps the two channel
@@ -122,7 +122,7 @@ def _find_draft(client: GitHubClient, *, prerelease: bool) -> dict[str, Any] | N
     return next(
         (
             release
-            for release in client.releases()
+            for release in releases
             if release["draft"] and bool(release["prerelease"]) == prerelease and release["tag_name"].startswith("v")
         ),
         None,
@@ -194,7 +194,8 @@ def main() -> None:
     channel = os.environ.get("CHANNEL", "stable")
     head_ref = os.environ.get("HEAD_REF", "master")
 
-    base = _latest_stable_release(client)
+    releases = client.releases()
+    base = _latest_stable_release(releases)
     if base is None:
         print("No published stable release found; nothing to draft against")
         return
@@ -219,13 +220,13 @@ def main() -> None:
     body = _build_body(pull_requests, _supporters_footer(), new_profile_counts)
 
     if channel == "beta":
-        version = f"{format_version(next_core)}-beta.{_next_beta_number(client, next_core)}"
+        version = f"{format_version(next_core)}-beta.{_next_beta_number(releases, next_core)}"
         prerelease = True
     else:
         version = format_version(next_core)
         prerelease = False
 
-    draft = _find_draft(client, prerelease=prerelease)
+    draft = _find_draft(releases, prerelease=prerelease)
     payload = {
         "tag_name": f"v{version}",
         "name": NAME_TEMPLATE.format(version=version),


### PR DESCRIPTION
## Summary

- resolve merged pull requests through batched GraphQL queries instead of one REST request per commit
- reuse the integration release list for version and draft selection
- retain deterministic PR ordering and deduplication

## Performance

The current release range contains 350 commits. This reduces the dominant commit-to-PR lookup from 350 sequential requests to 7 batched requests.

## Tests

- `uv run pytest .github/scripts/release_draft/tests -q`
- `uv run ruff format --check .github/scripts/release_draft`
- `uv run ruff check .github/scripts/release_draft`
- `uv run mypy .github/scripts/release_draft`
- `uv run ty check .github/scripts/release_draft`
- repository pre-commit hooks