### PR TITLE
Initialize standby group from tracked sensors

### DIFF
--- a/custom_components/powercalc/sensors/group/standby.py
+++ b/custom_components/powercalc/sensors/group/standby.py
@@ -77,6 +77,7 @@ class StandbyPowerSensor(PowerSensor, SensorEntity):
                 self._recalculate,
             ),
         )
+        await self._recalculate()
 
     async def _recalculate(self) -> None:
         """Calculate sum of all power sensors in standby, and update the state of the sensor."""

--- a/tests/sensors/group/test_standby.py
+++ b/tests/sensors/group/test_standby.py
@@ -59,6 +59,23 @@ async def test_standby_group(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "sensor.all_standby_power", "0.20")
 
 
+async def test_standby_group_includes_devices_already_off_at_startup(hass: HomeAssistant) -> None:
+    await set_states(hass, [("input_boolean.test", STATE_OFF)])
+
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_ENTITY_ID: "input_boolean.test",
+            CONF_STANDBY_POWER: 0.2,
+            CONF_MODE: CalculationStrategy.FIXED,
+            CONF_FIXED: {CONF_POWER: 20},
+        },
+    )
+
+    assert_entity_state(hass, "sensor.test_power", "0.20")
+    assert_entity_state(hass, "sensor.all_standby_power", "0.20")
+
+
 async def test_standby_group_utility_meter(hass: HomeAssistant) -> None:
     await run_powercalc_setup(
         hass,


### PR DESCRIPTION
## Summary

- recalculate the aggregate standby sensor when it is added to Home Assistant
- include standby values already tracked by devices that initialized earlier during startup
- add a regression test for a device that is already off at startup

This addresses the inconsistent startup behavior described in https://github.com/bramstroker/homeassistant-powercalc/discussions/4192, where the individual power sensor could show standby consumption while the aggregate standby group omitted it until a later state change.

## Testing

- `uv run pytest tests/sensors/group tests/sensors/test_standby_energy.py` (88 passed)
- repository pre-commit hooks (Ruff, Ruff format, mypy, ty, codespell, and other configured checks)