### PR TITLE
Explain grouping for larger light measurements

### DIFF
--- a/docs/source/contributing/measure/lights.md
+++ b/docs/source/contributing/measure/lights.md
@@ -94,7 +94,7 @@ Notes:
 
 When standby power is too low for your meter, measuring multiple identical lights in parallel can make the total load measurable. In the Home Assistant app, enable **Measure multiple lights**, then use **Add another light** to select two or three individual light entities directly. The app sends each operating point to all selected entities and divides the measured power by **Number of lights**.
 
-For larger sets, prefer a native Zigbee or Hue group: it sends one command over the lighting network. A Home Assistant light group also works, but Home Assistant may fan the command out to every member. The app automatically counts the entities you select directly. When selecting a group as one entity, enter its total number of physical lights manually.
+For larger sets, prefer a native Zigbee or Hue group: it sends one command over the lighting network. A [Home Assistant light group](https://www.home-assistant.io/integrations/group/) also works, but Home Assistant may fan the command out to every member. The app automatically counts the entities you select directly. When selecting a group as one entity, enter its total number of physical lights manually.
 
 Only use this when every connected light is the same model and receives the same commands. The app rejects different known model IDs and warns when Home Assistant does not provide enough model metadata to verify this. See [Measuring low-power devices](low-power-measurements.md) for details.
 

--- a/docs/source/contributing/measure/low-power-measurements.md
+++ b/docs/source/contributing/measure/low-power-measurements.md
@@ -26,10 +26,11 @@ If any representative point repeatedly reads `0` W, use one of the approaches be
 Measuring several identical devices in parallel raises the aggregate load above the meter's measurement floor. For
 example, four bulbs that each use approximately 0.2 W in standby produce a combined load of approximately 0.8 W.
 
-In the Home Assistant app, enable **Measure multiple lights** and select the individual light entities. For larger
-sets, prefer a native Zigbee or Hue group because it sends one lighting-network command. A Home Assistant light group
-also works but may send a separate command to each member. Enter the total number of physical lights in **Number of
-lights**; Powercalc divides the aggregate reading by that number.
+In the Home Assistant app, enable **Measure multiple lights** and select up to three individual light entities. For
+larger sets, prefer a native Zigbee or Hue group because it sends one lighting-network command. A
+[Home Assistant light group](https://www.home-assistant.io/integrations/group/) also works but may send a separate
+command to each member. Enter the total number of physical lights in **Number of lights**; Powercalc divides the
+aggregate reading by that number.
 
 Only combine devices when all of them:
 

--- a/utils/measure/frontend/src/components/setup-view.test.ts
+++ b/utils/measure/frontend/src/components/setup-view.test.ts
@@ -268,6 +268,13 @@ describe("setup view", () => {
     expect(element.shadowRoot.querySelector('input[name="multiple_light_count"][type="number"]')).toBeNull();
     expect(element.shadowRoot.querySelectorAll('measure-combobox[name="light_entity_id"]')).toHaveLength(1);
     expect(element.shadowRoot.querySelector(".multiple-lights")?.textContent).toContain("very low power use");
+    expect(element.shadowRoot.querySelector(".multiple-lights")?.textContent).toContain("Select up to three individual lights");
+    const groupGuide = element.shadowRoot.querySelector<HTMLAnchorElement>(
+      '.multiple-lights a[href="https://www.home-assistant.io/integrations/group/"]',
+    );
+    expect(groupGuide?.textContent).toBe("Home Assistant light group");
+    expect(groupGuide?.getAttribute("target")).toBe("_blank");
+    expect(groupGuide?.getAttribute("rel")).toBe("noopener noreferrer");
 
     element.shadowRoot.querySelector<HTMLInputElement>('input[name="measure_multiple_lights"]')!.click();
     await element.updateComplete;

--- a/utils/measure/frontend/src/components/setup-view.ts
+++ b/utils/measure/frontend/src/components/setup-view.ts
@@ -50,6 +50,7 @@ const LIGHT_DISCOVERY_HINT =
 
 const FULL_PRODUCT_NAME_HINT = "Enter the complete marketed name, including the series and variant shown on the product or packaging. Do not repeat the manufacturer name.";
 const MULTIPLE_LIGHTS_GUIDE_URL = "https://docs.powercalc.nl/contributing/measure/lights/#multiple-identical-lights";
+const HOME_ASSISTANT_GROUP_GUIDE_URL = "https://www.home-assistant.io/integrations/group/";
 
 @customElement("measure-setup-view")
 export class SetupView extends LitElement {
@@ -336,6 +337,9 @@ export class SetupView extends LitElement {
         </label>
         <p class="muted">
           Measuring multiple identical lights together increases the load, making very low power use easier to measure accurately.
+          Select up to three individual lights. For larger sets, select a native Zigbee or Hue group, or create a
+          <a href=${HOME_ASSISTANT_GROUP_GUIDE_URL} target="_blank" rel="noopener noreferrer">Home Assistant light group</a>,
+          then enter the total number of physical lights.
           <a
             class="help-link"
             href=${MULTIPLE_LIGHTS_GUIDE_URL}


### PR DESCRIPTION
## Summary

- explain the three-light direct-selection limit in the measure app
- guide users with larger sets toward native Zigbee/Hue groups or Home Assistant light groups
- link the Home Assistant group documentation and keep the Powercalc guides aligned

## Validation

- npm test (183 tests)
- npm run lint
- npm run build
- uv run --group docs zensical build --clean
- python .github/scripts/validate_translations.py
- uv run pytest tests/test_translations.py

Closes #4485