### PR TITLE
Add missing alias to ikea LED1739R5

### DIFF
--- a/profile_library/ikea/LED1739R5/model.json
+++ b/profile_library/ikea/LED1739R5/model.json
@@ -1,4 +1,7 @@
 {
+  "aliases": [
+    "TRADFRI bulb GU10 WS 400lm"
+  ],
   "calculation_strategy": "lut",
   "created_at": "2024-11-20T11:28:25Z",
   "device_type": "light",


### PR DESCRIPTION
See https://github.com/bramstroker/homeassistant-powercalc/discussions/4686.
This spot also identifies as `TRADFRI bulb GU10 WS 400lm` in ZHA.