### PR TITLE
Use repeatable inputs for profile aliases and barcodes

### DIFF
--- a/utils/measure/frontend/e2e/happy-flow.spec.ts
+++ b/utils/measure/frontend/e2e/happy-flow.spec.ts
@@ -302,17 +302,19 @@ for (const width of [1280, 390]) {
   });
 }
 
-test("preserves unfinished profile fields and tags when navigating back to Result", async ({ page }) => {
+test("preserves unfinished profile fields, list rows and tags when navigating back to Result", async ({ page }) => {
   await page.route("**/api/sessions/session-completed/contribution/preview", (route) => route.fulfill({
     json: { ...contributionPreview, product_name: "Edited lamp" },
   }));
   await page.getByRole("button", { name: "Open", exact: true }).click();
   await page.getByRole("button", { name: "Prepare profile" }).click();
   const product = page.locator('input[name="product_name"]');
-  const aliases = page.locator('input[name="aliases"]');
+  const aliases = page.locator('measure-string-list-input[name="aliases"]');
+  const aliasInputs = aliases.locator("input");
   const meter = page.getByRole("combobox", { name: "Measurement device", exact: true });
   await product.fill("Edited lamp ");
-  await aliases.fill("Alias one, ");
+  await aliasInputs.first().fill("Alias one ");
+  await aliases.getByRole("button", { name: "Add another alias" }).click();
   await meter.fill("Custom meter");
   await page.getByRole("combobox", { name: "Connectivity", exact: true }).click();
   await page.getByRole("option", { name: "Zigbee", exact: true }).click();
@@ -322,7 +324,9 @@ test("preserves unfinished profile fields and tags when navigating back to Resul
   await page.getByRole("button", { name: "Prepare profile" }).click();
 
   await expect(product).toHaveValue("Edited lamp ");
-  await expect(aliases).toHaveValue("Alias one, ");
+  await expect(aliasInputs).toHaveCount(2);
+  await expect(aliasInputs.first()).toHaveValue("Alias one ");
+  await expect(aliasInputs.nth(1)).toHaveValue("");
   await expect(meter).toHaveValue("Custom meter");
   await expect(page.getByRole("button", { name: "Remove Zigbee" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Continue to submit profile" })).toBeHidden();
@@ -342,6 +346,34 @@ test("preserves unfinished profile fields and tags when navigating back to Resul
   await page.keyboard.press("Space");
   await expect(page.getByRole("heading", { name: "Measurement complete" })).toBeVisible();
   await expect(progress.getByRole("button")).toHaveCount(0);
+});
+
+test("submits aliases and barcodes as individual metadata rows", async ({ page }) => {
+  let submitted: Record<string, unknown> | undefined;
+  await page.route("**/api/sessions/session-completed/contribution/preview", async (route) => {
+    submitted = route.request().postDataJSON() as Record<string, unknown>;
+    await route.fulfill({ json: contributionPreview });
+  });
+  await page.getByRole("button", { name: "Open", exact: true }).click();
+  await page.getByRole("button", { name: "Prepare profile" }).click();
+
+  const aliases = page.locator('measure-string-list-input[name="aliases"]');
+  await aliases.locator("input").first().fill("LWA017-A");
+  await aliases.getByRole("button", { name: "Add another alias" }).click();
+  await aliases.locator("input").nth(1).fill("LWA017-B");
+
+  const barcodes = page.locator('measure-string-list-input[name="gtins"]');
+  await expect(barcodes.locator("input").first()).toHaveAttribute("inputmode", "numeric");
+  await barcodes.locator("input").first().fill("12345678");
+  await barcodes.getByRole("button", { name: "Add another barcode" }).click();
+  await barcodes.locator("input").nth(1).fill("1234567890123");
+  await page.getByRole("button", { name: "Validate changes" }).click();
+
+  await expect.poll(() => submitted).toMatchObject({
+    aliases: ["LWA017-A", "LWA017-B"],
+    gtins: ["12345678", "1234567890123"],
+  });
+  await expect(page.locator(".validation-status")).toContainText("Profile validated");
 });
 
 test("keeps profile metadata controls aligned at a consistent height", async ({ page }) => {
@@ -373,8 +405,8 @@ test("keeps profile metadata controls aligned at a consistent height", async ({ 
     page.locator('input[name="model_id"]'),
     page.locator('input[name="product_name"]'),
     page.locator('input[name="product_url"]'),
-    page.locator('input[name="aliases"]'),
-    page.locator('input[name="gtins"]'),
+    page.locator('measure-string-list-input[name="aliases"] input').first(),
+    page.locator('measure-string-list-input[name="gtins"] input').first(),
   ];
   const contributorControls = [
     page.locator('input[name="contributor"]'),

--- a/utils/measure/frontend/src/components/profile/form-section.ts
+++ b/utils/measure/frontend/src/components/profile/form-section.ts
@@ -23,6 +23,11 @@ export abstract class ProfileFormSection extends LitElement {
     return formValue(this.values[name] ?? fallback);
   }
 
+  protected fieldValues(name: string, fallback: string[]): string[] {
+    const value = this.values[name];
+    return Array.isArray(value) ? value : fallback;
+  }
+
   protected fieldError(name: string): string {
     return this.errors[name] ?? "";
   }

--- a/utils/measure/frontend/src/components/profile/navigation.test.ts
+++ b/utils/measure/frontend/src/components/profile/navigation.test.ts
@@ -1,6 +1,7 @@
 import type { AppSettings, ContributionPreview } from "../../types";
 import { AppShell } from "../app/shell";
 import type { Combobox } from "../shared/combobox";
+import type { StringListInput } from "../shared/string-list-input";
 import type { ProfilePrepareView } from "./prepare-view";
 import { capabilities, controllerOf, defaultSettings } from "../testing/fixtures";
 
@@ -18,6 +19,10 @@ function view(app: AppShell): ProfilePrepareView {
 
 function field(app: AppShell, name: string): HTMLInputElement {
   return view(app).shadowRoot!.querySelector(`[name="${name}"]`)!;
+}
+
+function listField(app: AppShell, name: "aliases" | "gtins"): StringListInput {
+  return view(app).shadowRoot!.querySelector(`measure-string-list-input[name="${name}"]`)!;
 }
 
 async function rendered(app: AppShell): Promise<void> {
@@ -73,10 +78,12 @@ async function backAndForward(app: AppShell): Promise<void> {
 afterEach(() => document.body.replaceChildren());
 
 describe("profile draft navigation", () => {
-  it("keeps unfinished text, empty overrides and multiselect tags when returning from Result", async () => {
+  it("keeps unfinished text, list rows and multiselect tags when returning from Result", async () => {
     const { app } = await mount();
     await edit(app, "product_name", "Edited product ");
-    await edit(app, "aliases", "First alias, ");
+    const aliases = listField(app, "aliases");
+    aliases.value = ["First alias ", ""];
+    aliases.dispatchEvent(new CustomEvent("list-input-change", { bubbles: true, composed: true }));
     await edit(app, "contributor_github", "");
     const connectivity = field(app, "device_specs.connectivity") as unknown as Combobox;
     connectivity.value = ["zigbee", "wifi"];
@@ -86,7 +93,7 @@ describe("profile draft navigation", () => {
     await backAndForward(app);
 
     expect(field(app, "product_name").value).toBe("Edited product ");
-    expect(field(app, "aliases").value).toBe("First alias, ");
+    expect(listField(app, "aliases").value).toEqual(["First alias ", ""]);
     expect(field(app, "contributor_github").value).toBe("");
     expect(field(app, "device_specs.connectivity").value).toEqual(["zigbee", "wifi"]);
     expect(view(app).previewDirty).toBe(true);

--- a/utils/measure/frontend/src/components/profile/prepare-view.test.ts
+++ b/utils/measure/frontend/src/components/profile/prepare-view.test.ts
@@ -1,5 +1,6 @@
 import { ProfilePrepareView } from "./prepare-view";
 import type { Combobox } from "../shared/combobox";
+import type { StringListInput } from "../shared/string-list-input";
 import type { ContributionPreview } from "../../types";
 
 const preview: ContributionPreview = {
@@ -76,22 +77,27 @@ describe("profile validation", () => {
     const element = await mount();
     element.contributionPreview = { ...preview };
     await element.updateComplete;
-    input(element, "aliases").value = "Alias, Alias";
-    input(element, "aliases").dispatchEvent(new Event("input", { bubbles: true }));
+    const aliases = element.shadowRoot!.querySelector<StringListInput>('measure-string-list-input[name="aliases"]')!;
+    aliases.value = [" Alias ", "Second alias"];
+    aliases.dispatchEvent(new CustomEvent("list-input-change", { bubbles: true, composed: true }));
     await element.updateComplete;
     expect(element.shadowRoot!.textContent).toContain("Your changes have not been validated yet");
     expect(element.shadowRoot!.querySelector<HTMLButtonElement>('button[type="submit"]')?.textContent).toContain("Validate changes");
     expect(element.shadowRoot!.querySelector(".validation-status.valid")).toBeNull();
     expect(element.shadowRoot!.querySelector(".prepared-preview")).toBeNull();
     expect(element.shadowRoot!.textContent).not.toContain("Continue to submit profile");
+    const onPreview = vi.fn();
+    element.addEventListener("contribution-preview", onPreview);
     submit(element);
+    expect(onPreview.mock.calls[0]![0].detail.aliases).toEqual(["Alias", "Second alias"]);
     element.contributionBusy = true;
     await element.updateComplete;
     expect(element.shadowRoot!.querySelector("fieldset")!.disabled).toBe(true);
     element.contributionPreview = { ...preview };
     element.contributionBusy = false;
     await element.updateComplete;
-    expect(input(element, "aliases").value).toBe("Alias");
+    const normalizedAliases = element.shadowRoot!.querySelector<StringListInput>('measure-string-list-input[name="aliases"]')!;
+    expect(normalizedAliases.value).toEqual(["Alias"]);
   });
 
   it("preserves boolean and enum specification values and highlights schema errors on the exact field", async () => {

--- a/utils/measure/frontend/src/components/profile/prepare-view.ts
+++ b/utils/measure/frontend/src/components/profile/prepare-view.ts
@@ -160,7 +160,8 @@ export class ProfilePrepareView extends LitElement {
         <form class="contribution-form" novalidate @submit=${this.previewContribution}
           @input=${this.metadataChanged} @change=${this.metadataChanged}
           @focusout=${this.validateField}
-          @combobox-change=${this.metadataChanged}>
+          @combobox-change=${this.metadataChanged}
+          @list-input-change=${this.metadataChanged}>
           ${this.renderValidationSummary()}
           <p class="muted required-guidance">Fields marked <span class="required-marker" aria-hidden="true">*</span><span class="sr-only">with an asterisk</span> are required.</p>
           <measure-profile-product-fields
@@ -375,7 +376,7 @@ export class ProfilePrepareView extends LitElement {
 }
 
 function formList(data: FormData, name: string): string[] {
-  return formText(data, name).split(",").map((value) => value.trim()).filter(Boolean);
+  return data.getAll(name).map(String).map((value) => value.trim()).filter(Boolean);
 }
 
 function collectDeviceSpecifications(data: FormData, fields: DeviceSpecificationField[]): Record<string, unknown> {

--- a/utils/measure/frontend/src/components/profile/product-fields.ts
+++ b/utils/measure/frontend/src/components/profile/product-fields.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ProfileFormSection } from "./form-section";
 import "../shared/combobox";
+import "../shared/string-list-input";
 
 @customElement("measure-profile-product-fields")
 export class ProfileProductFields extends ProfileFormSection {
@@ -38,14 +39,27 @@ export class ProfileProductFields extends ProfileFormSection {
             required: false,
             placeholder: "https://…",
           })}
-          ${this.renderInput("aliases", "Model aliases", (this.draft.aliases ?? []).join(", "), {
-            required: false,
-            placeholder: "Comma separated",
-          })}
-          ${this.renderInput("gtins", "GTIN / barcodes", (this.draft.gtins ?? []).join(", "), {
-            required: false,
-            placeholder: "Comma separated",
-          })}
+          <measure-string-list-input
+            name="aliases"
+            label="Model aliases"
+            itemLabel="Alias"
+            .value=${this.fieldValues("aliases", this.draft.aliases ?? [])}
+            .error=${this.fieldError("aliases")}
+            ?disabled=${this.busy}
+            placeholder="Enter a model alias"
+            hint="Add each alternative model identifier separately."
+          ></measure-string-list-input>
+          <measure-string-list-input
+            name="gtins"
+            label="GTIN / barcodes"
+            itemLabel="Barcode"
+            .inputMode=${"numeric"}
+            .value=${this.fieldValues("gtins", this.draft.gtins ?? [])}
+            .error=${this.fieldError("gtins")}
+            ?disabled=${this.busy}
+            placeholder="Enter a barcode"
+            hint="Add one 8, 12, 13 or 14 digit barcode per field."
+          ></measure-string-list-input>
         </div>
       </div>
     </fieldset>`;

--- a/utils/measure/frontend/src/components/profile/validation.test.ts
+++ b/utils/measure/frontend/src/components/profile/validation.test.ts
@@ -23,7 +23,7 @@ describe("metadata validation", () => {
   it("explains invalid formats and length limits", () => {
     expect(validateMetadata({ ...valid, model_id: "../model", product_url: "http://example.com", gtins: ["123"], notes: "a".repeat(2001) })).toMatchObject({
       model_id: expect.stringContaining("Start with a letter"), product_url: expect.stringContaining("https://"),
-      gtins: expect.stringContaining("digits"), notes: "Use 2000 characters or fewer.",
+      gtins: expect.stringContaining("digit"), notes: "Use 2000 characters or fewer.",
     });
   });
 

--- a/utils/measure/frontend/src/components/profile/validation.ts
+++ b/utils/measure/frontend/src/components/profile/validation.ts
@@ -29,7 +29,7 @@ export function validateMetadata(values: ContributionPreviewRequest): Record<str
   }
   if (values.product_url && !values.product_url.startsWith("https://")) errors.product_url = "Enter a URL starting with https://.";
   if (values.gtins?.some((value) => !/^(?:\d{8}|\d{12,14})$/.test(value))) {
-    errors.gtins = "Enter barcodes of 8, 12, 13 or 14 digits, separated by commas.";
+    errors.gtins = "Enter an 8, 12, 13 or 14 digit barcode in each field.";
   }
   if (values.contributor_email && !validEmail(values.contributor_email)) {
     errors.contributor_email = "Enter a valid email address, for example name@example.com.";

--- a/utils/measure/frontend/src/components/shared/string-list-input.test.ts
+++ b/utils/measure/frontend/src/components/shared/string-list-input.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { submittedForm } from "../../utils/form";
+import { StringListInput } from "./string-list-input";
+
+function mount(values: string[] = []): { form: HTMLFormElement; field: StringListInput } {
+  const form = document.createElement("form");
+  const field = new StringListInput();
+  field.name = "barcodes";
+  field.label = "GTIN / barcodes";
+  field.itemLabel = "Barcode";
+  field.value = values;
+  form.append(field);
+  document.body.append(form);
+  return { form, field };
+}
+
+describe("string list input", () => {
+  afterEach(() => document.body.replaceChildren());
+
+  it("adds, submits and removes individual values", async () => {
+    const { form, field } = mount(["12345678"]);
+    await field.updateComplete;
+    const changed = vi.fn();
+    field.addEventListener("list-input-change", changed);
+
+    field.shadowRoot!.querySelector<HTMLButtonElement>(".add")!.click();
+    await field.updateComplete;
+    const inputs = [...field.shadowRoot!.querySelectorAll<HTMLInputElement>("input")];
+    expect(inputs).toHaveLength(2);
+    expect(field.shadowRoot!.activeElement).toBe(inputs[1]);
+    inputs[1]!.value = " 1234567890123 ";
+    inputs[1]!.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await field.updateComplete;
+
+    expect(field.value).toEqual(["12345678", " 1234567890123 "]);
+    expect(submittedForm(form).getAll("barcodes")).toEqual(["12345678", " 1234567890123 "]);
+    field.shadowRoot!.querySelector<HTMLButtonElement>('[aria-label="Remove barcode 1"]')!.click();
+    await field.updateComplete;
+    expect(field.value).toEqual([" 1234567890123 "]);
+    expect(field.shadowRoot!.querySelectorAll("input")).toHaveLength(1);
+    expect(changed).toHaveBeenCalledTimes(3);
+  });
+
+  it("renders one empty input and exposes guidance and errors", async () => {
+    const { form, field } = mount();
+    field.hint = "Add one barcode per field.";
+    field.error = "Enter a valid barcode.";
+    field.inputMode = "numeric";
+    await field.updateComplete;
+
+    const input = field.shadowRoot!.querySelector("input")!;
+    expect(input.inputMode).toBe("numeric");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("aria-describedby")).toBe("list-hint list-error");
+    expect(field.shadowRoot!.querySelectorAll("input")).toHaveLength(1);
+    expect(field.shadowRoot!.querySelector<HTMLButtonElement>(".add")!.disabled).toBe(true);
+    expect(submittedForm(form).getAll("barcodes")).toEqual([]);
+  });
+});

--- a/utils/measure/frontend/src/components/shared/string-list-input.ts
+++ b/utils/measure/frontend/src/components/shared/string-list-input.ts
@@ -1,0 +1,164 @@
+import { LitElement, css, html, nothing, type PropertyValues } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { sharedStyles } from "../../styles";
+import { emit } from "../../utils/events";
+
+@customElement("measure-string-list-input")
+export class StringListInput extends LitElement {
+  static readonly formAssociated = true;
+
+  @property({ type: String }) name = "";
+  @property({ type: String }) label = "";
+  @property({ type: String }) itemLabel = "Entry";
+  @property({ attribute: false }) value: string[] = [];
+  @property({ type: String }) placeholder = "";
+  @property({ type: String }) hint = "";
+  @property({ type: String }) error = "";
+  @property({ type: String }) inputMode: "text" | "numeric" = "text";
+  @property({ type: Boolean }) disabled = false;
+
+  private readonly internals = this.createInternals();
+
+  static readonly styles = [sharedStyles, css`
+    :host { display: grid; min-width: 0; }
+    fieldset { gap: 0.4rem; }
+    legend { margin-bottom: 0.4rem; }
+    .rows { display: grid; gap: 0.5rem; }
+    .row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; gap: 0.5rem; align-items: center; }
+    .row-action { display: grid; place-items: center; width: 44px; padding: 0; }
+    .row-action svg { width: 20px; height: 20px; }
+  `];
+
+  protected updated(changed: PropertyValues<this>): void {
+    if (changed.has("value") || changed.has("name") || changed.has("disabled") || changed.has("error")) {
+      this.syncFormControl();
+    }
+  }
+
+  render() {
+    const values = this.rows();
+    const describedBy = [this.hint ? "list-hint" : "", this.error ? "list-error" : ""].filter(Boolean).join(" ");
+    return html`
+      <fieldset ?disabled=${this.disabled}>
+        <legend>${this.label}</legend>
+        <div class="rows">
+          ${values.map((value, index) => html`
+            <div class="row">
+              <label>
+                <span class="sr-only">${this.itemLabel} ${index + 1}</span>
+                <input
+                  name=${this.name}
+                  type="text"
+                  inputmode=${this.inputMode}
+                  .value=${value}
+                  placeholder=${this.placeholder}
+                  autocomplete="off"
+                  aria-invalid=${this.error ? "true" : "false"}
+                  aria-describedby=${describedBy || nothing}
+                  @input=${(event: InputEvent) => this.rowChanged(index, event)}
+                />
+              </label>
+              ${values.length > 1 ? this.renderRemoveButton(index) : nothing}
+              ${index === values.length - 1 ? this.renderAddButton(value) : nothing}
+            </div>
+          `)}
+        </div>
+        ${this.hint ? html`<small id="list-hint" class="field-hint">${this.hint}</small>` : nothing}
+        ${this.error ? html`<small id="list-error" class="field-hint error">${this.error}</small>` : nothing}
+      </fieldset>
+    `;
+  }
+
+  private renderRemoveButton(index: number) {
+    return html`<button
+      class="row-action remove danger"
+      type="button"
+      aria-label=${`Remove ${this.itemLabel.toLowerCase()} ${index + 1}`}
+      title=${`Remove ${this.itemLabel.toLowerCase()} ${index + 1}`}
+      @click=${() => void this.removeRow(index)}
+    >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6M10 10v6M14 10v6"></path>
+      </svg>
+    </button>`;
+  }
+
+  private renderAddButton(value: string) {
+    const label = `Add another ${this.itemLabel.toLowerCase()}`;
+    return html`<button
+      class="row-action add"
+      type="button"
+      aria-label=${label}
+      title=${label}
+      ?disabled=${!value.trim()}
+      @click=${this.addRow}
+    >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+        <path d="M12 5v14M5 12h14"></path>
+      </svg>
+    </button>`;
+  }
+
+  private rowChanged(index: number, event: InputEvent): void {
+    event.stopPropagation();
+    const values = [...this.rows()];
+    values[index] = (event.currentTarget as HTMLInputElement).value;
+    this.change(values);
+  }
+
+  private async addRow(): Promise<void> {
+    this.change([...this.rows(), ""]);
+    await this.updateComplete;
+    this.inputs().at(-1)?.focus();
+  }
+
+  private async removeRow(index: number): Promise<void> {
+    const values = this.rows().filter((_, position) => position !== index);
+    this.change(values);
+    await this.updateComplete;
+    const inputs = this.inputs();
+    inputs[Math.min(index, inputs.length - 1)]?.focus();
+  }
+
+  private change(values: string[]): void {
+    this.value = values;
+    this.syncFormControl();
+    emit<{ value: string[] }>(this, "list-input-change", { value: values });
+  }
+
+  private rows(): string[] {
+    return this.value.length ? this.value : [""];
+  }
+
+  private inputs(): HTMLInputElement[] {
+    return [...this.renderRoot.querySelectorAll<HTMLInputElement>("input")];
+  }
+
+  private submittedValues(): string[] {
+    return this.value.map((value) => value.trim()).filter(Boolean);
+  }
+
+  private syncFormControl(): void {
+    const values = this.submittedValues();
+    const formValue = new FormData();
+    for (const value of values) formValue.append(this.name, value);
+    this.internals?.setFormValue(this.disabled || !this.name || !values.length ? null : formValue);
+    this.internals?.setValidity(
+      this.error ? { customError: true } : {},
+      this.error,
+      this.inputs()[0],
+    );
+  }
+
+  private createInternals(): ElementInternals | undefined {
+    if (typeof this.attachInternals !== "function") return undefined;
+    const internals = this.attachInternals();
+    return typeof internals.setFormValue === "function" ? internals : undefined;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "measure-string-list-input": StringListInput;
+  }
+}

--- a/utils/measure/frontend/src/utils/form.ts
+++ b/utils/measure/frontend/src/utils/form.ts
@@ -58,7 +58,7 @@ interface FormValueElement extends Element {
  */
 export function submittedForm(form: HTMLFormElement): FormData {
   const data = new FormData(form);
-  for (const control of form.querySelectorAll<FormValueElement>("measure-combobox")) {
+  for (const control of form.querySelectorAll<FormValueElement>("measure-combobox, measure-string-list-input")) {
     if (!control.name) continue;
     data.delete(control.name);
     if (control.disabled) continue;


### PR DESCRIPTION
## Summary
- replace comma-separated model alias and GTIN fields with compact repeatable inputs
- place an accessible plus action beside the final populated field and expose removal controls for extra rows
- keep profile metadata array-native through Lit state, FormData, validation, and API submission
- preserve unfinished rows across step navigation

## Verification
- PATH=/opt/homebrew/bin:$PATH npm run typecheck
- PATH=/opt/homebrew/bin:$PATH npm run lint
- PATH=/opt/homebrew/bin:$PATH npm test -- --run (273 passed)
- PATH=/opt/homebrew/bin:$PATH npm run build
- PATH=/opt/homebrew/bin:$PATH npm run test:e2e (24 passed)