### PR TITLE
Preserve progress across resumed measurements

### DIFF
--- a/utils/measure/measure/ha_app/coordinator.py
+++ b/utils/measure/measure/ha_app/coordinator.py
@@ -435,9 +435,7 @@ class MeasurementCoordinator:
     def _append_warning(warnings: tuple[str, ...], warning: str) -> tuple[str, ...]:
         """Append a new user-facing warning while preserving distinct prior warnings."""
 
-        if warning in warnings:
-            return warnings
-        return (*warnings[-19:], warning)
+        return tuple(dict.fromkeys((*warnings, warning)))[-20:]
 
     def _notify_checkpoint(self, event: SessionEvent) -> None:
         """Publish the state transition caused by an operator checkpoint."""

--- a/utils/measure/measure/ha_app/coordinator.py
+++ b/utils/measure/measure/ha_app/coordinator.py
@@ -398,7 +398,10 @@ class MeasurementCoordinator:
                     self._snapshot,
                     event_sequence=event.sequence,
                     updated_at=event.created_at,
-                    warnings=(*self._snapshot.warnings[-19:], str(event.data["message"])),
+                    warnings=self._append_warning(
+                        self._snapshot.warnings,
+                        str(event.data["message"]),
+                    ),
                 )
             elif event.type == SessionEventType.CHECKPOINT:
                 self._snapshot = replace(
@@ -427,6 +430,14 @@ class MeasurementCoordinator:
                 self.storage.write_snapshot(self._snapshot)
                 self._last_snapshot_write = time.monotonic()
         self._notify_checkpoint(event)
+
+    @staticmethod
+    def _append_warning(warnings: tuple[str, ...], warning: str) -> tuple[str, ...]:
+        """Append a new user-facing warning while preserving distinct prior warnings."""
+
+        if warning in warnings:
+            return warnings
+        return (*warnings[-19:], warning)
 
     def _notify_checkpoint(self, event: SessionEvent) -> None:
         """Publish the state transition caused by an operator checkpoint."""

--- a/utils/measure/measure/runner/light.py
+++ b/utils/measure/measure/runner/light.py
@@ -121,11 +121,9 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
             effects=list(self.plan.effects),
         )
 
-        all_variations: list[Variation] = []
-        for measurement in measurements_to_run:
-            all_variations.extend(measurement.variations)
+        all_variations = self.plan.variations
         _LOGGER.info("Total number of variations: %d", len(all_variations))
-        remaining_variations = all_variations.copy()
+        remaining_variations = self.active_plan.variations.copy()
         voltages: list[float] = []
 
         for measurement_info in measurements_to_run:
@@ -185,7 +183,7 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
 
         _LOGGER.info(
             "Starting measurements. Estimated duration: %s",
-            self.calculate_time_left(mode, all_variations, remaining_variations),
+            self.calculate_time_left(mode, remaining_variations),
         )
 
         with open(measurement_info.csv_file, file_write_mode, newline="") as csv_file:
@@ -273,7 +271,7 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
         if count % 10 != 0:
             return
 
-        time_left = self.calculate_time_left(mode, all_variations, remaining_variations, variation)
+        time_left = self.calculate_time_left(mode, remaining_variations, variation)
         progress_percentage = ((len(all_variations) - len(remaining_variations)) / len(all_variations)) * 100
         _LOGGER.info("Progress: %d%%, Estimated time left: %s", progress_percentage, time_left)
 
@@ -291,7 +289,6 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
             phase=mode.value,
             remaining_seconds=self.calculate_time_left_seconds(
                 mode,
-                all_variations,
                 remaining_variations,
                 current_variation,
             ),
@@ -363,7 +360,6 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
     def calculate_time_left(
         self,
         current_mode: LutMode,
-        all_variations: list[Variation],
         remaining_variations: list[Variation],
         current_variation: Variation | None = None,
     ) -> str:
