### PR TITLE
Improve light discovery guidance and preflight stabilization

### DIFF
--- a/utils/measure/frontend/src/components/fields.ts
+++ b/utils/measure/frontend/src/components/fields.ts
@@ -57,11 +57,12 @@ export function numberField(name: string, label: string, value: string, options:
 export interface EntitySelectOptions {
   selected?: string;
   required?: boolean;
+  hint?: string;
   onChange?: ((event: Event) => void) | null;
 }
 
 export function entitySelect(name: string, label: string, entities: EntityDescriptor[], options: EntitySelectOptions = {}) {
-  const { selected = "", required = false, onChange = null } = options;
+  const { selected = "", required = false, hint = "", onChange = null } = options;
   const comboboxOptions: ComboboxOption[] = entities.map((entity) => ({
     value: entity.entity_id,
     label: `${entity.name} · ${entity.entity_id}`,
@@ -74,6 +75,7 @@ export function entitySelect(name: string, label: string, entities: EntityDescri
       .value=${selected}
       .options=${comboboxOptions}
       placeholder=${`Search ${label.toLowerCase()} entities`}
+      hint=${hint}
       ?required=${required}
     >
       <input slot="value" type="hidden" name=${name} .value=${selected} @change=${onChange} />

--- a/utils/measure/frontend/src/components/setup-view.test.ts
+++ b/utils/measure/frontend/src/components/setup-view.test.ts
@@ -93,6 +93,7 @@ describe("setup view", () => {
     const light = entityCombobox(element, "light_entity_id");
     await light.updateComplete;
     expect((light.shadowRoot.querySelector("input") as HTMLInputElement).value).toBe("Desk lamp · light.desk");
+    expect(light.shadowRoot.textContent).toContain("If a light is missing, change its state once in Home Assistant, then reload this page.");
     expect(element.shadowRoot.textContent).toContain("Brightness");
     expect(element.shadowRoot.querySelector("details")?.open).toBe(false);
     expect(element.shadowRoot.querySelectorAll('input[name="modes"]')).toHaveLength(1);
@@ -232,6 +233,8 @@ describe("setup view", () => {
     expect(removeButton?.getAttribute("aria-label")).toBe("Remove Light");
     expect(removeButton?.querySelector("svg")).toBeTruthy();
     expect(removeButton?.textContent?.trim()).toBe("");
+    expect(element.shadowRoot.querySelector(".entity-list > .field-hint")?.textContent)
+      .toContain("If a light is missing, change its state once in Home Assistant, then reload this page.");
     expect(element.shadowRoot.querySelectorAll('input[name="modes"]')).toHaveLength(1);
     expect((element.shadowRoot.querySelector('input[name="model_id"]') as HTMLInputElement).value).toBe("LWA017");
     expect((element.shadowRoot.querySelector('input[name="multiple_light_count"]') as HTMLInputElement).value).toBe("2");

--- a/utils/measure/frontend/src/components/setup-view.ts
+++ b/utils/measure/frontend/src/components/setup-view.ts
@@ -45,6 +45,9 @@ import {
 } from "./setup-chrome";
 import { errorHelpLink } from "./error-help-link";
 
+const LIGHT_DISCOVERY_HINT =
+  "Newly discovered lights may not have a usable state until Home Assistant receives their first update. If a light is missing, change its state once in Home Assistant, then reload this page.";
+
 const FULL_PRODUCT_NAME_HINT = "Enter the complete marketed name, including the series and variant shown on the product or packaging. Do not repeat the manufacturer name.";
 const MULTIPLE_LIGHTS_GUIDE_URL = "https://docs.powercalc.nl/contributing/measure/lights/#multiple-identical-lights";
 
@@ -459,7 +462,12 @@ export class SetupView extends LitElement {
       let selected = field.multiple ? this.selectedEntityId(field, run) || value : value;
       if (!selected && field.same_device_only && entities.length === 1) selected = entities[0]?.entity_id ?? "";
       const relatedMissing = Boolean(field.same_device_only && this.relatedEntity(field, run) && entities.length === 0);
-      const selector = entitySelect(name, field.label, entities, { selected, required: field.required, onChange: this.entityChanged });
+      const selector = entitySelect(name, field.label, entities, {
+        selected,
+        required: field.required,
+        hint: this.lightDiscoveryHint(field),
+        onChange: this.entityChanged,
+      });
       if (!field.hint && !relatedMissing) return selector;
       return html`<div class="field-block">
         ${selector}
@@ -546,12 +554,19 @@ export class SetupView extends LitElement {
   }
 
   private multiEntityField(field: FormField, entities: EntityDescriptor[], run?: MeasurementRequest) {
+    const hint = [field.hint, this.lightDiscoveryHint(field)].filter(Boolean).join(" ");
     return renderEntityList({
-      field,
+      field: { ...field, hint },
       entities,
       rows: this.entityRows(field, run),
       onChange: (rows) => this.selectEntities(field.name, rows),
     });
+  }
+
+  private lightDiscoveryHint(field: FormField): string {
+    return field.role === "controller" && this.fieldDomains(field).includes("light")
+      ? LIGHT_DISCOVERY_HINT
+      : "";
   }
 
   private fieldDomains(field: MeasureDefinition["fields"][number]): string[] {

--- a/utils/measure/measure/ha_app/light_probe.py
+++ b/utils/measure/measure/ha_app/light_probe.py
@@ -101,14 +101,22 @@ class LightLoadProbe:
                 sleep_time=request.parameters.sleep_time,
                 wait=self._wait,
             )
-            self._wait(request.parameters.sleep_initial)
             points = [
                 LightLoadProbePoint(
                     label=light_load_probe_label(variation),
                     mode=variation.mode,
-                    power_w=round(self._measure_variation(controller, measure_util, request, variation), 3),
+                    power_w=round(
+                        self._measure_variation(
+                            controller,
+                            measure_util,
+                            request,
+                            variation,
+                            initial=index == 0,
+                        ),
+                        3,
+                    ),
                 )
-                for variation in variations
+                for index, variation in enumerate(variations)
             ]
             return LightLoadProbeResult(
                 checked_variations=len(points),
@@ -144,10 +152,14 @@ class LightLoadProbe:
         measure_util: MeasureUtil,
         request: LightMeasurementRequest,
         variation: Variation,
+        *,
+        initial: bool,
     ) -> float:
         start_timestamp = self._now()
         controller.change_light_state(variation.mode, on=True, **asdict(variation))
         self._wait(request.parameters.sleep_time)
+        if initial:
+            self._wait(request.parameters.sleep_initial)
         return measure_util.take_measurement(start_timestamp=start_timestamp).power
 
     @staticmethod

--- a/utils/measure/measure/ha_app/light_probe.py
+++ b/utils/measure/measure/ha_app/light_probe.py
@@ -7,7 +7,7 @@ import time
 
 from measure.assembler import MeasurementAssembler
 from measure.controller.light.const import LutMode
-from measure.controller.light.controller import LightController
+from measure.controller.light.controller import LightController, LightInfo
 from measure.execution import ImmediateInteraction
 from measure.home_assistant import HomeAssistantManager
 from measure.powermeter.errors import ZeroReadingError
@@ -93,6 +93,7 @@ class LightLoadProbe:
             meter = assembler.build_power_meter(request.power_meter)
             measure_util = MeasureUtil(meter, request.parameters, wait=self._wait)
             light_driven = True
+            self._stabilize_load(controller, request, variations[0].mode, light_info)
             points = [
                 LightLoadProbePoint(
                     label=light_load_probe_label(variation),
@@ -140,6 +141,28 @@ class LightLoadProbe:
         controller.change_light_state(variation.mode, on=True, **asdict(variation))
         self._wait(request.parameters.sleep_time)
         return measure_util.take_measurement(start_timestamp=start_timestamp).power
+
+    def _stabilize_load(
+        self,
+        controller: LightController,
+        request: LightMeasurementRequest,
+        mode: LutMode,
+        light_info: LightInfo,
+    ) -> None:
+        """Match the runner's full-load preparation before probing low-load points."""
+
+        kwargs: dict[str, int] = {"bri": 255}
+        if mode == LutMode.HS:
+            kwargs.update(hue=0, sat=1)
+        elif mode == LutMode.COLOR_TEMP:
+            kwargs["ct"] = light_info.min_mired
+        else:
+            mode = LutMode.BRIGHTNESS
+
+        for _ in range(2):
+            controller.change_light_state(mode, on=True, **kwargs)
+            self._wait(request.parameters.sleep_time)
+        self._wait(request.parameters.sleep_initial)
 
     @staticmethod
     def _cache_key(request: LightMeasurementRequest) -> str:

--- a/utils/measure/measure/ha_app/light_probe.py
+++ b/utils/measure/measure/ha_app/light_probe.py
@@ -7,12 +7,13 @@ import time
 
 from measure.assembler import MeasurementAssembler
 from measure.controller.light.const import LutMode
-from measure.controller.light.controller import LightController, LightInfo
+from measure.controller.light.controller import LightController
 from measure.execution import ImmediateInteraction
 from measure.home_assistant import HomeAssistantManager
 from measure.powermeter.errors import ZeroReadingError
 from measure.request import LightMeasurementRequest
 from measure.runner.light_plan import Variation, build_light_plan, low_load_probe_variations
+from measure.runner.light_setup import set_light_to_maximum_brightness
 from measure.util.measure_util import MeasureUtil
 
 LIGHT_LOAD_PROBE_CACHE_SECONDS = 600
@@ -93,7 +94,14 @@ class LightLoadProbe:
             meter = assembler.build_power_meter(request.power_meter)
             measure_util = MeasureUtil(meter, request.parameters, wait=self._wait)
             light_driven = True
-            self._stabilize_load(controller, request, variations[0].mode, light_info)
+            set_light_to_maximum_brightness(
+                controller,
+                light_info,
+                variations[0].mode,
+                sleep_time=request.parameters.sleep_time,
+                wait=self._wait,
+            )
+            self._wait(request.parameters.sleep_initial)
             points = [
                 LightLoadProbePoint(
                     label=light_load_probe_label(variation),
@@ -141,28 +149,6 @@ class LightLoadProbe:
         controller.change_light_state(variation.mode, on=True, **asdict(variation))
         self._wait(request.parameters.sleep_time)
         return measure_util.take_measurement(start_timestamp=start_timestamp).power
-
-    def _stabilize_load(
-        self,
-        controller: LightController,
-        request: LightMeasurementRequest,
-        mode: LutMode,
-        light_info: LightInfo,
-    ) -> None:
-        """Match the runner's full-load preparation before probing low-load points."""
-
-        kwargs: dict[str, int] = {"bri": 255}
-        if mode == LutMode.HS:
-            kwargs.update(hue=0, sat=1)
-        elif mode == LutMode.COLOR_TEMP:
-            kwargs["ct"] = light_info.min_mired
-        else:
-            mode = LutMode.BRIGHTNESS
-
-        for _ in range(2):
-            controller.change_light_state(mode, on=True, **kwargs)
-            self._wait(request.parameters.sleep_time)
-        self._wait(request.parameters.sleep_initial)
 
     @staticmethod
     def _cache_key(request: LightMeasurementRequest) -> str:

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -32,6 +32,7 @@ from measure.runner.light_plan import (
     variation_from_csv_row,
     variations_after,
 )
+from measure.runner.light_setup import set_light_to_maximum_brightness
 from measure.runner.runner import MeasurementRunner, RunnerResult
 from measure.tuning import MeasurementParameters
 from measure.util.measure_util import AverageMeasurementConvergence, MeasurementResult, MeasureUtil
@@ -195,7 +196,15 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
             # again, after they received two turn-off commands, followed by a single
             # turn on command, we set them to maximum brightness, twice here.
             # See issue #2598
-            self.set_light_to_maximum_brightness(mode)
+            assert self.light_info is not None
+            set_light_to_maximum_brightness(
+                self.light_controller,
+                self.light_info,
+                mode,
+                sleep_time=self.config.sleep_time,
+                wait=self._wait,
+                checkpoint=self._checkpoint,
+            )
 
             # Initially wait longer so the smartplug can settle
             _LOGGER.info(
@@ -349,36 +358,6 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
         ):
             _LOGGER.info("Extra waiting for effect change...")
             self._wait(self.config.sleep_time_effect_change)
-
-    def set_light_to_maximum_brightness(self, mode: LutMode) -> None:
-        """Set maximum brightness twice for lights that turn off after rapid commands."""
-        assert self.light_info is not None
-        _LOGGER.info("Turning on light with maximum brightness")
-        # Turn the light on twice to ensure it's in the correct state
-        for _ in range(2):
-            self._checkpoint()
-            if mode == LutMode.HS:
-                self.light_controller.change_light_state(
-                    mode,
-                    on=True,
-                    bri=255,
-                    hue=0,  # Set default hue
-                    sat=1,  # Set default saturation
-                )
-            elif mode == LutMode.COLOR_TEMP:
-                self.light_controller.change_light_state(
-                    mode,
-                    on=True,
-                    bri=255,
-                    ct=self.light_info.min_mired,  # Set to minimum mired value for color temp
-                )
-            else:
-                self.light_controller.change_light_state(
-                    LutMode.BRIGHTNESS,
-                    on=True,
-                    bri=255,
-                )
-            self._wait(self.config.sleep_time)  # Wait for the light to process
 
     def calculate_time_left(
         self,

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -206,14 +206,10 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
                 checkpoint=self._checkpoint,
             )
 
-            # Initially wait longer so the smartplug can settle
             _LOGGER.info(
                 "Start taking measurements for color mode: %s",
                 mode.value,
             )
-            _LOGGER.info("Waiting %d seconds...", self.config.sleep_initial)
-            self.interaction.phase(f"Stabilizing light before the first reading ({self.config.sleep_initial} s)")
-            self._wait(self.config.sleep_initial)
 
             self._report_progress(mode, all_variations, remaining_variations)
             previous_variation = None
@@ -331,6 +327,11 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
         self._wait(self.config.sleep_time)
 
         if not previous_variation:
+            # Initially wait longer after selecting the first measurement point so
+            # the smart plug cannot report a reading left over from maximum load.
+            _LOGGER.info("Waiting %d seconds...", self.config.sleep_initial)
+            self.interaction.phase(f"Stabilizing light before the first reading ({self.config.sleep_initial} s)")
+            self._wait(self.config.sleep_initial)
             return
 
         if (

--- a/utils/measure/measure/runner/light_setup.py
+++ b/utils/measure/measure/runner/light_setup.py
@@ -1,0 +1,34 @@
+from collections.abc import Callable
+import logging
+
+from measure.controller.light.const import LutMode
+from measure.controller.light.controller import LightController, LightInfo
+
+_LOGGER = logging.getLogger("measure")
+
+
+def set_light_to_maximum_brightness(
+    controller: LightController,
+    light_info: LightInfo,
+    mode: LutMode,
+    *,
+    sleep_time: float,
+    wait: Callable[[float], None],
+    checkpoint: Callable[[], None] | None = None,
+) -> None:
+    """Set maximum brightness twice for lights that turn off after rapid commands."""
+
+    kwargs: dict[str, int] = {"bri": 255}
+    if mode == LutMode.HS:
+        kwargs.update(hue=0, sat=1)
+    elif mode == LutMode.COLOR_TEMP:
+        kwargs["ct"] = light_info.min_mired
+    else:
+        mode = LutMode.BRIGHTNESS
+
+    _LOGGER.info("Turning on light with maximum brightness")
+    for _ in range(2):
+        if checkpoint is not None:
+            checkpoint()
+        controller.change_light_state(mode, on=True, **kwargs)
+        wait(sleep_time)

--- a/utils/measure/tests/runner/test_light.py
+++ b/utils/measure/tests/runner/test_light.py
@@ -162,6 +162,31 @@ def test_run(export_path: str) -> None:
     assert points[-1] == {"type": "light", "on": True, "brightness": 255}
 
 
+def test_initial_wait_happens_after_selecting_first_measurement_point(tmp_path: Path) -> None:
+    events: list[tuple[str, object]] = []
+    variation = Variation(1)
+    run = _brightness_run(tmp_path, [variation])
+    run.runner.config = replace(run.runner.config, sleep_time=2, sleep_initial=10)
+    light_controller = MagicMock(spec=DummyLightController)
+    light_controller.change_light_state.side_effect = lambda *args, **kwargs: events.append(("change", (args, kwargs)))
+    run.runner.light_controller = light_controller
+    run.runner.interaction.wait.side_effect = lambda seconds: events.append(("wait", seconds))
+    run.measure_util.take_measurement.return_value = MeasurementResult(power=1, voltages=[])
+
+    run.execute()
+
+    assert events[:7] == [
+        ("change", ((LutMode.BRIGHTNESS,), {"on": True, "bri": 255})),
+        ("wait", 2),
+        ("change", ((LutMode.BRIGHTNESS,), {"on": True, "bri": 255})),
+        ("wait", 2),
+        ("change", ((LutMode.BRIGHTNESS,), {"on": True, "bri": 1})),
+        ("wait", 2),
+        ("wait", 10),
+    ]
+    run.runner.interaction.phase.assert_called_once_with("Stabilizing light before the first reading (10 s)")
+
+
 def test_zero_reading_retries_current_variation_and_reports_skipped_progress(tmp_path: Path) -> None:
     variations = [Variation(1), Variation(2)]
     run = _brightness_run(tmp_path, variations)

--- a/utils/measure/tests/test_light_probe.py
+++ b/utils/measure/tests/test_light_probe.py
@@ -28,15 +28,19 @@ import pytest
 
 
 class FakeLightController:
-    def __init__(self, *, fail_cleanup: bool = False) -> None:
+    def __init__(self, *, fail_cleanup: bool = False, events: list[tuple[str, object]] | None = None) -> None:
         self.changes: list[tuple[LutMode, bool, dict[str, object]]] = []
         self.closed = False
         self.fail_cleanup = fail_cleanup
+        self.events = events
 
     def change_light_state(self, lut_mode: LutMode, on: bool = True, **kwargs: object) -> None:
         if not on and self.fail_cleanup:
             raise RuntimeError("turn-off failed")
-        self.changes.append((lut_mode, on, kwargs))
+        change = (lut_mode, on, kwargs)
+        self.changes.append(change)
+        if self.events is not None:
+            self.events.append(("change", change))
 
     def get_light_info(self) -> LightInfo:
         return LightInfo("test", min_mired=153, max_mired=454)
@@ -142,32 +146,63 @@ def test_active_probe_checks_rgb_primaries_and_caches_an_exact_request() -> None
 
 
 @pytest.mark.parametrize(
-    "mode, powers, expected_change",
+    "mode, powers, expected_maximum, expected_low",
     [
-        (LutMode.BRIGHTNESS, [1.2], (LutMode.BRIGHTNESS, True, {"bri": 255})),
-        (LutMode.COLOR_TEMP, [1.2, 1.1], (LutMode.COLOR_TEMP, True, {"bri": 255, "ct": 153})),
-        (LutMode.HS, [1.2, 0.9, 1.1], (LutMode.HS, True, {"bri": 255, "hue": 0, "sat": 1})),
+        (
+            LutMode.BRIGHTNESS,
+            [1.2],
+            (LutMode.BRIGHTNESS, True, {"bri": 255}),
+            (LutMode.BRIGHTNESS, True, {"bri": 1}),
+        ),
+        (
+            LutMode.COLOR_TEMP,
+            [1.2, 1.1],
+            (LutMode.COLOR_TEMP, True, {"bri": 255, "ct": 153}),
+            (LutMode.COLOR_TEMP, True, {"bri": 1, "ct": 153}),
+        ),
+        (
+            LutMode.HS,
+            [1.2, 0.9, 1.1],
+            (LutMode.HS, True, {"bri": 255, "hue": 0, "sat": 1}),
+            (LutMode.HS, True, {"bri": 1, "hue": 1, "sat": 255}),
+        ),
     ],
 )
 def test_active_probe_stabilizes_full_load_before_checking_low_load(
     mode: LutMode,
     powers: list[float],
-    expected_change: tuple[LutMode, bool, dict[str, int]],
+    expected_maximum: tuple[LutMode, bool, dict[str, int]],
+    expected_low: tuple[LutMode, bool, dict[str, int]],
 ) -> None:
-    controller = FakeLightController()
+    events: list[tuple[str, object]] = []
+    controller = FakeLightController(events=events)
     meter = FakePowerMeter(powers)
     waits: list[float] = []
     parameters = MeasurementParameters(sleep_time=2, sleep_initial=10)
+
+    def record_wait(seconds: float) -> None:
+        waits.append(seconds)
+        events.append(("wait", seconds))
+
     probe = LightLoadProbe(
         lambda: FakeAssembler(controller, meter),
-        wait=waits.append,
+        wait=record_wait,
         now=lambda: 10,
     )
 
     probe.evaluate(request(parameters=parameters, modes={mode}))
 
-    assert controller.changes[:2] == [expected_change, expected_change]
-    assert waits[:3] == [2, 2, 10]
+    assert controller.changes[:3] == [expected_maximum, expected_maximum, expected_low]
+    assert events[:7] == [
+        ("change", expected_maximum),
+        ("wait", 2),
+        ("change", expected_maximum),
+        ("wait", 2),
+        ("change", expected_low),
+        ("wait", 2),
+        ("wait", 10),
+    ]
+    assert waits[:4] == [2, 2, 2, 10]
 
 
 def test_active_probe_rejects_repeated_zero_on_saturated_green_and_cleans_up() -> None:

--- a/utils/measure/tests/test_light_probe.py
+++ b/utils/measure/tests/test_light_probe.py
@@ -135,10 +135,39 @@ def test_active_probe_checks_rgb_primaries_and_caches_an_exact_request() -> None
         "Color 240° / 100% saturation · brightness 1",
     ]
     assert meter.calls == 3
-    hues = [change[2]["hue"] for change in controller.changes if change[0] == LutMode.HS]
+    hues = [change[2]["hue"] for change in controller.changes if change[0] == LutMode.HS and change[2]["bri"] == 1]
     assert hues == [1, 21849, 43697]
     assert controller.changes[-1] == (LutMode.BRIGHTNESS, False, {})
     assert controller.closed
+
+
+@pytest.mark.parametrize(
+    "mode, powers, expected_change",
+    [
+        (LutMode.BRIGHTNESS, [1.2], (LutMode.BRIGHTNESS, True, {"bri": 255})),
+        (LutMode.COLOR_TEMP, [1.2, 1.1], (LutMode.COLOR_TEMP, True, {"bri": 255, "ct": 153})),
+        (LutMode.HS, [1.2, 0.9, 1.1], (LutMode.HS, True, {"bri": 255, "hue": 0, "sat": 1})),
+    ],
+)
+def test_active_probe_stabilizes_full_load_before_checking_low_load(
+    mode: LutMode,
+    powers: list[float],
+    expected_change: tuple[LutMode, bool, dict[str, int]],
+) -> None:
+    controller = FakeLightController()
+    meter = FakePowerMeter(powers)
+    waits: list[float] = []
+    parameters = MeasurementParameters(sleep_time=2, sleep_initial=10)
+    probe = LightLoadProbe(
+        lambda: FakeAssembler(controller, meter),
+        wait=waits.append,
+        now=lambda: 10,
+    )
+
+    probe.evaluate(request(parameters=parameters, modes={mode}))
+
+    assert controller.changes[:2] == [expected_change, expected_change]
+    assert waits[:3] == [2, 2, 10]
 
 
 def test_active_probe_rejects_repeated_zero_on_saturated_green_and_cleans_up() -> None:


### PR DESCRIPTION
## Summary

- explain how to initialize newly discovered Home Assistant lights when they are missing from the selector
- keep lights without a usable state excluded from measurement setup
- stabilize lights at full load before the preflight low-load probe, matching the actual measurement runner

## Validation

- uv run pytest (646 passed)
- uv run pytest tests/test_light_probe.py --cov=measure.ha_app.light_probe --cov-report=term-missing --cov-fail-under=100 (100% coverage)
- npm test (183 passed)
- npm run build
- npm run lint
- uv run prek run --all-files

Closes #4707
Follow-up to #4487