### PR TITLE
Add light mode and refine measurement session cards

### DIFF
--- a/utils/measure/frontend/e2e/happy-flow.spec.ts
+++ b/utils/measure/frontend/e2e/happy-flow.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import { contributionPreview, mockApi, startedSnapshot } from "./mock-api";
-import type { SessionSnapshot } from "../src/types";
+import type { SessionSnapshot, SessionSummary } from "../src/types";
 
 /**
  * Happy-flow smoke tests in a real browser.
@@ -33,6 +33,76 @@ test("boots and lists the stored measurement sessions", async ({ page }) => {
   await measureAgain.hover();
   await expect(tooltip).toBeVisible();
   await expect(tooltip).toHaveText("Start a new measurement using these settings");
+});
+
+test("follows the system color scheme and persists an explicit theme", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "light", reducedMotion: "reduce" });
+  await page.reload();
+  const app = page.locator("powercalc-measure-app");
+  const theme = app.getByRole("button", { name: /Color theme:/ });
+  const sessions = page.locator("measure-sessions-view");
+
+  await app.evaluate((element) => {
+    const shell = element as HTMLElement & { sessions: SessionSummary[]; requestUpdate: () => void };
+    const completed = shell.sessions[0];
+    if (!completed) return;
+    shell.sessions = [
+      completed,
+      { ...completed, session_id: "session-completed-2", product_name: "Recorder", model_id: "" },
+      { ...completed, session_id: "session-completed-3", product_name: "Recorder", model_id: "" },
+      {
+        ...completed,
+        session_id: "session-cancelled",
+        state: "cancelled",
+        product_name: "Bedroom",
+        model_id: "Room",
+        can_resume: true,
+        completed: 2,
+        total: 4,
+        percent: 50,
+      },
+    ];
+    shell.requestUpdate();
+  });
+  await expect(sessions.locator("article")).toHaveCount(4);
+
+  await expect(app).toHaveAttribute("data-theme", "system");
+  await expect(theme).toHaveAttribute("aria-label", /Color theme: System/);
+  await expect(app).toHaveCSS("background-color", "rgb(244, 247, 251)");
+  expect(await sessions.locator(".sessions").evaluate((grid) => getComputedStyle(grid).gridTemplateColumns.split(" "))).toHaveLength(3);
+  expect(await sessions.locator(".primary-actions").first().evaluate((grid) => getComputedStyle(grid).gridTemplateColumns.split(" "))).toHaveLength(3);
+  expect(await sessions.locator(".primary-actions button").evaluateAll((buttons) => buttons.every((button) => button.scrollWidth <= button.clientWidth))).toBe(true);
+  expect(await sessions.locator("article").first().evaluate((card) => getComputedStyle(card).backgroundColor))
+    .not.toBe(await sessions.locator(".panel").evaluate((panel) => getComputedStyle(panel).backgroundColor));
+  await page.screenshot({ path: testInfo.outputPath("sessions-light.png"), fullPage: true });
+
+  await theme.click();
+  await expect(app).toHaveAttribute("data-theme", "light");
+  await expect(theme).toHaveAttribute("title", "Color theme: Light");
+  await theme.click();
+  await expect(app).toHaveAttribute("data-theme", "dark");
+  await expect(app).toHaveCSS("background-color", "rgb(13, 17, 25)");
+  expect(await sessions.locator("article").first().evaluate((card) => getComputedStyle(card).backgroundColor))
+    .not.toBe(await sessions.locator(".panel").evaluate((panel) => getComputedStyle(panel).backgroundColor));
+  await page.screenshot({ path: testInfo.outputPath("sessions-dark.png"), fullPage: true });
+
+  await page.reload();
+  await expect(app).toHaveAttribute("data-theme", "dark");
+  await expect(theme).toHaveAttribute("aria-label", /Color theme: Dark/);
+  await theme.click();
+  await expect(app).toHaveAttribute("data-theme", "system");
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect(app).toHaveCSS("background-color", "rgb(13, 17, 25)");
+  await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute("content", "#0d1119");
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.emulateMedia({ colorScheme: "light", reducedMotion: "reduce" });
+  await expect(app).toHaveCSS("background-color", "rgb(244, 247, 251)");
+  await expect(page.getByRole("button", { name: "Settings" })).toHaveCSS("background-color", "rgb(237, 242, 247)");
+  await expect(page.getByRole("button", { name: "Measure again" })).toHaveCSS("background-color", "rgb(255, 255, 255)");
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390);
+  await expect(page.getByRole("button", { name: "Open", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Diagnostics" })).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("sessions-light-mobile.png"), fullPage: true });
 });
 
 test("configures a measurement and reaches the setup check", async ({ page }) => {
@@ -426,7 +496,14 @@ test("shows required field errors inline with red borders and keeps edited previ
   await expect(manufacturer).toBeFocused();
   for (const control of [manufacturer, model, product]) {
     await expect(control).toHaveAttribute("aria-invalid", "true");
-    await expect(control).toHaveCSS("border-top-color", "rgb(255, 123, 114)");
+    expect(await control.evaluate((element) => {
+      const marker = document.createElement("span");
+      marker.style.color = "var(--danger)";
+      element.getRootNode().appendChild(marker);
+      const matchesTheme = getComputedStyle(element).borderTopColor === getComputedStyle(marker).color;
+      marker.remove();
+      return matchesTheme;
+    })).toBe(true);
   }
   await expect(page.getByText("Fields marked")).toBeVisible();
   await expect(page.locator("measure-profile-prepare-view .required-marker")).toHaveCount(7);

--- a/utils/measure/frontend/index.html
+++ b/utils/measure/frontend/index.html
@@ -7,7 +7,14 @@
     <meta name="color-scheme" content="dark light" />
     <base href="./" />
     <title>Powercalc Measure</title>
-    <style>html, body { margin: 0; min-height: 100%; background: #101418; }</style>
+    <style>
+      :root { color-scheme: dark; background: #0d1119; }
+      :root[data-theme="light"] { color-scheme: light; background: #f4f7fb; }
+      @media (prefers-color-scheme: light) {
+        :root:not([data-theme="dark"]) { color-scheme: light; background: #f4f7fb; }
+      }
+      html, body { margin: 0; min-height: 100%; background: inherit; }
+    </style>
   </head>
   <body>
     <powercalc-measure-app></powercalc-measure-app>

--- a/utils/measure/frontend/src/components/app/shell.test.ts
+++ b/utils/measure/frontend/src/components/app/shell.test.ts
@@ -3,6 +3,13 @@ import { AppShell } from "./shell";
 import type { ResultView } from "../result/view";
 import type { ProfileSubmitView } from "../profile/submit-view";
 import { capabilities, controllerOf, defaultSettings, goodPowerMeterDiagnostic } from "../testing/fixtures";
+import { THEME_STORAGE_KEY } from "../../theme";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  document.documentElement.removeAttribute("data-theme");
+  localStorage.clear();
+});
 
 describe("app shell device entities", () => {
   it("loads device entities only after their measurement type is selected", async () => {
@@ -86,6 +93,29 @@ describe("app shell device entities", () => {
 });
 
 describe("app shell", () => {
+  it("cycles and persists the color theme independently from backend settings", async () => {
+    const element = new AppShell();
+    vi.spyOn(controllerOf(element), "boot").mockResolvedValue();
+    document.body.append(element);
+    await element.updateComplete;
+
+    const themeButton = () => element.shadowRoot!.querySelector<HTMLButtonElement>(".theme-toggle")!;
+    expect(element.dataset.theme).toBe("system");
+    expect(themeButton().getAttribute("aria-label")).toContain("Color theme: System");
+
+    themeButton().click();
+    await element.updateComplete;
+    expect(element.dataset.theme).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+    expect(themeButton().title).toBe("Color theme: Light");
+
+    themeButton().click();
+    await element.updateComplete;
+    expect(element.dataset.theme).toBe("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+
   it("keeps download callbacks stable while using the current session", async () => {
     const element = new AppShell();
     vi.spyOn(controllerOf(element), "boot").mockResolvedValue();

--- a/utils/measure/frontend/src/components/app/shell.ts
+++ b/utils/measure/frontend/src/components/app/shell.ts
@@ -1,5 +1,5 @@
 import { LitElement, css, html, nothing } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import { MeasureApiClient, SessionEventStream } from "../../api-client";
 import { MeasureAppController } from "../../app-controller";
 import type { AppView, MeasureAppState } from "../../app-controller";
@@ -8,7 +8,9 @@ import { reviewMetrics, reviewSummary } from "../preflight/summary";
 import { isAddressed, specFromRequest, specFromSettings } from "../../power-meter/registry";
 import type { MeterContext } from "../../power-meter/registry";
 import type { AppSettings, AppSettingsUpdate, Capabilities, ContributionAuthDeviceStatus, ContributionAuthState, ContributionDeviceFlow, ContributionFormValues, ContributionPreview, ContributionPreviewRequest, ContributionResult, ContributionSubmitRequest, DeviceSpecificationField, DummyLoadCalibration, EntityDescriptor, ErrorHelp, MeasureDefinition, MeasureType, MeasurementRequest, PlotCollection, PowerMeterSpec, PowerMeterDiagnostic, PreflightResponse, SessionFile, SessionSnapshot, SessionSummary, SettingsSection, ShellyDiscoveryDevice } from "../../types";
-import { sharedStyles } from "../../styles";
+import { sharedStyles, themeStyles } from "../../styles";
+import { THEME_CHANGE_EVENT, applyDocumentTheme, nextThemePreference, readThemePreference, saveThemePreference } from "../../theme";
+import type { ThemePreference } from "../../theme";
 import "../preflight/view";
 import "../profile/prepare-view";
 import "../profile/submit-view";
@@ -93,6 +95,13 @@ export class AppShell extends LitElement implements MeasureAppState {
 
   private renderedView?: AppView;
 
+  @state()
+  private themePreference: ThemePreference = readThemePreference();
+
+  private readonly systemColorScheme = typeof matchMedia === "function"
+    ? matchMedia("(prefers-color-scheme: dark)")
+    : undefined;
+
   private readonly api: MeasureApiClient = new MeasureApiClient();
   private readonly controller = new MeasureAppController(
     this,
@@ -101,7 +110,7 @@ export class AppShell extends LitElement implements MeasureAppState {
     () => this.requestUpdate(),
   );
 
-  static readonly styles = [sharedStyles, css`
+  static readonly styles = [themeStyles, sharedStyles, css`
     :host { display: block; min-height: 100vh; background: var(--canvas); }
     .shell { width: min(1320px, calc(100% - 2rem)); margin: 0 auto; padding: clamp(1rem, 3vw, 2rem) 0 4rem; }
     header { margin-bottom: clamp(1.5rem, 4vw, 2.5rem); }
@@ -116,6 +125,7 @@ export class AppShell extends LitElement implements MeasureAppState {
     .subtitle { max-width: 540px; margin: 0.8rem 0 0; color: var(--muted); font-size: 1rem; line-height: 1.6; }
     .topbar-actions { display: flex; align-items: center; gap: 0.55rem; }
     .topbar-action { min-height: 36px; padding: 0.4rem 0.8rem; border-radius: 999px; font: 700 0.72rem/1 ui-monospace, monospace; letter-spacing: 0.08em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.45rem; }
+    .theme-toggle { width: 36px; padding: 0; justify-content: center; font-size: 1rem; letter-spacing: normal; }
     .settings-toggle::before { content: "⚙"; font-size: 0.95rem; }
     .sequence { margin: 0; padding: 0; display: grid; grid-auto-flow: column; grid-auto-columns: minmax(0, 1fr); gap: 0.45rem; list-style: none; }
     .sequence > li { position: relative; display: grid; gap: 0.45rem; min-width: 0; color: var(--muted); font: 700 0.68rem/1.15 ui-monospace, monospace; letter-spacing: 0.08em; text-transform: uppercase; }
@@ -138,8 +148,18 @@ export class AppShell extends LitElement implements MeasureAppState {
     @media (max-width: 460px) { .shell { width: min(100% - 1.25rem, 980px); } .brand .version { display: none; } .topbar-action { padding-inline: 0.65rem; font-size: 0.66rem; } .sequence { gap: 0.3rem; } .sequence > li { font-size: 0.58rem; letter-spacing: 0.04em; } .sequence > li:not(:last-child)::after { left: calc(20px + 0.3rem); width: calc(100% - 40px - 0.3rem); } }
   `];
 
-  connectedCallback(): void { super.connectedCallback(); void this.boot(); }
-  disconnectedCallback(): void { this.controller.dispose(); super.disconnectedCallback(); }
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.applyTheme();
+    this.systemColorScheme?.addEventListener("change", this.systemThemeChanged);
+    void this.boot();
+  }
+
+  disconnectedCallback(): void {
+    this.systemColorScheme?.removeEventListener("change", this.systemThemeChanged);
+    this.controller.dispose();
+    super.disconnectedCallback();
+  }
 
   protected updated(): void {
     const previousView = this.renderedView;
@@ -165,6 +185,10 @@ export class AppShell extends LitElement implements MeasureAppState {
                 : nothing}
             </button>
             <div class="topbar-actions">
+              <button class="topbar-action theme-toggle" type="button" @click=${this.cycleTheme}
+                aria-label=${this.themeButtonLabel()} title=${this.themeButtonTitle()}>
+                <span aria-hidden="true">${themeIcon(this.themePreference)}</span>
+              </button>
               <button class="topbar-action sessions-toggle" type="button" @click=${this.showSessions} ?disabled=${this.view === "loading" || this.view === "sessions"}>All sessions</button>
               <button class="topbar-action settings-toggle" type="button" @click=${this.openSettings} ?disabled=${this.view === "loading" || this.view === "settings"}>Settings</button>
             </div>
@@ -426,6 +450,31 @@ export class AppShell extends LitElement implements MeasureAppState {
     void this.controller.showSessions();
   }
 
+  private readonly cycleTheme = (): void => {
+    this.themePreference = nextThemePreference(this.themePreference);
+    saveThemePreference(this.themePreference);
+    this.applyTheme();
+  };
+
+  private readonly systemThemeChanged = (): void => {
+    if (this.themePreference === "system") this.applyTheme();
+  };
+
+  private applyTheme(): void {
+    this.dataset.theme = this.themePreference;
+    applyDocumentTheme(this.themePreference, this.systemColorScheme?.matches ?? false);
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+  }
+
+  private themeButtonLabel(): string {
+    const next = nextThemePreference(this.themePreference);
+    return `Color theme: ${themeLabel(this.themePreference)}. Switch to ${themeLabel(next).toLowerCase()} theme.`;
+  }
+
+  private themeButtonTitle(): string {
+    return `Color theme: ${themeLabel(this.themePreference)}`;
+  }
+
   /** Settings can be opened bare from the top bar, or aimed at a section by a view that links into it. */
   private openSettings(event?: Event): void {
     const detail = (event as CustomEvent | undefined)?.detail;
@@ -473,4 +522,14 @@ function stepClass(index: number, current: number): string {
   if (index === current) return "active";
   if (index < current) return "done";
   return "";
+}
+
+function themeLabel(preference: ThemePreference): string {
+  return preference[0]!.toUpperCase() + preference.slice(1);
+}
+
+function themeIcon(preference: ThemePreference): string {
+  if (preference === "light") return "☀";
+  if (preference === "dark") return "☾";
+  return "◐";
 }

--- a/utils/measure/frontend/src/components/result/plot.test.ts
+++ b/utils/measure/frontend/src/components/result/plot.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ResultPlot } from "./plot";
 import type { PlotSpec } from "../../types";
