### PR TITLE
vesync Vital 200S (LAP-V201S-WUS) profile, fix Core200S rated_45w templates

### DIFF
--- a/profile_library/vesync/Core200S/rated_45w/model.json
+++ b/profile_library/vesync/Core200S/rated_45w/model.json
@@ -10,13 +10,13 @@
   "measure_device": "P3 P4400 Kill A Watt Usage Monitor",
   "measure_description": "US 120 V Core 200S-P, label rated 45 W, date code 1225. Night light adds 0.08 W (dim) or 0.23 W (on) in any mode: three minute averages on a Tasmota Sonoff S31 with the fan off gave 0.83 W off, 0.91 W dim, 1.06 W bright.",
   "mains_voltage": 120,
-  "standby_power": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 0.83 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
+  "standby_power": "{{ 0.83 + {'dim': 0.08, 'on': 0.23}.get(states('[[entity_by_translation_key:night_light_level]]'), 0) }}",
   "fixed_config": {
     "states_power": {
-      "preset_mode|sleep": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 7.7 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
-      "percentage|33": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 16.1 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
-      "percentage|66": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 23.7 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}",
-      "percentage|100": "{% set nl = states('[[entity_by_translation_key:night_light_level]]') %}{{ 45.4 + (0.23 if nl == 'on' else 0.08 if nl == 'dim' else 0) }}"
+      "preset_mode|sleep": "{{ 7.7 + {'dim': 0.08, 'on': 0.23}.get(states('[[entity_by_translation_key:night_light_level]]'), 0) }}",
+      "percentage|33": "{{ 16.1 + {'dim': 0.08, 'on': 0.23}.get(states('[[entity_by_translation_key:night_light_level]]'), 0) }}",
+      "percentage|66": "{{ 23.7 + {'dim': 0.08, 'on': 0.23}.get(states('[[entity_by_translation_key:night_light_level]]'), 0) }}",
+      "percentage|100": "{{ 45.4 + {'dim': 0.08, 'on': 0.23}.get(states('[[entity_by_translation_key:night_light_level]]'), 0) }}"
     }
   }
 }

