### PR TITLE
fix: restore utility meter startup subscriptions

### DIFF
--- a/custom_components/powercalc/sensors/utility_meter.py
+++ b/custom_components/powercalc/sensors/utility_meter.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from decimal import Decimal
 import inspect
 import logging
@@ -11,10 +12,12 @@ from homeassistant.components.utility_meter.const import (
 from homeassistant.components.utility_meter.select import TariffSelect
 from homeassistant.components.utility_meter.sensor import UtilityMeterSensor
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import async_generate_entity_id
 import homeassistant.helpers.entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, StateType
 from homeassistant.util import slugify
 
@@ -268,6 +271,73 @@ def create_utility_meter(
 class VirtualUtilityMeter(BaseEntity, UtilityMeterSensor):
     rounding_digits: int = DEFAULT_ENERGY_SENSOR_PRECISION
     _sensor_config: ConfigType
+    _startup_tariff_listener: Callable[[], None] | None = None
+    _handling_startup_tariff_change = False
+    _tariff_tracking_initialized = False
+
+    async def async_added_to_hass(self) -> None:
+        """Ensure tariff tracking starts even when the select is not ready yet."""
+        await super().async_added_to_hass()
+
+        if self._tariff_entity is None:
+            return
+
+        @callback
+        def async_startup_tariff_change(event: Event[EventStateChangedData]) -> None:
+            """Initialize tariff tracking when the select first has a state."""
+            if (new_state := event.data["new_state"]) is None:
+                return
+
+            self._handling_startup_tariff_change = True
+            try:
+                self._change_status(new_state.state)
+            finally:
+                self._handling_startup_tariff_change = False
+
+        self._startup_tariff_listener = async_track_state_change_event(
+            self.hass,
+            [self._tariff_entity],
+            async_startup_tariff_change,
+        )
+        self.async_on_remove(self._cancel_startup_tariff_listener)
+
+        if tariff_state := self.hass.states.get(self._tariff_entity):
+            self._handling_startup_tariff_change = True
+            try:
+                self._change_status(tariff_state.state)
+            finally:
+                self._handling_startup_tariff_change = False
+
+    @callback
+    def _cancel_startup_tariff_listener(self) -> None:
+        """Cancel the fallback listener once Home Assistant tracking is ready."""
+        if self._startup_tariff_listener:
+            self._startup_tariff_listener()
+            self._startup_tariff_listener = None
+
+    def _change_status(self, tariff: str) -> None:
+        """Update tariff status without duplicating source subscriptions."""
+        if not self._handling_startup_tariff_change:
+            self._cancel_startup_tariff_listener()
+
+        if tariff in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            if self._collecting:
+                self._collecting()
+                self._collecting = None
+            self._last_valid_state = None
+            self.async_write_ha_state()
+            return
+
+        should_collect = self._tariff == tariff
+        if self._tariff_tracking_initialized and (self._collecting is not None) == should_collect:
+            return
+
+        if self._collecting:
+            self._collecting()
+            self._collecting = None
+
+        super()._change_status(tariff)
+        self._tariff_tracking_initialized = True
 
     @property
     def unique_id(self) -> str | None:

--- a/tests/sensors/test_utility_meter.py
+++ b/tests/sensors/test_utility_meter.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
 import logging
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from freezegun import freeze_time
 from homeassistant.components import utility_meter
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.utility_meter.const import DAILY, HOURLY, QUARTER_HOURLY
+from homeassistant.components.utility_meter.select import TariffSelect
 from homeassistant.components.utility_meter.sensor import (
     ATTR_STATUS,
     ATTR_TARIFF,
@@ -13,7 +14,14 @@ from homeassistant.components.utility_meter.sensor import (
     CONF_UNIQUE_ID,
     PAUSED,
 )
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, CONF_ENTITY_ID, CONF_NAME, STATE_OFF, UnitOfEnergy
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    STATE_OFF,
+    UnitOfEnergy,
+    UnitOfPower,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
@@ -45,6 +53,34 @@ from tests.common import (
     run_powercalc_setup,
     set_states,
 )
+
+
+async def setup_existing_energy_tariff_meters(hass: HomeAssistant) -> None:
+    """Set up tariff meters backed by registered power and energy sensors."""
+    mock_entities_in_registry(
+        hass,
+        {
+            "sensor.existing_power": {"name": "Existing power", "device_class": SensorDeviceClass.POWER},
+            "sensor.existing_energy": {"name": "Existing energy", "device_class": SensorDeviceClass.ENERGY},
+        },
+    )
+    await set_states(
+        hass,
+        [
+            ("sensor.existing_power", 0, {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT}),
+            ("sensor.existing_energy", 10, {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR}),
+        ],
+    )
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_POWER_SENSOR_ID: "sensor.existing_power",
+            CONF_ENERGY_SENSOR_ID: "sensor.existing_energy",
+            CONF_CREATE_UTILITY_METERS: True,
+            CONF_UTILITY_METER_TARIFFS: ["peak", "offpeak"],
+            CONF_UTILITY_METER_TYPES: [DAILY],
+        },
+    )
 
 
 async def test_tariff_sensors_are_created(hass: HomeAssistant) -> None:
@@ -90,6 +126,81 @@ async def test_tariff_sensors_are_created(hass: HomeAssistant) -> None:
     assert_entity_state(hass, "sensor.test_energy_daily_peak", attributes={ATTR_STATUS: PAUSED})
 
     assert_entity_state(hass, "sensor.test_energy_daily_offpeak", attributes={ATTR_STATUS: COLLECTING})
+
+
+async def test_tariff_meter_tracks_existing_energy_sensor(hass: HomeAssistant) -> None:
+    await setup_existing_energy_tariff_meters(hass)
+
+    assert_entity_state(hass, "select.existing_energy_daily", "peak")
+    await set_states(
+        hass,
+        [("sensor.existing_energy", 12, {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR})],
+    )
+
+    assert_entity_state(
+        hass,
+        "sensor.existing_energy_daily_peak",
+        "2.0000",
+        attributes={ATTR_STATUS: COLLECTING},
+    )
+    assert_entity_state(
+        hass,
+        "sensor.existing_energy_daily_offpeak",
+        "0",
+        attributes={ATTR_STATUS: PAUSED},
+    )
+
+
+async def test_tariff_meter_recovers_when_select_becomes_available(hass: HomeAssistant) -> None:
+    with (
+        patch.object(TariffSelect, "current_option", new_callable=PropertyMock, return_value=None),
+        patch("homeassistant.components.utility_meter.sensor.async_at_started", return_value=lambda: None),
+    ):
+        await setup_existing_energy_tariff_meters(hass)
+
+    assert_entity_state(hass, "select.existing_energy_daily", "unknown")
+    await set_states(hass, [("select.existing_energy_daily", "peak")])
+    await set_states(
+        hass,
+        [("sensor.existing_energy", 12, {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR})],
+    )
+
+    assert_entity_state(
+        hass,
+        "sensor.existing_energy_daily_peak",
+        "2.0000",
+        attributes={ATTR_STATUS: COLLECTING},
+    )
+    assert_entity_state(
+        hass,
+        "sensor.existing_energy_daily_offpeak",
+        "0",
+        attributes={ATTR_STATUS: PAUSED},
+    )
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.existing_energy_daily", "option": "offpeak"},
+        blocking=True,
+    )
+    await set_states(
+        hass,
+        [("sensor.existing_energy", 15, {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR})],
+    )
+
+    assert_entity_state(
+        hass,
+        "sensor.existing_energy_daily_peak",
+        "2.0000",
+        attributes={ATTR_STATUS: PAUSED},
+    )
+    assert_entity_state(
+        hass,
+        "sensor.existing_energy_daily_offpeak",
+        "3.0000",
+        attributes={ATTR_STATUS: COLLECTING},
+    )
 
 
 async def test_tariff_sensors_created_for_gui_sensors(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:


### PR DESCRIPTION
Harden `VirtualUtilityMeter` startup so a tariff-specific meter does not treat a temporarily unavailable tariff-select state as a completed initialization. Preserve Home Assistant's utility-meter behavior, but ensure the meter re-evaluates the tariff and establishes source tracking when the select first becomes available, without requiring a manual tariff toggle and without creating duplicate listeners. Add a regression test using an existing energy sensor and tariffs that reproduces the select-before-source startup timing, then verifies that the active tariff meter consumes later source updates while the inactive tariff remains paused. Powercalc utility meters configured with existing power and energy sensors can restore as `collecting` after startup while their totals remain frozen. The reporter confirmed that the source energy sensor continues to increase, the tariff meters and selects are created, and no duplicate meter entities exist. The stale `last_valid_state` and maintainer analysis point to startup ordering: a tariff meter can initialize before its tariff select has a usable state and never establish source tracking until the select is manually toggled. The regression appeared after 1.21.2 and affects the tariff-meter lifecycle rather than energy calculation itself.

Testing: Start tariff utility meters for an existing registered power/energy sensor while the tariff select has no state; once the select becomes `peak`, a subsequent source-energy increase updates the peak meter automatically; Confirm the non-selected `offpeak` meter remains paused and does not accumulate the peak-period source change.

Fixes #4619