+import { THEME_CHANGE_EVENT } from "../../theme";
 
 const plot: PlotSpec = {
   id: "brightness", title: "Brightness", kind: "scatter", source: "brightness.csv",
@@ -52,6 +53,16 @@ describe("result plot lifecycle", () => {
     await element.updateComplete;
     expect(canvas.getContext).toHaveBeenCalledTimes(3);
     expect(canvas.getAttribute("aria-label")).toBe("Updated brightness: Power (W) by Brightness");
+  });
+
+  it("redraws for theme changes only while connected", async () => {
+    const element = await mount();
+    const canvas = element.shadowRoot!.querySelector("canvas")!;
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+    expect(canvas.getContext).toHaveBeenCalledTimes(2);
+    element.remove();
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+    expect(canvas.getContext).toHaveBeenCalledTimes(2);
   });
 
   it("disconnects the observer and resumes drawing after reattachment", async () => {

--- a/utils/measure/frontend/src/components/result/plot.ts
+++ b/utils/measure/frontend/src/components/result/plot.ts
@@ -2,6 +2,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import type { PlotSpec } from "../../types";
 import { sharedStyles } from "../../styles";
+import { THEME_CHANGE_EVENT } from "../../theme";
 
 interface PlotPalette {
   background: string;
@@ -38,6 +39,7 @@ export class ResultPlot extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+    window.addEventListener(THEME_CHANGE_EVENT, this.themeChanged);
     if (this.hasUpdated) {
       this.observeCanvas();
       this.draw();
@@ -53,6 +55,7 @@ export class ResultPlot extends LitElement {
   }
 
   disconnectedCallback(): void {
+    window.removeEventListener(THEME_CHANGE_EVENT, this.themeChanged);
     this.resizeObserver?.disconnect();
     this.resizeObserver = undefined;
     super.disconnectedCallback();
@@ -63,6 +66,8 @@ export class ResultPlot extends LitElement {
     this.resizeObserver = new ResizeObserver(() => this.draw());
     this.resizeObserver.observe(this.canvas);
   }
+
+  private readonly themeChanged = (): void => this.draw();
 
   render() {
     return html`

--- a/utils/measure/frontend/src/components/sessions/view.test.ts
+++ b/utils/measure/frontend/src/components/sessions/view.test.ts
@@ -32,6 +32,8 @@ describe("sessions view", () => {
 
     const labels = [...element.shadowRoot.querySelectorAll("button")].map((button) => button.textContent?.trim());
     expect(labels).toEqual(expect.arrayContaining(["New measurement", "Open", "Resume", "Measure again", "Delete"]));
+    expect([...element.shadowRoot.querySelectorAll(".primary-actions button")].map((button) => button.textContent?.trim())).toEqual(["Open", "Resume", "Measure again"]);
+    expect([...element.shadowRoot.querySelectorAll(".secondary-actions :is(a, button)")].map((action) => action.textContent?.trim())).toEqual(["Diagnostics", "Delete"]);
     const measureAgain = [...element.shadowRoot.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Measure again");
     const tooltip = element.shadowRoot.querySelector<HTMLElement>('[role="tooltip"]');
     expect(tooltip?.textContent).toBe("Start a new measurement using these settings");

--- a/utils/measure/frontend/src/components/sessions/view.ts
+++ b/utils/measure/frontend/src/components/sessions/view.ts
@@ -11,23 +11,117 @@ export class SessionsView extends LitElement {
     .heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
     .heading h2 { margin: 0.15rem 0 0.35rem; }
     .heading button, .empty button { display: inline-flex; align-items: center; justify-content: center; gap: 0.45rem; }
-    .sessions { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 360px), 1fr)); gap: 0.8rem; align-items: stretch; }
-    article { display: flex; flex-direction: column; min-width: 0; padding: 0.9rem; border: 1px solid var(--line); border-radius: 12px; background: var(--well); }
-    article.active { border-color: var(--signal); box-shadow: inset 3px 0 0 var(--signal); }
+    .sessions {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.9rem;
+      align-items: stretch;
+    }
+    article {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      padding: 1rem;
+      border: 1px solid var(--line);
+      border-radius: 13px;
+      background: color-mix(in srgb, var(--surface-raised) 62%, var(--surface));
+      box-shadow: 0 5px 16px color-mix(in srgb, var(--ink) 8%, transparent);
+    }
+    article.active { border-color: var(--signal); box-shadow: inset 3px 0 0 var(--signal), 0 5px 16px color-mix(in srgb, var(--ink) 8%, transparent); }
     .session-head { display: flex; justify-content: space-between; gap: 1rem; align-items: flex-start; }
-    h3 { margin: 0; font-size: 1rem; overflow-wrap: anywhere; }
-    .state { display: inline-flex; padding: 0.3rem 0.55rem; border-radius: 999px; background: var(--surface-raised); color: var(--muted); font: 700 0.68rem/1 ui-monospace, monospace; text-transform: uppercase; }
-    .state.running, .state.awaiting_confirmation { color: var(--signal-strong); }
-    .state.completed { color: var(--good); }
-    .state.failed { color: var(--danger); }
-    dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.65rem 0.8rem; margin: 0.85rem 0; }
-    dt { color: var(--muted); font-size: 0.7rem; font-weight: 700; text-transform: uppercase; }
+    h3 { margin: 0 0 0.1rem; font-size: 1.02rem; overflow-wrap: anywhere; }
+    .state {
+      display: inline-flex;
+      flex: none;
+      padding: 0.32rem 0.58rem;
+      border: 1px solid color-mix(in srgb, var(--muted) 22%, transparent);
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--muted) 8%, transparent);
+      color: var(--muted);
+      font: 700 0.67rem/1 ui-monospace, monospace;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .state.running, .state.awaiting_confirmation {
+      border-color: color-mix(in srgb, var(--signal) 28%, transparent);
+      background: color-mix(in srgb, var(--signal) 10%, transparent);
+      color: var(--signal-strong);
+    }
+    .state.completed {
+      border-color: color-mix(in srgb, var(--good) 28%, transparent);
+      background: color-mix(in srgb, var(--good) 9%, transparent);
+      color: var(--good);
+    }
+    .state.failed {
+      border-color: color-mix(in srgb, var(--danger) 28%, transparent);
+      background: color-mix(in srgb, var(--danger) 9%, transparent);
+      color: var(--danger);
+    }
+    dl {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0.85rem 0 0.8rem;
+      padding-top: 0.8rem;
+      border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+    }
+    dt { color: var(--muted); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.025em; text-transform: uppercase; }
     dd { margin: 0.15rem 0 0; font-size: 0.88rem; overflow-wrap: anywhere; }
-    progress { width: 100%; height: 6px; margin-top: auto; accent-color: var(--signal); }
-    .actions { justify-content: flex-start; gap: 0.4rem; margin-top: 0.75rem; }
-    .actions button, .actions .action-button { display: inline-flex; align-items: center; justify-content: center; gap: 0.35rem; min-height: 34px; padding: 0.4rem 0.65rem; font-size: 0.78rem; }
-    .actions .action-button { border: 1px solid var(--line); border-radius: 10px; color: var(--ink); background: var(--surface-raised); font-weight: 650; text-decoration: none; transition: transform 150ms ease, border-color 150ms ease, background 150ms ease; }
-    .actions .action-button:hover { border-color: var(--signal); transform: translateY(-1px); }
+    progress { width: 100%; height: 6px; accent-color: var(--signal); }
+    .actions {
+      display: grid;
+      gap: 0.4rem;
+      justify-content: stretch;
+      margin-top: auto;
+      padding-top: 0.85rem;
+      border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+    }
+    progress + .actions { border-top: 0; }
+    .primary-actions { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.4rem; }
+    .primary-actions > button, .primary-actions > .tooltip-trigger { min-width: 0; }
+    .secondary-actions { display: flex; flex-wrap: wrap; gap: 0.15rem; }
+    .actions button, .actions .action-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.35rem;
+      min-height: 36px;
+      padding: 0.42rem 0.68rem;
+      font-size: 0.78rem;
+    }
+    .primary-actions button, .primary-actions .tooltip-trigger button {
+      width: 100%;
+      padding-inline: 0.45rem;
+      background: var(--surface);
+      font-size: 0.72rem;
+      white-space: nowrap;
+    }
+    .open-action {
+      border-color: color-mix(in srgb, var(--signal) 40%, var(--line));
+      background: color-mix(in srgb, var(--signal) 9%, var(--surface));
+    }
+    .actions .action-button {
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      color: var(--ink);
+      background: var(--surface);
+      font-weight: 650;
+      text-decoration: none;
+      transition: transform 150ms ease, border-color 150ms ease, background 150ms ease;
+    }
+    .secondary-actions button, .secondary-actions .action-button {
+      min-height: 34px;
+      padding: 0.32rem 0.5rem;
+      border-color: transparent;
+      background: transparent;
+      color: var(--muted);
+    }
+    .secondary-actions button:hover:not(:disabled), .secondary-actions .action-button:hover {
+      border-color: var(--line);
+      background: var(--surface-raised);
+      transform: none;
+    }
+    .secondary-actions .danger { color: var(--danger); }
     .tooltip-trigger { position: relative; display: inline-flex; }
     .tooltip-content {
       position: absolute;
@@ -74,8 +168,12 @@ export class SessionsView extends LitElement {
     .icon { width: 1rem; height: 1rem; flex: none; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
     .danger { color: var(--danger); }
     .empty { padding: 2rem; text-align: center; border: 1px dashed var(--line); border-radius: 12px; color: var(--muted); }
+    @media (max-width: 900px) { .sessions { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
     @media (max-width: 720px) { .heading { flex-direction: column; } }
-    @media (max-width: 640px) { .actions .action-button, .actions .tooltip-trigger { width: 100%; } }
+    @media (max-width: 620px) { .sessions { grid-template-columns: 1fr; } }
+    @media (max-width: 420px) {
+      .primary-actions { grid-template-columns: 1fr; }
+    }
   `];
 
   @property({ attribute: false })
@@ -125,17 +223,21 @@ export class SessionsView extends LitElement {
       </dl>
       ${session.total ? html`<progress max=${session.total} value=${session.completed}>${session.percent}%</progress>` : nothing}
       <div class="actions">
-        <button type="button" ?disabled=${this.busy} @click=${() => this.emit("open", session.session_id)}>${this.icon(session.active ? "monitor" : "open")}<span>${session.active ? "Monitor" : "Open"}</span></button>
-        ${session.can_resume ? html`<button type="button" ?disabled=${this.busy || this.sessions.some((item) => item.active)} @click=${() => this.emit("resume", session.session_id)}>${this.icon("resume")}<span>Resume</span></button>` : nothing}
-        <span class="tooltip-trigger">
-          <button type="button" aria-describedby=${measureAgainTooltipId} ?disabled=${this.busy} @click=${() => this.emit("duplicate", session.session_id)}>${this.icon("duplicate")}<span>Measure again</span></button>
-          <span class="tooltip-content" id=${measureAgainTooltipId} role="tooltip">Start a new measurement using these settings</span>
-        </span>
-        <a class="action-button" href=${this.diagnosticsUrl(session.session_id)} download>${this.icon("diagnostics")}<span>Diagnostics</span></a>
-        ${this.pendingDelete === session.session_id ? html`
-          <button class="danger" type="button" ?disabled=${this.busy} @click=${() => this.confirmDelete(session.session_id)}>${this.icon("delete")}<span>Confirm delete</span></button>
-          <button type="button" @click=${() => { this.pendingDelete = undefined; }}>${this.icon("keep")}<span>Keep</span></button>
-        ` : html`<button class="danger" type="button" ?disabled=${this.busy || session.active} @click=${() => { this.pendingDelete = session.session_id; }}>${this.icon("delete")}<span>Delete</span></button>`}
+        <div class="primary-actions">
+          <button class="open-action" type="button" ?disabled=${this.busy} @click=${() => this.emit("open", session.session_id)}>${this.icon(session.active ? "monitor" : "open")}<span>${session.active ? "Monitor" : "Open"}</span></button>
+          ${session.can_resume ? html`<button type="button" ?disabled=${this.busy || this.sessions.some((item) => item.active)} @click=${() => this.emit("resume", session.session_id)}>${this.icon("resume")}<span>Resume</span></button>` : nothing}
+          <span class="tooltip-trigger">
+            <button type="button" aria-describedby=${measureAgainTooltipId} ?disabled=${this.busy} @click=${() => this.emit("duplicate", session.session_id)}>${this.icon("duplicate")}<span>Measure again</span></button>
+            <span class="tooltip-content" id=${measureAgainTooltipId} role="tooltip">Start a new measurement using these settings</span>
+          </span>
+        </div>
+        <div class="secondary-actions">
+          <a class="action-button" href=${this.diagnosticsUrl(session.session_id)} download>${this.icon("diagnostics")}<span>Diagnostics</span></a>
+          ${this.pendingDelete === session.session_id ? html`
+            <button class="danger" type="button" ?disabled=${this.busy} @click=${() => this.confirmDelete(session.session_id)}>${this.icon("delete")}<span>Confirm delete</span></button>
+            <button type="button" @click=${() => { this.pendingDelete = undefined; }}>${this.icon("keep")}<span>Keep</span></button>
+          ` : html`<button class="danger" type="button" ?disabled=${this.busy || session.active} @click=${() => { this.pendingDelete = session.session_id; }}>${this.icon("delete")}<span>Delete</span></button>`}
+        </div>
       </div>
     </article>`;
   }

--- a/utils/measure/frontend/src/components/shared/styles.test.ts
+++ b/utils/measure/frontend/src/components/shared/styles.test.ts
@@ -1,5 +1,7 @@
-import { sharedStyles } from "../../styles";
+import { sharedStyles, themeStyles } from "../../styles";
 
-it("uses dark native form controls so iOS select indicators remain visible", () => {
-  expect(sharedStyles.cssText).toContain("color-scheme: dark");
+it("inherits the selected native control color scheme through shadow roots", () => {
+  expect(sharedStyles.cssText).toContain("color-scheme: var(--measure-color-scheme, dark)");
+  expect(themeStyles.cssText).toContain(':host([data-theme="light"])');
+  expect(themeStyles.cssText).toContain("@media (prefers-color-scheme: light)");
 });

--- a/utils/measure/frontend/src/styles.ts
+++ b/utils/measure/frontend/src/styles.ts
@@ -1,26 +1,94 @@
 import { css, html } from "lit";
 
+/** Theme tokens live on the app shell and inherit through every nested shadow root. */
+export const themeStyles = css`
+  :host {
+    --measure-ink: #eef2f7;
+    --measure-muted: #93a1b5;
+    --measure-canvas: #0d1119;
+    --measure-surface: #151b24;
+    --measure-surface-raised: #1e2632;
+    --measure-well: #0a0e15;
+    --measure-field: #111925;
+    --measure-line: #2c3644;
+    --measure-track: #2a3444;
+    --measure-grid: #55647a;
+    --measure-signal: #5488e8;
+    --measure-signal-deep: #3f74d6;
+    --measure-signal-strong: #93b5f4;
+    --measure-on-signal: #ffffff;
+    --measure-good: #61d4a3;
+    --measure-warning: #f2b84b;
+    --measure-danger: #ff7b72;
+    --measure-color-scheme: dark;
+  }
+
+  :host([data-theme="light"]) {
+    --measure-ink: #1b2634;
+    --measure-muted: #586779;
+    --measure-canvas: #f4f7fb;
+    --measure-surface: #ffffff;
+    --measure-surface-raised: #edf2f7;
+    --measure-well: #e8eef5;
+    --measure-field: #f8fafc;
+    --measure-line: #c5cfda;
+    --measure-track: #d6dee8;
+    --measure-grid: #9aa8b8;
+    --measure-signal: #326bc4;
+    --measure-signal-deep: #2459a6;
+    --measure-signal-strong: #174b91;
+    --measure-on-signal: #ffffff;
+    --measure-good: #147455;
+    --measure-warning: #8a5b00;
+    --measure-danger: #bc332d;
+    --measure-color-scheme: light;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :host([data-theme="system"]) {
+      --measure-ink: #1b2634;
+      --measure-muted: #586779;
+      --measure-canvas: #f4f7fb;
+      --measure-surface: #ffffff;
+      --measure-surface-raised: #edf2f7;
+      --measure-well: #e8eef5;
+      --measure-field: #f8fafc;
+      --measure-line: #c5cfda;
+      --measure-track: #d6dee8;
+      --measure-grid: #9aa8b8;
+      --measure-signal: #326bc4;
+      --measure-signal-deep: #2459a6;
+      --measure-signal-strong: #174b91;
+      --measure-on-signal: #ffffff;
+      --measure-good: #147455;
+      --measure-warning: #8a5b00;
+      --measure-danger: #bc332d;
+      --measure-color-scheme: light;
+    }
+  }
+`;
+
 export const sharedStyles = css`
   :host {
-    --ink: #eef2f7;
-    --muted: #93a1b5;
-    --canvas: #0d1119;
-    --surface: #151b24;
-    --surface-raised: #1e2632;
-    --well: #0a0e15;
-    --field: #111925;
-    --line: #2c3644;
-    --track: #2a3444;
-    --grid: #55647a;
-    --signal: #5488e8;
-    --signal-deep: #3f74d6;
-    --signal-strong: #93b5f4;
-    --on-signal: #ffffff;
-    --good: #61d4a3;
-    --warning: #f2b84b;
-    --danger: #ff7b72;
+    --ink: var(--measure-ink, #eef2f7);
+    --muted: var(--measure-muted, #93a1b5);
+    --canvas: var(--measure-canvas, #0d1119);
+    --surface: var(--measure-surface, #151b24);
+    --surface-raised: var(--measure-surface-raised, #1e2632);
+    --well: var(--measure-well, #0a0e15);
+    --field: var(--measure-field, #111925);
+    --line: var(--measure-line, #2c3644);
+    --track: var(--measure-track, #2a3444);
+    --grid: var(--measure-grid, #55647a);
+    --signal: var(--measure-signal, #5488e8);
+    --signal-deep: var(--measure-signal-deep, #3f74d6);
+    --signal-strong: var(--measure-signal-strong, #93b5f4);
+    --on-signal: var(--measure-on-signal, #ffffff);
+    --good: var(--measure-good, #61d4a3);
+    --warning: var(--measure-warning, #f2b84b);
+    --danger: var(--measure-danger, #ff7b72);
     --radius: 14px;
-    color-scheme: dark;
+    color-scheme: var(--measure-color-scheme, dark);
     color: var(--ink);
     font-family: "Avenir Next", "Segoe UI", sans-serif;
   }

--- a/utils/measure/frontend/src/theme.test.ts
+++ b/utils/measure/frontend/src/theme.test.ts
@@ -1,0 +1,48 @@
+import {
+  THEME_STORAGE_KEY,
+  applyDocumentTheme,
+  nextThemePreference,
+  readThemePreference,
+  resolvedTheme,
+  saveThemePreference,
+} from "./theme";
+
+afterEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+  document.querySelector('meta[data-theme-test]')?.remove();
+});
+
+describe("theme preference", () => {
+  it("reads only supported stored preferences", () => {
+    expect(readThemePreference({ getItem: () => "light" })).toBe("light");
+    expect(readThemePreference({ getItem: () => "sepia" })).toBe("system");
+    expect(readThemePreference({ getItem: () => { throw new Error("blocked"); } })).toBe("system");
+  });
+
+  it("cycles through system, light and dark", () => {
+    expect(nextThemePreference("system")).toBe("light");
+    expect(nextThemePreference("light")).toBe("dark");
+    expect(nextThemePreference("dark")).toBe("system");
+  });
+
+  it("resolves system preferences and applies document chrome colors", () => {
+    const themeColor = document.createElement("meta");
+    themeColor.name = "theme-color";
+    themeColor.content = "#000000";
+    themeColor.dataset.themeTest = "";
+    document.head.append(themeColor);
+    applyDocumentTheme("system", false);
+    expect(document.documentElement.dataset.theme).toBe("system");
+    expect(themeColor.content).toBe("#f4f7fb");
+    expect(resolvedTheme("system", true)).toBe("dark");
+    applyDocumentTheme("dark", false);
+    expect(themeColor.content).toBe("#0d1119");
+  });
+
+  it("persists the selected preference without requiring writable storage", () => {
+    const setItem = vi.fn();
+    saveThemePreference("dark", { setItem });
+    expect(setItem).toHaveBeenCalledWith(THEME_STORAGE_KEY, "dark");
+    expect(() => saveThemePreference("light", { setItem: () => { throw new Error("blocked"); } })).not.toThrow();
+  });
+});

--- a/utils/measure/frontend/src/theme.ts
+++ b/utils/measure/frontend/src/theme.ts
@@ -1,0 +1,46 @@
+export const THEME_STORAGE_KEY = "powercalc-measure-theme";
+export const THEME_CHANGE_EVENT = "measure-theme-change";
+
+export type ThemePreference = "system" | "light" | "dark";
+
+const THEMES: readonly ThemePreference[] = ["system", "light", "dark"];
+
+export function readThemePreference(storage: Pick<Storage, "getItem"> = localStorage): ThemePreference {
+  try {
+    const value = storage.getItem(THEME_STORAGE_KEY);
+    return isThemePreference(value) ? value : "system";
+  } catch {
+    return "system";
+  }
+}
+
+export function saveThemePreference(
+  preference: ThemePreference,
+  storage: Pick<Storage, "setItem"> = localStorage,
+): void {
+  try {
+    storage.setItem(THEME_STORAGE_KEY, preference);
+  } catch {
+    // A blocked storage area should not prevent an in-memory theme change.
+  }
+}
+
+export function nextThemePreference(preference: ThemePreference): ThemePreference {
+  return THEMES[(THEMES.indexOf(preference) + 1) % THEMES.length]!;
+}
+
+export function resolvedTheme(preference: ThemePreference, systemPrefersDark: boolean): "light" | "dark" {
+  return preference === "system" ? (systemPrefersDark ? "dark" : "light") : preference;
+}
+
+export function applyDocumentTheme(preference: ThemePreference, systemPrefersDark: boolean): void {
+  document.documentElement.dataset.theme = preference;
+  const themeColor = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (themeColor) {
+    themeColor.content = resolvedTheme(preference, systemPrefersDark) === "dark" ? "#0d1119" : "#f4f7fb";
+  }
+}
+
+function isThemePreference(value: string | null): value is ThemePreference {
+  return value === "system" || value === "light" || value === "dark";
+}


### PR DESCRIPTION
## Summary

- add System, Light, and Dark appearance modes with persisted preference and live system-theme updates
- apply theme tokens consistently across Lit shadow roots and redraw result plots when the theme changes
- refine measurement session cards with a responsive three-column layout, clearer card surfaces, semantic status badges, consistent three-slot primary actions, and improved metadata spacing
- add focused unit and browser coverage for theme behavior, responsive layouts, action overflow, and light/dark card contrast

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test` (32 files, 277 tests passed)
- `npm run build`
- `npm run test:e2e` (24 tests passed)
- `git diff --check`

All frontend commands were run from `utils/measure/frontend`.