@@ -371,7 +367,6 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
         return self.format_time_left(
             self.calculate_time_left_seconds(
                 current_mode,
-                all_variations,
                 remaining_variations,
                 current_variation,
             ),
@@ -380,13 +375,11 @@ class LightRunner(MeasurementRunner[LightMeasurementRequest]):
     def calculate_time_left_seconds(
         self,
         current_mode: LutMode,
-        all_variations: list[Variation],
         remaining_variations: list[Variation],
         current_variation: Variation | None = None,
     ) -> float:
         """Return the shared remaining-time estimate for progress consumers."""
         assert self.active_plan is not None
-        assert all_variations == self.active_plan.variations
         return estimate_light_time_left(
             self.active_plan,
             self.config,

--- a/utils/measure/tests/runner/test_light.py
+++ b/utils/measure/tests/runner/test_light.py
@@ -162,6 +162,51 @@ def test_run(export_path: str) -> None:
     assert points[-1] == {"type": "light", "on": True, "brightness": 255}
 
 
+@pytest.mark.parametrize("completed_brightnesses", [[1], [1, 128]])
+def test_resume_reports_progress_against_the_full_plan(
+    tmp_path: Path,
+    completed_brightnesses: list[int],
+) -> None:
+    parameters = replace(_zero_sleep_parameters(), bri_bri_steps=127)
+    measure_util = MagicMock(MeasureUtil)
+    measure_util.take_measurement.return_value = MeasurementResult(power=1, voltages=[])
+    interaction = MagicMock(spec=RunInteraction)
+    runner = LightRunner(
+        measure_util,
+        parameters,
+        DummyLightController(),
+        interaction,
+        resume=True,
+    )
+    request = LightMeasurementRequest(
+        model_id="measurement",
+        product_name="Measurement",
+        measure_device="Test meter",
+        power_meter=DummyPowerMeterSpec(),
+        controller=DummyLightControllerSpec(),
+        modes={LutMode.BRIGHTNESS},
+        parameters=parameters,
+        gzip=False,
+    )
+    csv_path = tmp_path / "brightness.csv"
+    with csv_path.open("w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["bri", "watt"])
+        writer.writerows([brightness, 1.0] for brightness in completed_brightnesses)
+
+    runner.run(request, str(tmp_path))
+
+    initial_progress = interaction.progress.call_args_list[0].kwargs
+    assert initial_progress["completed"] == len(completed_brightnesses)
+    assert initial_progress["total"] == 3
+    final_progress = interaction.progress.call_args_list[-1].kwargs
+    assert final_progress["completed"] == 3
+    assert final_progress["total"] == 3
+    with csv_path.open(newline="") as csv_file:
+        rows = list(csv.reader(csv_file))
+    assert [int(row[0]) for row in rows[1:]] == [1, 128, 255]
+
+
 def test_initial_wait_happens_after_selecting_first_measurement_point(tmp_path: Path) -> None:
     events: list[tuple[str, object]] = []
     variation = Variation(1)

--- a/utils/measure/tests/test_coordinator.py
+++ b/utils/measure/tests/test_coordinator.py
@@ -12,7 +12,7 @@ from measure.ha_app.coordinator import (
     SessionMeasurementService,
 )
 from measure.ha_app.interaction import SessionInteraction
-from measure.ha_app.session import SessionControl, SessionSnapshot, SessionState
+from measure.ha_app.session import SessionControl, SessionEventType, SessionSnapshot, SessionState
 from measure.ha_app.storage import SessionStorage
 from measure.powermeter.powermeter import PowerMeasurementResult, PowerMeter
 from measure.powermeter.spec import DummyPowerMeterSpec
@@ -113,6 +113,17 @@ class SamplingService(SessionMeasurementService):
         context: SessionExecutionContext,
     ) -> RunnerResult:
         control.sample(4.2)
+        return RunnerResult(model_json_data={})
+
+
+class WarningService(SessionMeasurementService):
+    def run(
+        self,
+        request: MeasurementRequest,
+        control: SessionControl,
+        context: SessionExecutionContext,
+    ) -> RunnerResult:
+        control.log("Repeated warning", warning=True)
         return RunnerResult(model_json_data={})
 
 
@@ -421,6 +432,31 @@ def test_coordinator_resumes_a_retained_historical_session(tmp_path: Path) -> No
     assert "old-session" in (tmp_path / "current.json").read_text(encoding="utf-8")
     coordinator.cancel(old.id)
     wait_for_state(coordinator, SessionState.CANCELLED)
+
+
+def test_coordinator_deduplicates_warnings_when_resuming(tmp_path: Path) -> None:
+    storage = SessionStorage(tmp_path)
+    snapshot = SessionSnapshot(
+        id="resumable-session",
+        state=SessionState.CANCELLED,
+        created_at="2026-07-12T12:00:00Z",
+        updated_at="2026-07-12T12:05:00Z",
+        warnings=("Repeated warning",),
+    )
+    storage.create(snapshot, light_request())
+    output = storage.artifact_directory(snapshot.id, "LCT010")
+    output.mkdir()
+    (output / "brightness.csv").write_text("bri,watt\n1,1.0\n", encoding="utf-8")
+    coordinator = MeasurementCoordinator(storage, WarningService)
+
+    coordinator.resume(snapshot.id)
+    wait_for_state(coordinator, SessionState.COMPLETED)
+
+    assert coordinator.get(snapshot.id).warnings == ("Repeated warning",)
+    warning_events = [
+        event for event in coordinator.events_since(0, snapshot.id) if event.type == SessionEventType.WARNING
+    ]
+    assert [event.data["message"] for event in warning_events] == ["Repeated warning"]
 
 
 def test_coordinator_deletes_only_terminal_sessions(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_coordinator.py
+++ b/utils/measure/tests/test_coordinator.py
@@ -441,7 +441,7 @@ def test_coordinator_deduplicates_warnings_when_resuming(tmp_path: Path) -> None
         state=SessionState.CANCELLED,
         created_at="2026-07-12T12:00:00Z",
         updated_at="2026-07-12T12:05:00Z",
-        warnings=("Repeated warning",),
+        warnings=("Repeated warning", "Repeated warning", "Repeated warning"),
     )
     storage.create(snapshot, light_request())
     output = storage.artifact_directory(snapshot.id, "LCT010")


### PR DESCRIPTION
## Summary

- report resumed light measurement progress against the full original plan while executing only unfinished points
- keep remaining-time estimates based on the unfinished work
- deduplicate repeated user-facing warnings across resumes while preserving warning events for diagnostics
- add regression coverage for one and multiple resume boundaries, retained CSV rows, and warning projection

## Verification

- `uv run --locked --extra dev --extra app --extra cli ruff check measure tests prepare_app_release.py`
- `MYPYPATH=. uv run --locked --extra dev --extra app --extra cli mypy --strict --explicit-package-bases --follow-imports=silent --ignore-missing-imports --config-file ../../pyproject.toml prepare_app_release.py measure`
- `uv run --locked --extra dev --extra app --extra cli pytest -qq --durations=10 -o console_output_style=count -p no:sugar tests` (750 passed)
- commit hooks (passed)