### PR TITLE
vesync Core200S rated_45w: model the night light (+0.08 W dim, +0.23 W bright)

### DIFF
--- a/profile_library/vesync/Core200S/rated_45w/model.json
+++ b/profile_library/vesync/Core200S/rated_45w/model.json
@@ -8,15 +8,15 @@
     ]
   },
   "measure_device": "P3 P4400 Kill A Watt Usage Monitor",
-  "measure_description": "US 120 V Core 200S-P, label rated 45 W, date code 1225.",
+  "measure_description": "US 120 V Core 200S-P, label rated 45 W, date code 1225. Night light adds 0.08 W (dim) or 0.23 W (on) in any mode: three minute averages on a Tasmota Sonoff S31 with the fan off gave 0.83 W off, 0.91 W dim, 1.06 W bright.",
   "mains_voltage": 120,
-  "standby_power": 0.8,
+  "standby_power": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 0.83 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
   "fixed_config": {
     "states_power": {
-      "preset_mode|sleep": 7.7,
-      "percentage|33": 16.1,
-      "percentage|66": 23.7,
-      "percentage|100": 45.4
+      "preset_mode|sleep": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 7.7 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
+      "percentage|33": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 16.1 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
+      "percentage|66": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 23.7 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
+      "percentage|100": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 45.4 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}"
     }
   }
 }


### PR DESCRIPTION

Follow up to #4683, as discussed there: the Core 200S-P's built in night light is now modelled.

## What changed

`profile_library/vesync/Core200S/rated_45w/model.json` only. `standby_power` and the four `states_power` values become templates that add the night light's draw to the measured fan value:

```jinja
{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 45.4 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}
```

`[[entity_by_translation_key:night_light_level]]` resolves to the VeSync integration's `select.<device>_night_light_level` on the same device (states `off`, `dim`, `on`), the same mechanism the `apc/BE650G1` profile uses for its load sensor. Standby moves from 0.8 to 0.83 W, which is the S31 reading; the Kill A Watt showed 0.8 at its 0.1 W resolution.

Resulting values:

| Mode | light off | dim | bright |
|---|---|---|---|
| Standby | 0.83 W | 0.91 W | 1.06 W |
| Sleep | 7.7 W | 7.78 W | 7.93 W |
| Low | 16.1 W | 16.18 W | 16.33 W |
| Medium | 23.7 W | 23.78 W | 23.93 W |
| High | 45.4 W | 45.48 W | 45.63 W |

## Measurement

The deltas are below what a Kill A Watt can resolve, so they were taken on a Tasmota Sonoff S31 (checked against the Kill A Watt at 45.3 vs 45.4 W on high) set to `WattRes 2` and `TelePeriod 10`, fan off. Time weighted means over three minute blocks with the transitions trimmed:

| Night light | Mean | Delta |
|---|---|---|
| off | 0.830 W | |
| dim | 0.909 W | +0.08 W |
| on | 1.063 W | +0.23 W |

Sample spread within a block was about 0.07 W and the three bands do not overlap.

## Notes

- `rated_37w` is untouched, it is probably very similar in power consumption from the LED night light, but I don't have the exact model and didn't want to assume any values.
