### PR TITLE
docs: fix mini typo (double dot) in measure bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-measure.yml
+++ b/.github/ISSUE_TEMPLATE/bug-measure.yml
@@ -22,7 +22,7 @@ body:
         required: true
       - label: This issue only contains 1 issue (if you have multiple issues, open one issue for each issue).
         required: true
-      - label: This issue is not a duplicate issue of currently [previous issues](https://github.com/bramstroker/homeassistant-powercalc/issues?q=is%3Aissue+label%3A%22bug%22+)..
+      - label: This issue is not a duplicate issue of currently [previous issues](https://github.com/bramstroker/homeassistant-powercalc/issues?q=is%3Aissue+label%3A%22bug%22+).
         required: true
 - type: textarea
   attributes:


### PR DESCRIPTION
Followup of https://github.com/bramstroker/homeassistant-powercalc/pull/4708