### PR TITLE
docs: fix errors in measure bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-measure.yml
+++ b/.github/ISSUE_TEMPLATE/bug-measure.yml
@@ -10,7 +10,6 @@ body:
   attributes:
     label: "System information"
     description: "Paste the data from the measurement app here or manually write your used versions"
-    required: true
 - type: checkboxes
   attributes:
     label: Checklist
@@ -43,9 +42,8 @@ body:
   validations:
     required: true
 - type: upload
-  id: "Measurement logs and diagnostics"
   attributes:
-    label: Upload measurement logs and diagnostics
+    label: Measurement logs and diagnostics
     description: Please upload your measurement data. You can download that from the GUI or write the CLI output into a file.
   validations:
     required: true


### PR DESCRIPTION
Followup of #4490 

As expected there were some errors.

There are some problems with this template

```
body[1]: required is not a permitted attribute. Learn more about error 1.

body[5]: id can contain only numbers, letters, -, _. Learn more about error 2.
```

