### PR TITLE
fix: harden remote profile downloads

### DIFF
--- a/custom_components/powercalc/power_profile/loader/remote.py
+++ b/custom_components/powercalc/power_profile/loader/remote.py
@@ -47,6 +47,9 @@ LIBRARY_REPOSITORY_SEGMENTS = ("bramstroker", "homeassistant-powercalc")
 LIBRARY_RESOURCE_DIRECTORY = "profile_library"
 MAX_RESOURCE_SIZE = 10 * 1024 * 1024
 MAX_MANIFEST_SIZE = 1024 * 1024
+MAX_LIBRARY_SIZE = 10 * 1024 * 1024
+MAX_PROFILE_RESOURCES = 256
+MAX_PROFILE_DOWNLOAD_SIZE = 25 * 1024 * 1024
 DOWNLOAD_CHUNK_SIZE = 64 * 1024
 
 
@@ -104,6 +107,48 @@ async def _read_capped(response: aiohttp.ClientResponse, limit: int, description
     return b"".join(chunks)
 
 
+def _validate_path_segment(value: object, description: str) -> str:
+    """Validate a library identifier before using it as one directory component."""
+    if (
+        not isinstance(value, str)
+        or not value
+        or value in {".", ".."}
+        or any(character in value for character in ("/", "\\", ":", "\0"))
+    ):
+        raise ProfileDownloadError(f"Library index contains an invalid {description}")
+    return value
+
+
+def _validate_library_contents(contents: object) -> dict[str, Any]:
+    """Validate the parts of library.json that determine local storage paths."""
+    if not isinstance(contents, dict) or not isinstance(manufacturers := contents.get("manufacturers"), list):
+        raise ProfileDownloadError("Library index contains invalid manufacturers")
+
+    for manufacturer in manufacturers:
+        if not isinstance(manufacturer, dict):
+            raise ProfileDownloadError("Library index contains an invalid manufacturer")
+        _validate_path_segment(manufacturer.get("dir_name"), "manufacturer directory")
+
+        models = manufacturer.get("models", [])
+        if not isinstance(models, list):
+            raise ProfileDownloadError("Library index contains invalid models")
+        for model in models:
+            if not isinstance(model, dict):
+                raise ProfileDownloadError("Library index contains an invalid model")
+            _validate_path_segment(model.get("id"), "model ID")
+
+    return cast(dict[str, Any], contents)
+
+
+def _decode_library_json(data: bytes, description: str) -> dict[str, Any]:
+    """Decode and validate a downloaded library index."""
+    try:
+        contents = json.loads(data)
+    except (JSONDecodeError, UnicodeDecodeError, RecursionError) as err:
+        raise ProfileDownloadError(f"{description} is not valid JSON") from err
+    return _validate_library_contents(contents)
+
+
 def _resolve_resource_path(storage_path: str, resource_path: object) -> Path:
     """Resolve and validate a resource path within the profile storage directory."""
     if not isinstance(resource_path, str) or not resource_path or "\0" in resource_path:
@@ -127,6 +172,10 @@ def _validate_resources(resources: object, storage_path: str) -> list[tuple[str,
     """Validate all resources in a remote profile response."""
     if not isinstance(resources, list) or not all(isinstance(resource, dict) for resource in resources):
         raise ProfileDownloadError("Remote profile response contains invalid resources")
+    if len(resources) > MAX_PROFILE_RESOURCES:
+        raise ProfileDownloadError(
+            f"Remote profile contains more than the maximum of {MAX_PROFILE_RESOURCES} resources",
+        )
 
     return [
         (_validate_resource_url(resource.get("url")), _resolve_resource_path(storage_path, resource.get("path")))
@@ -221,7 +270,7 @@ class RemoteLoader(Loader):
         powercalc_version = AwesomeVersion(str(integration.version))
 
         self._clear_caches()
-        self.library_contents = await self.load_library_json(prefer_cached)
+        self.library_contents = _validate_library_contents(await self.load_library_json(prefer_cached))
         self.profile_hashes = await self.hass.async_add_executor_job(self._load_profile_hashes)
 
         self.model_infos.clear()
@@ -342,9 +391,12 @@ class RemoteLoader(Loader):
         if not os.path.exists(local_path):
             return None
         try:
-            with open(local_path) as f:
-                return cast(dict[str, Any], json.load(f))
-        except (JSONDecodeError, OSError) as err:
+            with open(local_path, "rb") as f:
+                data = f.read(MAX_LIBRARY_SIZE + 1)
+            if len(data) > MAX_LIBRARY_SIZE:
+                raise ProfileDownloadError(f"Local library is larger than the maximum of {MAX_LIBRARY_SIZE} bytes")
+            return _decode_library_json(data, "Local library")
+        except (OSError, ProfileDownloadError) as err:
             _LOGGER.warning("Local library.json is unusable (%s), discarding it and downloading a fresh copy", err)
             return None
 
@@ -372,14 +424,15 @@ class RemoteLoader(Loader):
                         f"Failed to download library.json, unexpected status code: {resp.status}",
                     )
 
-                data = await resp.read()
+                data = await _read_capped(resp, MAX_LIBRARY_SIZE, "Remote library")
 
         except (TimeoutError, ClientError) as err:
             raise ProfileDownloadError(f"Failed to download library.json: {err}") from err
 
+        library_contents = _decode_library_json(data, "Remote library")
         await self.hass.async_add_executor_job(_save_resource, data, Path(local_path))
 
-        return cast(dict[str, Any], json.loads(data))
+        return library_contents
 
     @async_cache
     async def get_manufacturer_listing(
@@ -611,7 +664,16 @@ class RemoteLoader(Loader):
 
     def get_storage_path(self, manufacturer: str, model: str) -> str:
         """Retrieve the storage path for a given manufacturer and model."""
-        return str(self.hass.config.path(STORAGE_DIR, BUILT_IN_LIBRARY_DIR, manufacturer, model))
+        manufacturer = _validate_path_segment(manufacturer, "manufacturer directory")
+        model = _validate_path_segment(model, "model ID")
+        storage_root = Path(self.hass.config.path(STORAGE_DIR, BUILT_IN_LIBRARY_DIR)).resolve()
+        try:
+            storage_path = (storage_root / manufacturer / model).resolve()
+        except (OSError, RuntimeError, ValueError) as err:
+            raise ProfileDownloadError("Remote profile has an invalid storage path") from err
+        if not storage_path.is_relative_to(storage_root):
+            raise ProfileDownloadError("Remote profile storage path is outside the profile library")
+        return str(storage_path)
 
     async def download_with_retry(
         self,
@@ -672,12 +734,30 @@ class RemoteLoader(Loader):
 
                 # Download the files
                 downloaded_resources: list[tuple[bytes, Path]] = []
+                downloaded_size = 0
                 for url, destination in validated_resources:
                     async with session.get(url, allow_redirects=False) as resp:
                         if resp.status != 200:
                             raise ProfileDownloadError(f"Failed to download github URL: {url}")
 
-                        contents = await _read_capped(resp, MAX_RESOURCE_SIZE, f"Remote profile resource {url}")
+                        remaining_size = MAX_PROFILE_DOWNLOAD_SIZE - downloaded_size
+                        if remaining_size <= 0:
+                            raise ProfileDownloadError(
+                                f"Remote profile is larger than the maximum of {MAX_PROFILE_DOWNLOAD_SIZE} bytes",
+                            )
+                        try:
+                            contents = await _read_capped(
+                                resp,
+                                min(MAX_RESOURCE_SIZE, remaining_size),
+                                f"Remote profile resource {url}",
+                            )
+                        except ProfileDownloadError as err:
+                            if remaining_size < MAX_RESOURCE_SIZE:
+                                raise ProfileDownloadError(
+                                    f"Remote profile is larger than the maximum of {MAX_PROFILE_DOWNLOAD_SIZE} bytes",
+                                ) from err
+                            raise
+                        downloaded_size += len(contents)
                         downloaded_resources.append((contents, destination))
 
                 await self.hass.async_add_executor_job(_save_resources, downloaded_resources)

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -30,6 +30,7 @@ from custom_components.powercalc.power_profile.loader.remote import (
     RemoteLoader,
     _read_capped,
     _save_resource,
+    _validate_library_contents,
 )
 from custom_components.powercalc.power_profile.power_profile import DeviceType, DiscoveryBy
 from tests.common import get_test_config_dir, get_test_profile_dir
@@ -293,6 +294,55 @@ async def test_download_rejects_invalid_storage_path(
         await remote_loader.download_profile("test", "model", "invalid\0path", "test_download")
 
 
+@pytest.mark.parametrize(
+    "manufacturer, model",
+    [
+        ("../outside", "model"),
+        ("test", "../outside"),
+        ("test/../../outside", "model"),
+        ("test", "model\\..\\outside"),
+    ],
+)
+def test_get_storage_path_rejects_unsafe_library_identifiers(
+    remote_loader: RemoteLoader,
+    manufacturer: str,
+    model: str,
+) -> None:
+    with pytest.raises(ProfileDownloadError, match="invalid"):
+        remote_loader.get_storage_path(manufacturer, model)
+
+
+def test_get_storage_path_rejects_symlink_escape(
+    remote_loader: RemoteLoader,
+    tmp_path: Path,
+) -> None:
+    storage_root = tmp_path / "profiles"
+    outside_path = tmp_path / "outside"
+    storage_root.mkdir()
+    outside_path.mkdir()
+    (storage_root / "linked").symlink_to(outside_path, target_is_directory=True)
+
+    with (
+        patch.object(remote_loader.hass.config, "path", return_value=str(storage_root)),
+        pytest.raises(ProfileDownloadError, match="outside"),
+    ):
+        remote_loader.get_storage_path("linked", "model")
+
+
+def test_get_storage_path_handles_resolution_error(
+    remote_loader: RemoteLoader,
+    tmp_path: Path,
+) -> None:
+    storage_root = tmp_path / "profiles"
+
+    with (
+        patch.object(remote_loader.hass.config, "path", return_value=str(storage_root)),
+        patch.object(Path, "resolve", side_effect=[storage_root, OSError("cannot resolve path")]),
+        pytest.raises(ProfileDownloadError, match="invalid storage path"),
+    ):
+        remote_loader.get_storage_path("test", "model")
+
+
 @pytest.mark.parametrize("resources", [{}, ["invalid"]])
 async def test_download_rejects_invalid_resource_manifest(
     remote_loader: RemoteLoader,
@@ -420,6 +470,86 @@ async def test_download_rejects_oversized_resource(
     assert not (storage_path / "model.json").exists()
 
 
+async def test_download_rejects_too_many_resources(
+    remote_loader: RemoteLoader,
+    mock_aioresponse: aioresponses,
+    tmp_path: Path,
+) -> None:
+    resources = [
+        {"path": "model.json", "url": LIBRARY_RESOURCE_URL},
+        {"path": "data.csv.gz", "url": LIBRARY_CSV_RESOURCE_URL},
+    ]
+    mock_aioresponse.get(
+        f"{ENDPOINT_DOWNLOAD}/test/model?hash=test_download",
+        status=200,
+        payload=resources,
+    )
+
+    with (
+        patch("custom_components.powercalc.power_profile.loader.remote.MAX_PROFILE_RESOURCES", 1),
+        pytest.raises(ProfileDownloadError, match="maximum of 1 resources"),
+    ):
+        await remote_loader.download_profile("test", "model", str(tmp_path / "profiles"), "test_download")
+
+
+async def test_download_rejects_oversized_profile(
+    remote_loader: RemoteLoader,
+    mock_aioresponse: aioresponses,
+    tmp_path: Path,
+) -> None:
+    resources = [
+        {"path": "model.json", "url": LIBRARY_RESOURCE_URL},
+        {"path": "data.csv.gz", "url": LIBRARY_CSV_RESOURCE_URL},
+    ]
+    mock_aioresponse.get(
+        f"{ENDPOINT_DOWNLOAD}/test/model?hash=test_download",
+        status=200,
+        payload=resources,
+    )
+    mock_aioresponse.get(LIBRARY_RESOURCE_URL, status=200, body=b"x" * 8)
+    mock_aioresponse.get(LIBRARY_CSV_RESOURCE_URL, status=200, body=b"x" * 8)
+    storage_path = tmp_path / "profiles"
+
+    with (
+        patch("custom_components.powercalc.power_profile.loader.remote.MAX_PROFILE_DOWNLOAD_SIZE", 12),
+        patch("custom_components.powercalc.power_profile.loader.remote.MAX_RESOURCE_SIZE", 10),
+        pytest.raises(ProfileDownloadError, match="Remote profile is larger than the maximum"),
+    ):
+        await remote_loader.download_profile("test", "model", str(storage_path), "test_download")
+
+    assert not (storage_path / "model.json").exists()
+    assert not (storage_path / "data.csv.gz").exists()
+
+
+async def test_download_rejects_resources_after_profile_size_limit(
+    remote_loader: RemoteLoader,
+    mock_aioresponse: aioresponses,
+    tmp_path: Path,
+) -> None:
+    resources = [
+        {"path": "model.json", "url": LIBRARY_RESOURCE_URL},
+        {"path": "data.csv.gz", "url": LIBRARY_CSV_RESOURCE_URL},
+    ]
+    mock_aioresponse.get(
+        f"{ENDPOINT_DOWNLOAD}/test/model?hash=test_download",
+        status=200,
+        payload=resources,
+    )
+    mock_aioresponse.get(LIBRARY_RESOURCE_URL, status=200, body=b"x" * 12)
+    mock_aioresponse.get(LIBRARY_CSV_RESOURCE_URL, status=200, body=b"x")
+    storage_path = tmp_path / "profiles"
+
+    with (
+        patch("custom_components.powercalc.power_profile.loader.remote.MAX_PROFILE_DOWNLOAD_SIZE", 12),
+        patch("custom_components.powercalc.power_profile.loader.remote.MAX_RESOURCE_SIZE", 12),
+        pytest.raises(ProfileDownloadError, match="Remote profile is larger than the maximum"),
+    ):
+        await remote_loader.download_profile("test", "model", str(storage_path), "test_download")
+
+    assert not (storage_path / "model.json").exists()
+    assert not (storage_path / "data.csv.gz").exists()
+
+
 async def _async_chunks(chunks: list[bytes]) -> AsyncIterator[bytes]:
     for chunk in chunks:
         yield chunk
@@ -449,6 +579,20 @@ async def test_read_capped_returns_a_body_within_the_limit() -> None:
 async def test_read_capped_rejects_an_oversized_body(chunks: list[bytes], content_length: int | None) -> None:
     with pytest.raises(ProfileDownloadError, match="larger than the maximum"):
         await _read_capped(_streamed_response(chunks, content_length), 16, "resource")
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        {},
+        {"manufacturers": ["invalid"]},
+        {"manufacturers": [{"dir_name": "test", "models": {}}]},
+        {"manufacturers": [{"dir_name": "test", "models": ["invalid"]}]},
+    ],
+)
+def test_validate_library_contents_rejects_invalid_structure(contents: object) -> None:
+    with pytest.raises(ProfileDownloadError, match="invalid"):
+        _validate_library_contents(contents)
 
 
 async def test_get_manufacturer_listing(remote_loader: RemoteLoader) -> None:
@@ -886,6 +1030,21 @@ async def test_prefer_cached_redownloads_when_local_copy_is_corrupt(
         assert json.load(f)
 
 
+def test_oversized_local_library_is_discarded(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    local_path = Path(hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json"))
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    local_path.write_bytes(b"x" * 32)
+    loader = RemoteLoader(hass)
+
+    with patch("custom_components.powercalc.power_profile.loader.remote.MAX_LIBRARY_SIZE", 16):
+        assert loader._read_local_library_json() is None  # noqa: SLF001
+
+    assert "Local library is larger than the maximum" in caplog.text
+
+
 async def test_library_json_falls_back_when_download_fails_and_local_copy_is_corrupt(
     hass: HomeAssistant,
     mock_aioresponse: aioresponses,
@@ -932,6 +1091,58 @@ async def test_library_json_is_written_atomically(
 
     assert local_path in renamed
     assert "signify" in loader.model_lookup
+
+
+async def test_download_rejects_oversized_library(
+    hass: HomeAssistant,
+    mock_aioresponse: aioresponses,
+) -> None:
+    mock_aioresponse.get(ENDPOINT_LIBRARY, status=200, body=b"x" * 64)
+    loader = RemoteLoader(hass)
+
+    with (
+        patch("custom_components.powercalc.power_profile.loader.remote.MAX_LIBRARY_SIZE", 16),
+        pytest.raises(ProfileDownloadError, match="Remote library is larger than the maximum"),
+    ):
+        await loader._download_remote_library_json()  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "manufacturer, model",
+    [
+        ("../outside", "model"),
+        ("test", "../outside"),
+    ],
+)
+async def test_download_rejects_unsafe_library_paths_before_caching(
+    hass: HomeAssistant,
+    mock_aioresponse: aioresponses,
+    manufacturer: str,
+    model: str,
+) -> None:
+    local_path = Path(hass.config.path(STORAGE_DIR, "powercalc_profiles", "library.json"))
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    original_contents = b'{"manufacturers": []}'
+    await hass.async_add_executor_job(local_path.write_bytes, original_contents)
+    mock_aioresponse.get(
+        ENDPOINT_LIBRARY,
+        status=200,
+        payload={
+            "manufacturers": [
+                {
+                    "name": "Test",
+                    "dir_name": manufacturer,
+                    "models": [{"id": model, "hash": "dummy"}],
+                },
+            ],
+        },
+    )
+    loader = RemoteLoader(hass)
+
+    with pytest.raises(ProfileDownloadError, match="invalid"):
+        await loader._download_remote_library_json()  # noqa: SLF001
+
+    assert await hass.async_add_executor_job(local_path.read_bytes) == original_contents
 
 
 async def test_corrupt_profile_hashes_are_discarded(


### PR DESCRIPTION
## Summary

- validate manufacturer and model path components before caching or using library metadata
- keep resolved profile storage paths inside the PowerCalc profile cache, including symlink escapes
- cap remote and cached library indexes at 10 MiB
- cap each profile at 256 resources and 25 MiB total

## Security impact

This prevents a compromised library response from escaping the profile cache through crafted directory names. It also bounds memory, request, and disk consumption from oversized library indexes and profile manifests.

## Validation

- 103 remote-loader tests passed
- Ruff passed
- mypy passed
- ty passed
- all pre-commit hooks passed