### PR TITLE
Restrict management actions to admins

### DIFF
--- a/custom_components/powercalc/__init__.py
+++ b/custom_components/powercalc/__init__.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.entity_platform import async_get_platforms
 import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.reload import async_integration_yaml_config
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
@@ -306,7 +307,8 @@ def register_services(hass: HomeAssistant) -> None:
     async def _handle_change_gui_service(call: ServiceCall) -> None:
         await change_gui_configuration(hass, call)
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_CHANGE_GUI_CONFIGURATION,
         _handle_change_gui_service,
@@ -318,7 +320,8 @@ def register_services(hass: HomeAssistant) -> None:
         discovery_manager = get_discovery_manager(hass)
         await discovery_manager.update_library_and_rediscover()
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_UPDATE_LIBRARY,
         _handle_update_library_service,
@@ -353,7 +356,8 @@ def register_services(hass: HomeAssistant) -> None:
         setup_domain_groups(hass, global_config)
         await create_standby_group(hass, global_config)
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_RELOAD,
         _reload_config,

--- a/custom_components/powercalc/flow_helper/profile_preview.py
+++ b/custom_components/powercalc/flow_helper/profile_preview.py
@@ -34,6 +34,7 @@ async def async_setup_preview(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_start_preview)
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required("type"): f"{PREVIEW_NAME}/start_preview",

--- a/tests/config_flow/test_profile_preview.py
+++ b/tests/config_flow/test_profile_preview.py
@@ -9,7 +9,7 @@ from homeassistant.components import websocket_api
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON, CONF_ENTITY_ID, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import UnknownFlow
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 import pytest
 import voluptuous as vol
 
@@ -58,8 +58,9 @@ def _build_ws_message(
     }
 
 
-def _make_ws_connection() -> MagicMock:
+def _make_ws_connection(*, is_admin: bool = True) -> MagicMock:
     connection = MagicMock()
+    connection.user.is_admin = is_admin
     connection.subscriptions = {}
     return connection
 
@@ -69,6 +70,13 @@ async def test_async_setup_preview_registers_websocket_command(hass: HomeAssista
         await async_setup_preview(hass)
 
     register_command.assert_called_once_with(hass, ws_start_preview)
+
+
+def test_preview_websocket_requires_admin(hass: HomeAssistant) -> None:
+    connection = _make_ws_connection(is_admin=False)
+
+    with pytest.raises(Unauthorized):
+        ws_start_preview(hass, connection, _build_ws_message("flow-id", {CONF_POWER: 10}))
 
 
 async def test_build_profile_preview_returns_current_power(hass: HomeAssistant) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from homeassistant.auth.const import GROUP_ID_ADMIN, GROUP_ID_USER
 from homeassistant.components import input_boolean, light
 from homeassistant.components.utility_meter.const import DAILY
 from homeassistant.config_entries import ConfigEntryState
@@ -12,14 +13,18 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers.entity_registry import EntityRegistry
+import pytest
 
 from custom_components.powercalc import (
     CONF_DISCOVERY,
     DATA_DISCOVERY_MANAGER,
     DOMAIN_CONFIG,
+    SERVICE_CHANGE_GUI_CONFIGURATION,
     SERVICE_RELOAD,
+    SERVICE_UPDATE_LIBRARY,
     DiscoveryManager,
     repair_none_config_entries_issue,
 )
@@ -82,6 +87,33 @@ async def test_domain_groups(hass: HomeAssistant, entity_registry: EntityRegistr
     entity_entry = entity_registry.async_get("sensor.all_input_boolean_power")
     assert entity_entry
     assert entity_entry.platform == "powercalc"
+
+
+@pytest.mark.parametrize(
+    "service,service_data",
+    [
+        (SERVICE_CHANGE_GUI_CONFIGURATION, {"field": CONF_CREATE_ENERGY_SENSOR, "value": "1"}),
+        (SERVICE_UPDATE_LIBRARY, {}),
+        (SERVICE_RELOAD, {}),
+    ],
+)
+async def test_management_services_require_admin(
+    hass: HomeAssistant,
+    service: str,
+    service_data: dict[str, str],
+) -> None:
+    await run_powercalc_setup(hass)
+    await hass.auth.async_create_user("Owner", group_ids=[GROUP_ID_ADMIN])
+    user = await hass.auth.async_create_user("Non-admin", group_ids=[GROUP_ID_USER])
+
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            service_data,
+            blocking=True,
+            context=Context(user_id=user.id),
+        )
 
 
 async def test_unload_entry(hass: HomeAssistant, entity_registry: EntityRegistry) -> None:


### PR DESCRIPTION
## Summary
- require administrator access for the change_gui_config, update_library, and reload services
- require administrator access for the profile preview WebSocket command
- add regression coverage for non-admin service and WebSocket calls

## Validation
- 1,430 tests passed
- 100.00% coverage
- all pre-commit hooks passed