--- a/profile_library/vesync/Vital 200S/model.json
+++ b/profile_library/vesync/Vital 200S/model.json
@@ -1,0 +1,45 @@
+{
+  "calculation_strategy": "fixed",
+  "created_at": "2026-09-03T00:00:00Z",
+  "device_type": "air_purifier",
+  "min_version": "v1.25.3",
+  "device_specs": {
+    "form_factor": "air_purifier",
+    "rated_power": 51,
+    "connectivity": [
+      "wifi"
+    ]
+  },
+  "measure_device": "Sonoff S31",
+  "measure_method": "manual",
+  "measure_description": "Vital 200S-P, US 120 V, measured at the wall with a Tasmota Sonoff S31; three minute averages per state. Display draws 0.6 W and is subtracted when display_status is off. Manual speeds and sleep are measured directly. Auto maps the air_quality sensor state (excellent/good/moderate/poor, the manual's Very Good/Good/Moderate/Bad) to sleep/low/medium/high speed per the manual; only excellent was measured (PM2.5 1). Pet alternates 15 min high and 60 min medium per the manual (cycle not measured); value is the cycle average. Both presets assume light detection is off or the room is lit. With light detection on, the unit caps them at medium (50 %) in the dark, a state HA cannot see. Standby is below the S31's floor and comes from corrected Shelly Plug history.",
+  "mains_voltage": 120,
+  "name": "Smart Air Purifier",
+  "aliases": [
+    "LAP-V201S-WUS",
+    "LAP-V201S-WEU",
+    "LAP-V201S-WJP",
+    "LAP-V201S-AASR",
+    "LAP-V201S-AUSR",
+    "LAP-V201S-AEUR"
+  ],
+  "product_url": "https://levoit.com/products/vital-200s-p-smart-air-purifier",
+  "standby_power": 0.25,
+  "fixed_config": {
+    "states_power": {
+      "preset_mode|sleep": 2.91,
+      "preset_mode|pet": "{{ 10.0 - (0.6 if state_attr('[[entity]]', 'display_status') == 'off' else 0) }}",
+      "preset_mode|auto": "{{ {'good': 4.92, 'moderate': 6.45, 'poor': 24.24}.get(states('[[entity_by_translation_key:air_quality]]'), 3.53) - (0.6 if state_attr('[[entity]]', 'display_status') == 'off' else 0) }}",
+      "percentage|25": "{{ 4.92 - (0.6 if state_attr('[[entity]]', 'display_status') == 'off' else 0) }}",
+      "percentage|50": "{{ 6.45 - (0.6 if state_attr('[[entity]]', 'display_status') == 'off' else 0) }}",
+      "percentage|75": "{{ 24.24 - (0.6 if state_attr('[[entity]]', 'display_status') == 'off' else 0) }}",
+      "percentage|100": "{{ 40.62 - (0.6 if state_attr('[[entity]]', 'display_status') == 'off' else 0) }}"
+    }
+  },
+  "authors": [
+    {
+      "name": "Ryan Ronnander",
+      "github": "ryan-ronnander"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->

Levoit Vital 200S-P, https://levoit.com/products/levoit-vital-200s-p-smart-air-purifier-white-grey. Label: model LAP-V201S-WUS, rated 51 W, 24 V adapter. HA reports the model as `LAP-V201S-WUS`.

<img width="878" height="971" alt="image" src="https://github.com/user-attachments/assets/4ba399d1-05c7-4e5b-b325-64ccbd3a9d1f" />


Measured at the wall with a Tasmota Sonoff S31. Three minute averages.

| HA state | Power |
|---|---|
| `percentage: 25 / 50 / 75 / 100` | 4.92 / 6.45 / 24.24 / 40.62 W |
| `preset_mode: sleep` | 2.91 W |
| `preset_mode: pet` | 10.0 W, cycle average |
| `preset_mode: auto` | template on the air quality sensor |
| `off` | 0.25 W |

- **Display** draws 0.6 W, subtracted when the fan's `display_status` is `off`.
- **Auto** is a template on the device's `air_quality` sensor (`[[entity_by_translation_key:air_quality]]`), following the manual's chart:

  | Manual band | HA `air_quality` state | Fan speed | Power |
  |---|---|---|---|
  | Very Good | `excellent` | sleep speed | 3.53 W (measured, display lit) |
  | Good | `good` | low | 4.92 W |
  | Moderate | `moderate` | medium | 6.45 W |
  | Bad | `poor` | high | 24.24 W |

- **Pet** per the manual runs 15 min high then 60 min medium and repeats; 10.0 W is that cycle's average.
- **Standby** is below the S31's floor; 0.25 W is from Shelly Plug history corrected for that plug's measured 1.22x error.

With the light detection toggled on, the purifier caps pet and auto at medium fan speeds in a dark room, which HA cannot see. Without these metrics exposed in the VeSync integration, we can only make a best guess (lit room, or light detection off), pet mode is averaged, etc.

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->

```
LAP-V201S-WUS
by VeSync
Firmware: 1.0.16
```

<img width="785" height="578" alt="image" src="https://github.com/user-attachments/assets/f5065861-27af-4c7c-b1fa-2743dbe2655d" />


## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] The model name does not repeat the manufacturer name.
- [x] I have checked existing profiles for this manufacturer for consistent naming and metadata.
- [x] I have reused the existing `measure_device` value when my measurement device is already in the library.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->

Both profiles verified live on HA 2026.8.3 / powercalc v1.25.3 from the custom profile directory.

**Also in this PR: hotfix for the Core200S `rated_45w` templates from #4695.** Got ahead of myself and didn't fully test the template change. The second commit affects `profile_library/vesync/Core200S/rated_45w/model.json` only. PowerCalc treats a profile value as a template only when the string starts with `{{`; the `{% set %}` templates were read as literals and left the sensor unavailable. Rewritten as `{{ ... }}` expressions, same values.

Related: #4683, #4695.
