### PR TITLE
Support debugging standby group

### DIFF
--- a/custom_components/powercalc/sensors/group/standby.py
+++ b/custom_components/powercalc/sensors/group/standby.py
@@ -1,12 +1,13 @@
 from decimal import Decimal
 import logging
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import CONF_NAME, UnitOfPower
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -14,6 +15,8 @@ from homeassistant.helpers.typing import ConfigType
 
 from custom_components.powercalc.common import create_source_entity
 from custom_components.powercalc.const import (
+    ATTR_MEMBERS,
+    ATTR_STATE,
     CONF_CREATE_ENERGY_SENSORS,
     CONF_POWER_SENSOR_PRECISION,
     DATA_STANDBY_POWER_SENSORS,
@@ -91,3 +94,18 @@ class StandbyPowerSensor(PowerSensor, SensorEntity):
         else:
             self._attr_native_value = None
         self.async_schedule_update_ha_state(True)
+
+    def debug_group(self) -> dict[str, Any]:
+        """Return the current standby contribution of each tracked power sensor."""
+        members = {
+            entity_id: {
+                ATTR_STATE: str(round(power, self._rounding_digits)),
+                ATTR_UNIT_OF_MEASUREMENT: self.native_unit_of_measurement,
+            }
+            for entity_id, power in sorted(self.standby_sensors.items())
+        }
+        return {
+            ATTR_STATE: str(self.state),
+            ATTR_UNIT_OF_MEASUREMENT: self.native_unit_of_measurement,
+            ATTR_MEMBERS: members,
+        }

--- a/tests/sensors/group/test_standby.py
+++ b/tests/sensors/group/test_standby.py
@@ -1,6 +1,8 @@
 from homeassistant.components.mqtt.const import CONF_STATE_CLOSING, CONF_STATE_OPENING
 from homeassistant.components.utility_meter.const import DAILY
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_ENTITY_ID,
     STATE_OFF,
     STATE_ON,
@@ -8,11 +10,14 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_STANDBY,
     STATE_UNKNOWN,
+    UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
 
 from custom_components.powercalc import CONF_CREATE_STANDBY_GROUP
 from custom_components.powercalc.const import (
+    ATTR_MEMBERS,
+    ATTR_STATE,
     CONF_CREATE_UTILITY_METERS,
     CONF_FIXED,
     CONF_MANUFACTURER,
@@ -22,6 +27,8 @@ from custom_components.powercalc.const import (
     CONF_STANDBY_POWER,
     CONF_STATES_POWER,
     CONF_UTILITY_METER_TYPES,
+    DOMAIN,
+    SERVICE_DEBUG_GROUP,
     CalculationStrategy,
 )
 from tests.common import assert_entity_state, run_powercalc_setup, set_states
@@ -57,6 +64,51 @@ async def test_standby_group(hass: HomeAssistant) -> None:
 
     await set_states(hass, [("input_boolean.test2", STATE_ON)])
     assert_entity_state(hass, "sensor.all_standby_power", "0.20")
+
+
+async def test_debug_standby_group_action(hass: HomeAssistant) -> None:
+    await run_powercalc_setup(
+        hass,
+        [
+            {
+                CONF_ENTITY_ID: "input_boolean.test1",
+                CONF_STANDBY_POWER: 0.2,
+                CONF_MODE: CalculationStrategy.FIXED,
+                CONF_FIXED: {CONF_POWER: 20},
+            },
+            {
+                CONF_ENTITY_ID: "input_boolean.test2",
+                CONF_STANDBY_POWER: 0.3,
+                CONF_MODE: CalculationStrategy.FIXED,
+                CONF_FIXED: {CONF_POWER: 40},
+            },
+        ],
+    )
+
+    await set_states(hass, [("input_boolean.test1", STATE_OFF), ("input_boolean.test2", STATE_OFF)])
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DEBUG_GROUP,
+        {ATTR_ENTITY_ID: "sensor.all_standby_power"},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["sensor.all_standby_power"] == {
+        ATTR_STATE: "0.50",
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT,
+        ATTR_MEMBERS: {
+            "sensor.test1_power": {
+                ATTR_STATE: "0.20",
+                ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT,
+            },
+            "sensor.test2_power": {
+                ATTR_STATE: "0.30",
+                ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT,
+            },
+        },
+    }
 
 
 async def test_standby_group_includes_devices_already_off_at_startup(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

- support the debug group action for the All standby power sensor
- report each currently tracked standby contribution in watts
- add regression coverage for the reported AttributeError

Discussion: https://github.com/bramstroker/homeassistant-powercalc/discussions/4192#discussioncomment-18268026

## Validation

- uv run pytest tests/sensors/group -q
- uv run pytest tests/sensors/group/test_standby.py -q --cov=custom_components.powercalc.sensors.group.standby --cov-report=term-missing --cov-fail-under=100
- uv run ruff check custom_components/powercalc/sensors/group/standby.py tests/sensors/group/test_standby.py
- uv run ty check custom_components/powercalc/sensors/group/standby.py
- uv run mypy custom_components/powercalc/sensors/group/standby.py
- git diff --check