### PR TITLE
Support gamma curves from smart dimmer profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,9 @@ Keep unrelated working-tree changes intact.
 Use [Conventional Commits](https://www.conventionalcommits.org/) for commit
 messages, for example: `refactor: simplify discovery flow`.
 
+Write PR titles as concise, human-readable titles without Conventional Commit
+prefixes such as `feat:` or `fix:`.
+
 ## Change-specific rules
 
 ### Translations

--- a/custom_components/powercalc/power_profile/power_profile.py
+++ b/custom_components/powercalc/power_profile/power_profile.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from custom_components.powercalc.const import (
     BUILT_IN_LIBRARY_DIR,
+    CONF_CALIBRATE,
     CONF_ENERGY_SENSOR_NAMING,
     CONF_MAX_POWER,
     CONF_MIN_POWER,
@@ -309,9 +310,11 @@ class PowerProfile:
         if self.only_self_usage:
             return False
 
-        return self.is_strategy_supported(
-            CalculationStrategy.LINEAR,
-        ) and not self._json_data.get("linear_config")
+        if not self.is_strategy_supported(CalculationStrategy.LINEAR):
+            return False
+
+        linear_config = self._json_data.get("linear_config") or {}
+        return CONF_MAX_POWER not in linear_config and not linear_config.get(CONF_CALIBRATE)
 
     @property
     def device_type(self) -> DeviceType | None:

--- a/custom_components/powercalc/strategy/factory.py
+++ b/custom_components/powercalc/strategy/factory.py
@@ -12,7 +12,11 @@ import voluptuous as vol
 
 from custom_components.powercalc.common import SourceEntity
 from custom_components.powercalc.const import (
+    CONF_CALIBRATE,
     CONF_COMPOSITE,
+    CONF_GAMMA_CURVE,
+    CONF_MAX_POWER,
+    CONF_MIN_POWER,
     CONF_MODE,
     CONF_MULTI_SWITCH,
     CONF_POWER,
@@ -118,7 +122,7 @@ class PowerCalculatorStrategyFactory:
         power_profile: PowerProfile | None,
     ) -> LinearStrategy:
         """Create the linear strategy."""
-        linear_config = self._get_strategy_config(CalculationStrategy.LINEAR, config, power_profile)
+        linear_config = self._get_linear_config(config, power_profile)
 
         return LinearStrategy(
             linear_config,
@@ -126,6 +130,45 @@ class PowerCalculatorStrategyFactory:
             source_entity,
             config.get(CONF_STANDBY_POWER),
         )
+
+    @staticmethod
+    def _get_linear_config(config: ConfigType, power_profile: PowerProfile | None) -> ConfigType:
+        """Combine an incomplete profile configuration with user supplied power values."""
+        user_config = cast(ConfigType | None, config.get(CalculationStrategy.LINEAR))
+
+        if power_profile is None or not power_profile.is_strategy_supported(CalculationStrategy.LINEAR):
+            if user_config is not None:
+                return user_config
+            raise StrategyConfigurationError("No linear configuration supplied")
+
+        profile_config = dict(power_profile.linear_config or {})
+
+        # Preserve the existing behavior for complete profiles: an explicitly supplied
+        # user configuration replaces the profile configuration entirely.
+        if not power_profile.needs_linear_config:
+            return user_config if user_config is not None else profile_config
+
+        # Smart dimmer profiles without load values can be used from YAML to measure
+        # only the dimmer's own consumption. Keep that behavior when the profile adds
+        # defaults such as gamma_curve but the user omits the linear configuration.
+        if not user_config:
+            return {
+                CONF_MIN_POWER: 0,
+                CONF_MAX_POWER: 0,
+                **profile_config,
+            }
+
+        linear_config = {
+            **profile_config,
+            **user_config,
+        }
+
+        # A user supplied calibration curve fully describes the power curve. Do not
+        # modify it with a gamma value inherited from the profile.
+        if CONF_CALIBRATE in user_config and CONF_GAMMA_CURVE not in user_config:
+            linear_config.pop(CONF_GAMMA_CURVE, None)
+
+        return linear_config
 
     def _create_fixed(
         self,

--- a/profile_library/model_schema.json
+++ b/profile_library/model_schema.json
@@ -529,6 +529,10 @@
         "max_power": {
           "type": "number"
         },
+        "gamma_curve": {
+          "type": "number",
+          "description": "Exponent applied to the normalized entity value before scaling it between min_power and max_power"
+        },
         "calibrate": {
           "type": "array",
           "items": {

--- a/tests/power_profile/device_types/test_smart_dimmer.py
+++ b/tests/power_profile/device_types/test_smart_dimmer.py
@@ -6,7 +6,9 @@ from homeassistant.data_entry_flow import FlowResultType
 from custom_components.powercalc import CONF_IGNORE_UNAVAILABLE_STATE, async_setup_entry
 from custom_components.powercalc.config_flow import Step
 from custom_components.powercalc.const import (
+    CONF_CALIBRATE,
     CONF_CUSTOM_MODEL_DIRECTORY,
+    CONF_GAMMA_CURVE,
     CONF_LINEAR,
     CONF_MAX_POWER,
     CONF_MIN_POWER,
@@ -79,6 +81,89 @@ async def test_smart_dimmer_power_input_yaml_omit_linear_config(
     assert_entity_state(hass, power_sensor_id, "0.30")
 
 
+async def test_smart_dimmer_profile_gamma_combined_with_user_power_input(
+    hass: HomeAssistant,
+) -> None:
+    """Test profile gamma is combined with user supplied min and max power."""
+    light_entity_id = "light.test"
+    power_sensor_id = "sensor.test_power"
+
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_ENTITY_ID: light_entity_id,
+            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("smart_dimmer_gamma"),
+            CONF_LINEAR: {CONF_MIN_POWER: 1.5, CONF_MAX_POWER: 50},
+        },
+    )
+
+    await set_states(hass, [(light_entity_id, STATE_ON, {ATTR_BRIGHTNESS: 128})])
+    assert_entity_state(hass, power_sensor_id, "14.22")
+
+
+async def test_smart_dimmer_user_gamma_overrides_profile_gamma(
+    hass: HomeAssistant,
+) -> None:
+    """Test an explicitly supplied gamma overrides the profile gamma."""
+    light_entity_id = "light.test"
+    power_sensor_id = "sensor.test_power"
+
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_ENTITY_ID: light_entity_id,
+            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("smart_dimmer_gamma"),
+            CONF_LINEAR: {
+                CONF_MIN_POWER: 1.5,
+                CONF_MAX_POWER: 50,
+                CONF_GAMMA_CURVE: 1,
+            },
+        },
+    )
+
+    await set_states(hass, [(light_entity_id, STATE_ON, {ATTR_BRIGHTNESS: 128})])
+    assert_entity_state(hass, power_sensor_id, "26.35")
+
+
+async def test_smart_dimmer_user_calibration_ignores_profile_gamma(
+    hass: HomeAssistant,
+) -> None:
+    """Test an existing user calibration is not modified by profile gamma."""
+    light_entity_id = "light.test"
+    power_sensor_id = "sensor.test_power"
+
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_ENTITY_ID: light_entity_id,
+            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("smart_dimmer_gamma"),
+            CONF_LINEAR: {CONF_CALIBRATE: ["0 -> 1.5", "255 -> 50"]},
+        },
+    )
+
+    await set_states(hass, [(light_entity_id, STATE_ON, {ATTR_BRIGHTNESS: 128})])
+    assert_entity_state(hass, power_sensor_id, "26.35")
+
+
+async def test_smart_dimmer_profile_gamma_without_user_power_input(
+    hass: HomeAssistant,
+) -> None:
+    """Test profile gamma keeps the self-usage-only YAML configuration valid."""
+    light_entity_id = "light.test"
+    power_sensor_id = "sensor.test_power"
+
+    await run_powercalc_setup(
+        hass,
+        {
+            CONF_ENTITY_ID: light_entity_id,
+            CONF_CUSTOM_MODEL_DIRECTORY: get_test_profile_dir("smart_dimmer_gamma"),
+        },
+    )
+
+    await set_states(hass, [(light_entity_id, STATE_ON, {ATTR_BRIGHTNESS: 255})])
+    assert_entity_state(hass, power_sensor_id, "0.50")
+
+
 async def test_smart_dimmer_power_input_gui_config_flow(
     hass: HomeAssistant,
 ) -> None:
@@ -138,3 +223,37 @@ async def test_smart_dimmer_power_input_gui_config_flow(
     # Set the switch on again and see if it has the updated power value
     await set_states(hass, [(light_entity_id, STATE_ON, {ATTR_BRIGHTNESS: 255})])
     assert_entity_state(hass, power_sensor_id, "40.50")
+
+
+async def test_smart_dimmer_profile_gamma_gui_config_flow(
+    hass: HomeAssistant,
+) -> None:
+    """Test a partial profile linear config still requests the lamp power values."""
+    light_entity_id = "light.test"
+    power_sensor_id = "sensor.test_power"
+
+    mock_device_with_entities(
+        hass,
+        entity_ids=light_entity_id,
+        manufacturer="test",
+        model="smart_dimmer_gamma",
+    )
+
+    await run_powercalc_setup(hass)
+
+    flow = hass.config_entries.flow.async_progress_by_handler(DOMAIN)[0]
+    result = await confirm_auto_discovered_model(hass, flow)
+
+    assert result["step_id"] == Step.LINEAR
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"],
+        {CONF_MIN_POWER: 1.5, CONF_MAX_POWER: 50},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_LINEAR] == {CONF_MIN_POWER: 1.5, CONF_MAX_POWER: 50}
+
+    await async_setup_entry(hass, result["result"])
+    await hass.async_block_till_done()
+
+    await set_states(hass, [(light_entity_id, STATE_ON, {ATTR_BRIGHTNESS: 128})])
+    assert_entity_state(hass, power_sensor_id, "14.22")

--- a/tests/power_profile/loader/test_remote.py
+++ b/tests/power_profile/loader/test_remote.py
@@ -108,11 +108,12 @@ async def test_download(
     mock_aioresponse: aioresponses,
     remote_loader: RemoteLoader,
     mock_download_profile_endpoints: list[dict],
+    tmp_path: Path,
 ) -> None:
     """Mock the API response for the download of a profile."""
     remote_files = mock_download_profile_endpoints
 
-    storage_dir = get_test_profile_dir("download")
+    storage_dir = str(tmp_path / "download")
     await remote_loader.download_profile("signify", "LCA001", storage_dir, "test_download")
 
     for remote_file in remote_files:
@@ -186,7 +187,11 @@ def test_save_resource_flushes_to_disk_before_renaming(tmp_path: Path) -> None:
     assert not list(tmp_path.glob(".model.json.*"))
 
 
-async def test_download_with_parenthesis(remote_loader: RemoteLoader, mock_aioresponse: aioresponses) -> None:
+async def test_download_with_parenthesis(
+    remote_loader: RemoteLoader,
+    mock_aioresponse: aioresponses,
+    tmp_path: Path,
+) -> None:
     remote_files = [
         {
             "path": "model.json",
@@ -210,7 +215,7 @@ async def test_download_with_parenthesis(remote_loader: RemoteLoader, mock_aiore
                 repeat=True,
             )
 
-    storage_dir = get_test_profile_dir("download")
+    storage_dir = str(tmp_path / "download")
     await remote_loader.download_profile("google", "Home Mini (HOA)", storage_dir, "test_download")
 
     for remote_file in remote_files:
@@ -761,6 +766,7 @@ async def test_load_model_raises_library_exception_on_non_existing_model(remote_
 async def test_download_profile_exception_unexpected_status_code(
     mock_aioresponse: aioresponses,
     remote_loader: RemoteLoader,
+    tmp_path: Path,
 ) -> None:
     mock_aioresponse.get(
         f"{ENDPOINT_DOWNLOAD}/signify/LCA001?hash=test_download",
@@ -768,7 +774,7 @@ async def test_download_profile_exception_unexpected_status_code(
         repeat=True,
     )
 
-    profile_dir = get_test_profile_dir("download")
+    profile_dir = str(tmp_path / "download")
     with pytest.raises(ProfileDownloadError):
         await remote_loader.download_profile("signify", "LCA001", profile_dir, "test_download")
 
@@ -776,10 +782,11 @@ async def test_download_profile_exception_unexpected_status_code(
 async def test_exception_is_raised_on_connection_error(
     mock_aioresponse: aioresponses,
     remote_loader: RemoteLoader,
+    tmp_path: Path,
 ) -> None:
     mock_aioresponse.get(f"{ENDPOINT_DOWNLOAD}/signify/LCA001?hash=test_download", exception=ClientError("test"))
 
-    profile_dir = get_test_profile_dir("download")
+    profile_dir = str(tmp_path / "download")
     with pytest.raises(ProfileDownloadError):
         await remote_loader.download_profile("signify", "LCA001", profile_dir, "test_download")
 

--- a/tests/power_profile/test_power_profile.py
+++ b/tests/power_profile/test_power_profile.py
@@ -9,7 +9,9 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry, Regist
 
 from custom_components.powercalc.common import SourceEntity
 from custom_components.powercalc.const import (
+    CONF_CALIBRATE,
     CONF_ENERGY_SENSOR_NAMING,
+    CONF_GAMMA_CURVE,
     CONF_MANUFACTURER,
     CONF_MAX_POWER,
     CONF_MIN_POWER,
@@ -356,6 +358,36 @@ async def test_needs_user_configuration(hass: HomeAssistant, json_data: dict[str
     )
 
     assert await power_profile.needs_user_configuration == expected_result
+
+
+@pytest.mark.parametrize(
+    "linear_config,expected_result",
+    [
+        (None, True),
+        ({CONF_GAMMA_CURVE: 2.4}, True),
+        ({CONF_MIN_POWER: 1, CONF_GAMMA_CURVE: 2.4}, True),
+        ({CONF_MAX_POWER: 20, CONF_GAMMA_CURVE: 2.4}, False),
+        ({CONF_CALIBRATE: ["0 -> 1", "255 -> 20"]}, False),
+    ],
+)
+def test_needs_linear_config(
+    hass: HomeAssistant,
+    linear_config: dict[str, Any] | None,
+    expected_result: bool,
+) -> None:
+    json_data: dict[str, Any] = {"calculation_strategy": CalculationStrategy.LINEAR}
+    if linear_config is not None:
+        json_data["linear_config"] = linear_config
+
+    power_profile = PowerProfile(
+        hass,
+        manufacturer="test",
+        model="test",
+        directory=get_test_profile_dir("smart_dimmer"),
+        json_data=json_data,
+    )
+
+    assert power_profile.needs_linear_config == expected_result
 
 
 @pytest.mark.parametrize(

--- a/tests/testing_config/powercalc/profiles/test/smart_dimmer_gamma/model.json
+++ b/tests/testing_config/powercalc/profiles/test/smart_dimmer_gamma/model.json
@@ -1,0 +1,10 @@
+{
+  "calculation_strategy": "linear",
+  "device_type": "smart_dimmer",
+  "linear_config": {
+    "gamma_curve": 2
+  },
+  "name": "Some smart dimmer with gamma curve",
+  "standby_power": 0.3,
+  "standby_power_on": 0.5
+}


### PR DESCRIPTION
## Summary
- allow smart dimmer profiles to provide a partial linear configuration such as gamma_curve
- combine profile curve defaults with user-supplied minimum and maximum lamp power while preserving explicit user overrides and calibration curves
- isolate remote profile download tests with tmp_path so tracked fixtures are no longer mutated

## Testing
- uv run pytest tests -q (1255 passed)
- Ruff check and format check
- mypy custom_components/powercalc
- full profile model schema validation
- commit hooks, including ty

Related to #4703