### PR TITLE
Improve measurement setup, recovery, and profile preparation

### DIFF
--- a/utils/measure/README.md
+++ b/utils/measure/README.md
@@ -37,10 +37,12 @@ label and prefills known device details in Prepare. For measurements without a
 controlled entity, you can supply an optional session name.
 
 CLI profile measurements without a `MODEL_ID` use a unique `export/session-<id>`
-directory, printed when the run finishes. Existing `MODEL_ID` and `MODEL_NAME`
+directory, printed before the run starts and when it finishes. Existing `MODEL_ID` and `MODEL_NAME`
 environment settings remain supported; a supplied ID keeps `export/<model-id>`
 as the output directory. To resume a CLI measurement, set `MODEL_ID` to its export
-directory name.
+directory name. Interrupted light measurements print a command to return to the
+same directory; use the same device and settings and accept the resume prompt.
+Successful profile measurements print the next `powercalc-profile prepare` command.
 
 Prepare validates the metadata and creates a profile-library-shaped package in
 `<artifact-directory>/prepared` without changing the raw artifacts. Use the

--- a/utils/measure/frontend/e2e/happy-flow.spec.ts
+++ b/utils/measure/frontend/e2e/happy-flow.spec.ts
@@ -21,6 +21,56 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
 });
 
+test("preserves unfinished setup through settings and resets it for a new measurement", async ({ page }) => {
+  await startAverageSetup(page);
+  const duration = page.getByRole("spinbutton", { name: "Duration (seconds)", exact: true });
+  const sessionName = page.locator('input[name="session_name"]');
+  await duration.fill("300");
+  await sessionName.fill("Living room standby");
+  await page.getByRole("button", { name: "Change power meter" }).click();
+  await page.getByRole("button", { name: "Back", exact: true }).click();
+  await expect(duration).toHaveValue("300");
+  await expect(sessionName).toHaveValue("Living room standby");
+  await duration.fill("");
+  await page.getByRole("button", { name: /Settings/ }).click();
+  await page.getByRole("button", { name: "Back", exact: true }).click();
+  await expect(duration).toHaveValue("");
+  await page.getByRole("button", { name: "All sessions", exact: true }).click();
+  await startAverageSetup(page);
+  await expect(duration).toHaveValue("60");
+  await expect(sessionName).toHaveValue("");
+});
+
+test("keeps keyboard focus in the JSON inspector and restores its trigger on Escape", async ({ page }) => {
+  await page.getByRole("button", { name: "Open", exact: true }).click();
+  const trigger = page.getByRole("button", { name: "View model.json", exact: true });
+  await trigger.click();
+  const dialog = page.getByRole("dialog", { name: "model.json" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Close" })).toBeFocused();
+  for (let index = 0; index < 4; index++) {
+    await page.keyboard.press("Tab");
+    await expect(page.getByRole("button", { name: "Prepare profile", exact: true })).not.toBeFocused();
+  }
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});
+
+test("keeps profile validation visible on mobile with optional fields collapsed", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole("button", { name: "Open", exact: true }).click();
+  await page.getByRole("button", { name: "Prepare profile" }).click();
+  const validate = page.getByRole("button", { name: "Validate profile", exact: true });
+  await expect(validate).toBeInViewport();
+  await expect(page.getByRole("textbox", { name: "Notes", exact: true })).toBeHidden();
+  await expect(page.getByRole("spinbutton", { name: "Rated power (W)", exact: true })).toBeHidden();
+  await page.getByText("Device specifications (optional)", { exact: true }).click();
+  await expect(page.getByRole("spinbutton", { name: "Rated power (W)", exact: true })).toBeVisible();
+  await expect(validate).toBeInViewport();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390);
+});
+
 test("boots and lists the stored measurement sessions", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Your measurements" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Hue White Ambiance A60" })).toBeVisible();
@@ -386,6 +436,7 @@ test("preserves unfinished profile fields, list rows and tags when navigating ba
   await aliasInputs.first().fill("Alias one ");
   await aliases.getByRole("button", { name: "Add another alias" }).click();
   await meter.fill("Custom meter");
+  await page.getByText("Device specifications (optional)", { exact: true }).click();
   await page.getByRole("combobox", { name: "Connectivity", exact: true }).click();
   await page.getByRole("option", { name: "Zigbee", exact: true }).click();
   const progress = page.getByRole("navigation", { name: "Measurement progress" });
@@ -398,6 +449,7 @@ test("preserves unfinished profile fields, list rows and tags when navigating ba
   await expect(aliasInputs.first()).toHaveValue("Alias one ");
   await expect(aliasInputs.nth(1)).toHaveValue("");
   await expect(meter).toHaveValue("Custom meter");
+  await page.getByText("Device specifications (optional)", { exact: true }).click();
   await expect(page.getByRole("button", { name: "Remove Zigbee" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Continue to submit profile" })).toBeHidden();
   await page.getByRole("button", { name: "Validate changes" }).click();
@@ -460,6 +512,7 @@ test("keeps profile metadata controls aligned at a consistent height", async ({ 
   await measureDevice.press("ArrowDown");
   await measureDevice.press("Enter");
   await expect(measureDevice).toHaveValue("Kasa EP25");
+  await page.getByText("Device specifications (optional)", { exact: true }).click();
   const connectivity = page.getByRole("combobox", { name: "Connectivity", exact: true });
   await connectivity.click();
   await page.getByRole("option", { name: "Zigbee", exact: true }).click();

--- a/utils/measure/frontend/src/app-controller.sessions.test.ts
+++ b/utils/measure/frontend/src/app-controller.sessions.test.ts
@@ -2,6 +2,19 @@ import { MeasureAppController } from "./app-controller";
 import { api, connection, state } from "./testing/controller";
 
 describe("measure app controller: sessions", () => {
+  it("clears the previous live-update timestamp when resuming a session", async () => {
+    const appState = state();
+    appState.snapshot = { state: "failed", session_id: "session-1" };
+    appState.lastEventReceivedAt = "2026-08-13T10:00:00Z";
+    const controller = new MeasureAppController(appState, () => api({
+      resume: async () => ({ state: "running", session_id: "session-1" }),
+    }), () => connection(), () => undefined);
+
+    await controller.resume();
+
+    expect(appState.view).toBe("running");
+    expect(appState.lastEventReceivedAt).toBeUndefined();
+  });
   it("loads files and plots for a persisted terminal session", async () => {
     const appState = state();
     let calibrationCalls = 0;

--- a/utils/measure/frontend/src/app-controller.ts
+++ b/utils/measure/frontend/src/app-controller.ts
@@ -40,6 +40,8 @@ export type AppView = "loading" | "sessions" | "setup" | "review" | "running" | 
 
 export interface MeasureAppState {
   view: AppView;
+  setupDraftVersion?: number;
+  lastEventReceivedAt?: string;
   settingsSection?: SettingsSection;
   errorMessage: string;
   errorHelp?: ErrorHelp;
@@ -583,6 +585,7 @@ export class MeasureAppController {
   }
 
   private consumeEvent(event: SessionEvent): void {
+    this.state.lastEventReceivedAt = new Date().toISOString();
     if ((event.type === "log" || event.type === "warning" || event.type === "checkpoint") && event.data.message) {
       this.state.logs = [...this.state.logs.slice(-39), event.data.message];
     }
@@ -625,6 +628,8 @@ export class MeasureAppController {
   }
 
   private resetDraft(request?: MeasurementRequest): void {
+    this.state.setupDraftVersion = (this.state.setupDraftVersion ?? 0) + 1;
+    this.state.lastEventReceivedAt = undefined;
     this.eventConnection?.close();
     this.state.connectedToEvents = false;
     this.state.snapshot = { state: "idle" };
@@ -682,11 +687,14 @@ export class MeasureAppController {
 
   /** Adopt the configuration a stored session was started with, so the draft and forms match it. */
   private async adoptRequest(request?: MeasurementRequest): Promise<void> {
+    this.state.setupDraftVersion = (this.state.setupDraftVersion ?? 0) + 1;
+    this.state.lastEventReceivedAt = undefined;
     this.state.request = request;
     if (request) await this.loadTypeEntities(request.measure_type, request);
   }
 
   private async enterRunning(): Promise<void> {
+    this.state.lastEventReceivedAt = undefined;
     await this.refreshSessions();
     this.state.view = "running";
     this.connectEvents();

--- a/utils/measure/frontend/src/components/app/shell.ts
+++ b/utils/measure/frontend/src/components/app/shell.ts
@@ -1,5 +1,7 @@
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { cache } from "lit/directives/cache.js";
+import { keyed } from "lit/directives/keyed.js";
 import { MeasureApiClient, SessionEventStream } from "../../api-client";
 import { MeasureAppController } from "../../app-controller";
 import type { AppView, MeasureAppState } from "../../app-controller";
@@ -42,6 +44,8 @@ const MEASUREMENT_STEPS: readonly { view: AppView; label: string }[] = [
 @customElement("powercalc-measure-app")
 export class AppShell extends LitElement implements MeasureAppState {
   view: AppView = "loading";
+  setupDraftVersion = 0;
+  lastEventReceivedAt?: string;
   settingsSection?: SettingsSection;
   loadingMessage = "Connecting to Home Assistant…";
   errorMessage = "";
@@ -123,6 +127,9 @@ export class AppShell extends LitElement implements MeasureAppState {
     .intro { display: grid; grid-template-columns: minmax(0, 1fr) minmax(360px, 0.78fr); gap: 1.25rem clamp(1.5rem, 5vw, 4rem); align-items: end; padding-top: clamp(1.5rem, 4vw, 2.5rem); }
     h1 { grid-column: 1 / -1; margin: 0; font-size: clamp(2rem, 3.4vw, 3rem); line-height: 1; letter-spacing: -0.04em; }
     .subtitle { max-width: 540px; margin: 0.8rem 0 0; color: var(--muted); font-size: 1rem; line-height: 1.6; }
+    .intro.compact { display: block; padding-top: 1rem; }
+    .intro.compact h1, .intro.compact .subtitle { display: none; }
+    .intro.compact .sequence { max-width: 620px; }
     .topbar-actions { display: flex; align-items: center; gap: 0.55rem; }
     .topbar-action { min-height: 36px; padding: 0.4rem 0.8rem; border-radius: 999px; font: 700 0.72rem/1 ui-monospace, monospace; letter-spacing: 0.08em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.45rem; }
     .theme-toggle { width: 36px; padding: 0; justify-content: center; font-size: 1rem; letter-spacing: normal; }
@@ -193,7 +200,7 @@ export class AppShell extends LitElement implements MeasureAppState {
               <button class="topbar-action settings-toggle" type="button" @click=${this.openSettings} ?disabled=${this.view === "loading" || this.view === "settings"}>Settings</button>
             </div>
           </div>
-          <div class="intro">
+          <div class="intro ${this.view === "sessions" ? "" : "compact"}">
             <h1>Turn real watts into a precise profile.</h1>
             <div>
             <p class="subtitle">Configure, validate, and monitor a power measurement without leaving Home Assistant.</p>
@@ -207,8 +214,9 @@ export class AppShell extends LitElement implements MeasureAppState {
             <button type="button" @click=${() => void this.controller.retryDummyLoadCalibration()}>Retry</button>
           </div>
         ` : nothing}
-        ${this.renderView()}
-        <footer>Keep this app running while the measurement is in progress.</footer>
+        ${keyed(this.setupDraftVersion, html`${cache(this.view === "setup" ? this.renderSetup() : nothing)}`)}
+        ${this.view === "setup" ? nothing : this.renderView()}
+        <footer>You can close this page during a measurement. Keep the Powercalc Measure app running in Home Assistant.</footer>
       </main>
     `;
   }
@@ -291,6 +299,7 @@ export class AppShell extends LitElement implements MeasureAppState {
       <measure-running-view
         .snapshot=${snapshot} .confirmationAction=${this.confirmationAction()} .warningConfirmation=${this.confirmationIsWarning()}
         .connected=${this.connectedToEvents} .logs=${this.logs} .samples=${this.samples}
+        .lastEventReceivedAt=${this.lastEventReceivedAt}
         .diagnosticsUrl=${this.api.diagnosticsUrl(snapshot.session_id ?? "")} .busy=${this.busy}
         @cancel=${() => void this.controller.cancel()} @confirm=${() => void this.controller.confirm()}
       ></measure-running-view>`;

--- a/utils/measure/frontend/src/components/profile/contribution-details.ts
+++ b/utils/measure/frontend/src/components/profile/contribution-details.ts
@@ -8,6 +8,8 @@ export class ProfileContributionDetails extends ProfileFormSection {
   render() {
     const context = Object.entries(this.draft.home_assistant).filter(([, value]) => value !== null && value !== "");
     return html`
+      <details class="profile-details">
+        <summary>Contribution notes (optional)</summary>
       <fieldset class="metadata-group" ?disabled=${this.busy}>
         <legend>Contribution notes</legend>
         <div class="metadata-group-body">
@@ -15,6 +17,7 @@ export class ProfileContributionDetails extends ProfileFormSection {
           ${this.renderTextarea("notes", "Notes", this.draft.notes)}
         </div>
       </fieldset>
+      </details>
       ${context.length ? html`
         <details class="profile-details">
           <summary>Measurement context</summary>

--- a/utils/measure/frontend/src/components/profile/device-specification-fields.ts
+++ b/utils/measure/frontend/src/components/profile/device-specification-fields.ts
@@ -14,6 +14,8 @@ export class ProfileDeviceSpecificationFields extends ProfileFormSection {
     const fields = deviceType ? this.specificationFields[deviceType] ?? [] : [];
     const typeLabel = deviceType ? optionLabel(deviceType) : "this device type";
     return html`
+      <details class="profile-details">
+        <summary>Device specifications (optional)</summary>
       <fieldset class="metadata-group" ?disabled=${this.busy}>
         <legend>Device specifications</legend>
         <div class="metadata-group-body">
@@ -23,7 +25,8 @@ export class ProfileDeviceSpecificationFields extends ProfileFormSection {
             : html`<p class="muted">Specification fields are currently unavailable. Existing values will be kept.</p>`}
           ${this.renderFieldError("device_specs")}
         </div>
-      </fieldset>`;
+      </fieldset>
+      </details>`;
   }
 
   private renderSpecification(field: DeviceSpecificationField) {

--- a/utils/measure/frontend/src/components/profile/prepare-view.ts
+++ b/utils/measure/frontend/src/components/profile/prepare-view.ts
@@ -86,7 +86,7 @@ export class ProfilePrepareView extends LitElement {
     measure-profile-device-specification-fields,
     measure-profile-contribution-details,
     measure-profile-prepared-preview { display: contents; }
-    .validation-footer { display: flex; align-items: center; justify-content: space-between; gap: 1.25rem; margin-top: 1.5rem; padding: 1rem 1.1rem; border: 1px solid var(--line); border-radius: 12px; background: color-mix(in srgb, var(--field) 72%, transparent); }
+    .validation-footer { position: sticky; bottom: 0.5rem; z-index: 5; display: flex; align-items: center; justify-content: space-between; gap: 1.25rem; margin-top: 1.5rem; padding: 1rem 1.1rem; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); box-shadow: 0 4px 20px rgb(0 0 0 / 0.2); }
     .validation-status { margin: 0; color: var(--muted); line-height: 1.45; }
     .validation-status.pending { color: var(--ink); }
     .validation-status.valid { color: var(--good); font-weight: 650; }
@@ -122,8 +122,9 @@ export class ProfilePrepareView extends LitElement {
     a { color: var(--signal-strong); font-weight: 700; }
     @media (max-width: 520px) {
       .contribution-grid, .contribution-grid.contributor-grid { grid-template-columns: 1fr; }
-      .validation-footer { align-items: stretch; flex-direction: column; }
-      .validation-footer button { width: 100%; }
+      .validation-footer { gap: 0.75rem; padding: 0.75rem; }
+      .validation-footer .validation-status { font-size: 0.75rem; }
+      .validation-footer button { max-width: 55%; padding: 0.7rem; }
     }
   `];
 
@@ -310,6 +311,8 @@ export class ProfilePrepareView extends LitElement {
 
   private focusField(name: string): void {
     const control = this.fieldControl(name);
+    const details = control?.closest("details");
+    if (details) details.open = true;
     const input = control?.shadowRoot?.querySelector<HTMLElement>("input, select") ?? control;
     input?.focus();
     input?.scrollIntoView?.({ block: "center", behavior: "smooth" });

--- a/utils/measure/frontend/src/components/result/view.test.ts
+++ b/utils/measure/frontend/src/components/result/view.test.ts
@@ -2,6 +2,11 @@ import type { SessionSnapshot } from "../../types";
 import "./view";
 
 describe("result view", () => {
+  // jsdom does not implement native modal behavior; keyboard/inert behavior is covered in e2e.
+  beforeAll(() => {
+    HTMLDialogElement.prototype.showModal = function () { this.open = true; };
+    HTMLDialogElement.prototype.close = function () { this.open = false; };
+  });
   it.each(["completed", "failed", "cancelled", "resumable"] as const)("offers diagnostics for a %s session without generated files", async (state) => {
     const element = document.createElement("measure-result-view") as HTMLElement & {
       snapshot: SessionSnapshot;
@@ -20,12 +25,13 @@ describe("result view", () => {
     expect(element.shadowRoot.querySelector(".diagnostics-download")?.textContent).toContain("snapshot and logs");
   });
 
-  it("keeps failed results focused on the actionable error", async () => {
+  it("keeps failure guidance alongside partial downloads and recovery", async () => {
     const element = document.createElement("measure-result-view") as HTMLElement & {
       snapshot: SessionSnapshot;
       files: { name: string; size: number; media_type: string }[];
       plotCollection: { partial: boolean; plots: never[]; warnings: string[] };
       diagnosticsUrl: string;
+      canResume: boolean;
       updateComplete: Promise<boolean>;
       shadowRoot: ShadowRoot;
     };
@@ -34,6 +40,9 @@ describe("result view", () => {
       error: "Aborting measurement session after repeated 0 W readings. The power meter may not resolve this low load. See https://docs.powercalc.nl/contributing/measure/troubleshooting/ for troubleshooting guidance.",
     };
     element.files = [{ name: "brightness.csv", size: 10, media_type: "text/csv" }];
+    element.canResume = true;
+    const resume = vi.fn();
+    element.addEventListener("resume", resume);
     element.plotCollection = { partial: true, plots: [], warnings: ["Could not plot brightness.csv"] };
     element.diagnosticsUrl = "http://ha.local/ingress/api/sessions/session-1/diagnostics";
     document.body.append(element);
@@ -44,9 +53,13 @@ describe("result view", () => {
     expect(troubleshootingLink.textContent).toBe("Troubleshooting guide");
     expect(troubleshootingLink.href).toBe("https://docs.powercalc.nl/contributing/measure/troubleshooting/");
     expect(element.shadowRoot.textContent).toContain("correct the problem");
-    expect(element.shadowRoot.textContent).not.toContain("Could not plot");
-    expect(element.shadowRoot.textContent).not.toContain("Generated files");
-    expect(element.shadowRoot.textContent).not.toContain("Download all");
+    expect(element.shadowRoot.textContent).toContain("Could not plot");
+    expect(element.shadowRoot.textContent).toContain("Saved partial files");
+    expect(element.shadowRoot.textContent).toContain("Download all");
+    const resumeButton = [...element.shadowRoot.querySelectorAll("button")].find((button) => button.textContent?.includes("Resume"));
+    expect(resumeButton).toBeTruthy();
+    resumeButton!.click();
+    expect(resume).toHaveBeenCalledOnce();
     expect(element.shadowRoot.querySelector(".diagnostics-download a")).toBeTruthy();
   });
 
@@ -217,6 +230,7 @@ describe("result view", () => {
     (element.shadowRoot.querySelector(".json-dialog-header button") as HTMLButtonElement).click();
     await element.updateComplete;
     expect(element.shadowRoot.querySelector('[role="dialog"]')).toBeNull();
+    expect(element.shadowRoot.activeElement).toBe(buttons[0]);
   });
 
   it("shows JSON inspection failures inside the viewer", async () => {
@@ -233,6 +247,34 @@ describe("result view", () => {
     await element.updateComplete;
     (element.shadowRoot.querySelector(".inspect-file") as HTMLButtonElement).click();
     await vi.waitFor(() => expect(element.shadowRoot.querySelector('.json-dialog [role="alert"]')?.textContent).toContain("File could not be read"));
+  });
+
+  it.each(["cancel", "backdrop"])("closes a loading inspector via %s and ignores its late response", async (action) => {
+    const element = document.createElement("measure-result-view") as import("./view").ResultView;
+    element.snapshot = { state: "completed" };
+    element.files = [{ name: "model.json", size: 100, media_type: "application/json" }];
+    let resolve!: (value: unknown) => void;
+    element.inspectJsonFile = () => new Promise((done) => { resolve = done; });
+    document.body.append(element);
+    await element.updateComplete;
+    const trigger = element.shadowRoot!.querySelector<HTMLButtonElement>(".inspect-file")!;
+    trigger.click();
+    await element.updateComplete;
+    const dialog = element.shadowRoot!.querySelector<HTMLDialogElement>("dialog")!;
+    expect(dialog.textContent).toContain("Loading JSON");
+    if (action === "cancel") {
+      const event = new Event("cancel", { cancelable: true });
+      dialog.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    } else {
+      dialog.dispatchEvent(new MouseEvent("click", { clientX: -1, clientY: -1 }));
+    }
+    await element.updateComplete;
+    expect(element.shadowRoot!.querySelector("dialog")).toBeNull();
+    expect(element.shadowRoot!.activeElement).toBe(trigger);
+    resolve({ name: "Late response" });
+    await element.updateComplete;
+    expect(element.shadowRoot!.querySelector("dialog")).toBeNull();
   });
 
   it("renders partial plots and offers a PNG download", async () => {

--- a/utils/measure/frontend/src/components/result/view.ts
+++ b/utils/measure/frontend/src/components/result/view.ts
@@ -57,7 +57,7 @@ const OUTCOMES: Partial<Record<SessionState, ResultOutcome>> = {
   failed: {
     mark: "!",
     title: "Measurement stopped with an error",
-    description: "Review the guidance below, correct the problem, and start a new measurement.",
+    description: "Review the guidance below and correct the problem before continuing.",
   },
   resumable: {
     mark: "↻",
@@ -85,6 +85,12 @@ export class ResultView extends LitElement {
   @property({ attribute: false }) errorHelp?: ErrorHelp;
 
   @state() private jsonInspector?: JsonInspectorState;
+  private inspectorTrigger?: HTMLElement;
+
+  protected updated(): void {
+    const dialog = this.shadowRoot?.querySelector<HTMLDialogElement>(".json-dialog");
+    if (dialog && !dialog.open) dialog.showModal();
+  }
 
   static readonly styles = [sharedStyles, css`
     .result-summary { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 1rem; align-items: start; padding-bottom: 1.5rem; border-bottom: 1px solid var(--line); }
@@ -122,8 +128,9 @@ export class ResultView extends LitElement {
     .file-actions { display: flex; align-items: center; gap: 0.55rem; }
     .inspect-file { display: grid; place-items: center; width: 38px; min-height: 38px; padding: 0; color: var(--signal-strong); }
     .inspect-file svg { width: 19px; height: 19px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
-    .json-backdrop { position: fixed; z-index: 1000; inset: 0; display: grid; place-items: center; padding: clamp(1rem, 4vw, 3rem); background: rgb(0 0 0 / 0.72); }
-    .json-dialog { display: grid; grid-template-rows: auto minmax(0, 1fr); width: min(900px, 100%); max-height: min(82vh, 900px); padding: 1rem; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); box-shadow: 0 24px 80px rgb(0 0 0 / 0.45); }
+    .json-dialog::backdrop { background: rgb(0 0 0 / 0.72); }
+    .json-dialog { grid-template-rows: auto minmax(0, 1fr); width: min(900px, calc(100% - 2rem)); max-height: min(82vh, 900px); padding: 1rem; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); color: var(--ink); box-shadow: 0 24px 80px rgb(0 0 0 / 0.45); }
+    .json-dialog[open] { display: grid; }
     .json-dialog-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding-bottom: 0.8rem; }
     .json-dialog-header h3 { margin: 0; overflow-wrap: anywhere; }
     .json-dialog-header button { min-height: 38px; padding: 0.4rem 0.7rem; }
@@ -152,7 +159,7 @@ export class ResultView extends LitElement {
     const state = this.snapshot.state;
     const outcome = this.outcome(state);
     const error = typeof this.snapshot.error === "string" ? this.snapshot.error : this.snapshot.error?.message;
-    const showArtifacts = state !== "failed";
+    const showArtifacts = state !== "failed" || this.files.length > 0;
     return html`
       <section class="panel" aria-labelledby="result-title">
         <p class="eyebrow">04 / Result</p>
@@ -161,6 +168,10 @@ export class ResultView extends LitElement {
           <div><h2 id="result-title">${outcome.title}</h2><p class="muted">${outcome.description}</p></div>
         </div>
         ${error ? html`<p class="notice error" role="alert">${this.renderError(error)}</p>` : nothing}
+        ${state !== "completed" && this.files.length ? html`<p class="notice" role="status">
+          Saved output is available below. This measurement is incomplete; these files are partial results.
+          ${this.canResume ? "Resume to continue from the last complete variation." : "You can download the saved data before starting again."}
+        </p>` : nothing}
         ${showArtifacts ? this.renderSummary() : nothing}
         ${showArtifacts || this.canAnalyse ? this.renderAnalysis() : nothing}
         ${showArtifacts ? this.renderWarnings() : nothing}
@@ -204,13 +215,13 @@ export class ResultView extends LitElement {
     if (this.files.length) {
       return html`
         <div class="files-header">
-          <h3>Generated files</h3>
+          <h3>${this.snapshot.state === "completed" ? "Generated files" : "Saved partial files"}</h3>
           <button class="download-all" type="button" @click=${() => this.downloadAll()}>Download all</button>
         </div>
         <ul>${this.files.map((file) => html`
           <li><span>${file.name}</span><small>${fileSize(file.size)}</small><div class="file-actions">
             ${this.isInspectableJson(file) ? html`
-              <button class="inspect-file" type="button" title=${`View ${file.name}`} aria-label=${`View ${file.name}`} @click=${() => void this.openJsonInspector(file.name)}>
+              <button class="inspect-file" type="button" title=${`View ${file.name}`} aria-label=${`View ${file.name}`} @click=${(event: MouseEvent) => void this.openJsonInspector(file.name, event.currentTarget as HTMLElement)}>
                 <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6-9.5-6-9.5-6Z"></path><circle cx="12" cy="12" r="2.5"></circle></svg>
               </button>
             ` : nothing}
@@ -228,7 +239,8 @@ export class ResultView extends LitElement {
     return file.media_type === "application/json" && INSPECTABLE_JSON_FILES.has(basename);
   }
 
-  private async openJsonInspector(name: string): Promise<void> {
+  private async openJsonInspector(name: string, trigger: HTMLElement): Promise<void> {
+    this.inspectorTrigger = trigger;
     this.jsonInspector = { name };
     try {
       const content = await this.inspectJsonFile(name);
@@ -240,21 +252,30 @@ export class ResultView extends LitElement {
     }
   }
 
+  private closeJsonInspector(): void {
+    this.shadowRoot?.querySelector<HTMLDialogElement>(".json-dialog")?.close();
+    this.jsonInspector = undefined;
+    this.inspectorTrigger?.focus();
+  }
+
   private renderJsonInspector() {
     const inspector = this.jsonInspector;
     if (!inspector) return nothing;
     return html`
-      <div class="json-backdrop" role="presentation" @click=${(event: MouseEvent) => {
-        if (event.target === event.currentTarget) this.jsonInspector = undefined;
-      }}>
-        <section class="json-dialog" role="dialog" aria-modal="true" aria-labelledby="json-dialog-title">
+        <dialog class="json-dialog" role="dialog" aria-labelledby="json-dialog-title"
+          @cancel=${(event: Event) => { event.preventDefault(); this.closeJsonInspector(); }}
+          @click=${(event: MouseEvent) => {
+            const dialog = event.currentTarget as HTMLDialogElement;
+            const bounds = dialog.getBoundingClientRect();
+            if (event.target === dialog && (event.clientX < bounds.left || event.clientX > bounds.right
+              || event.clientY < bounds.top || event.clientY > bounds.bottom)) this.closeJsonInspector();
+          }}>
           <div class="json-dialog-header">
             <h3 id="json-dialog-title">${inspector.name}</h3>
-            <button type="button" autofocus @click=${() => { this.jsonInspector = undefined; }}>Close</button>
+            <button type="button" autofocus @click=${() => this.closeJsonInspector()}>Close</button>
           </div>
           ${this.renderJsonInspectorContent(inspector)}
-        </section>
-      </div>
+        </dialog>
     `;
   }
 
@@ -378,7 +399,7 @@ export class ResultView extends LitElement {
   }
 
   private renderResume(state: SessionState) {
-    if (!this.canResume || (state !== "resumable" && state !== "cancelled")) return nothing;
+    if (!this.canResume || !["resumable", "cancelled", "failed"].includes(state)) return nothing;
     return html`<button class="primary" type="button" @click=${() => this.emit("resume")} ?disabled=${this.busy}>${this.busy ? "Resuming…" : "Resume measurement"}</button>`;
   }
 

--- a/utils/measure/frontend/src/components/running/view.test.ts
+++ b/utils/measure/frontend/src/components/running/view.test.ts
@@ -2,6 +2,19 @@ import type { SessionSnapshot } from "../../types";
 import "./view";
 
 describe("running view", () => {
+  it("explains a disconnected stream and labels the last received update", async () => {
+    const element = document.createElement("measure-running-view") as import("./view").RunningView;
+    element.snapshot = { state: "running", phase: "Measuring" };
+    element.connected = false;
+    element.lastEventReceivedAt = "2026-09-06T10:00:00Z";
+    document.body.append(element);
+    await element.updateComplete;
+    expect(element.shadowRoot?.textContent).toContain("may still be running in Home Assistant");
+    expect(element.shadowRoot?.querySelector("time")?.dateTime).toBe(element.lastEventReceivedAt);
+    element.connected = true;
+    await element.updateComplete;
+    expect(element.shadowRoot?.querySelector("time")).toBeNull();
+  });
   it("stops averaging through the same action as recording and disables repeated requests", async () => {
     const element = document.createElement("measure-running-view") as HTMLElement & {
       snapshot: SessionSnapshot; busy: boolean; updateComplete: Promise<boolean>; shadowRoot: ShadowRoot;

--- a/utils/measure/frontend/src/components/running/view.ts
+++ b/utils/measure/frontend/src/components/running/view.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html, nothing, svg } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import type { SessionProgress, SessionSnapshot } from "../../types";
 import { emit } from "../../utils/events";
-import { remaining } from "../../utils/format";
+import { remaining, timestamp } from "../../utils/format";
 import { diagnosticsDownload, sharedStyles } from "../../styles";
 import "./chart";
 import "./log";
@@ -21,6 +21,9 @@ export class RunningView extends LitElement {
 
   @property({ type: Boolean })
   connected = false;
+
+  @property({ type: String })
+  lastEventReceivedAt?: string;
 
   @property({ attribute: false })
   logs: string[] = [];
@@ -102,6 +105,10 @@ export class RunningView extends LitElement {
   /** Warnings, the log drawer, diagnostics and the stop control — the same on both screens. */
   private renderFooter(openEnded: boolean) {
     return html`
+      ${!this.connected ? html`<p class="notice" role="status">
+        Reconnecting to live updates. The measurement may still be running in Home Assistant.
+        ${this.lastEventReceivedAt ? html`Last update received: <time datetime=${this.lastEventReceivedAt}>${timestamp(this.lastEventReceivedAt)}</time>.` : "Waiting for a live update."}
+      </p>` : nothing}
       ${this.renderLatestWarning()}
       ${diagnosticsDownload(this.diagnosticsUrl)}
       <div class="actions">${this.renderStopButton(openEnded)}</div>

--- a/utils/measure/measure/cli/main.py
+++ b/utils/measure/measure/cli/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 from pathlib import Path
 import re
+import shlex
 import sys
 from typing import Any, cast
 from uuid import uuid4
@@ -126,7 +127,21 @@ class Measure:
                 measurement=prepared,
                 output_directory=Path(PROJECT_DIR) / "export" / model_id,
             )
-            execution.run()
+            if execution.output_directory is not None:
+                _LOGGER.info("Measurement output directory: %s", execution.output_directory)
+            try:
+                execution.run()
+            except KeyboardInterrupt, Exception:
+                if execution.output_directory is not None:
+                    _LOGGER.warning("Measurement stopped. Any saved output is kept in %s", execution.output_directory)
+                    if self.measure_type == MeasureType.LIGHT:
+                        _LOGGER.warning(
+                            "To resume, run from the measure directory with the same device and settings, "
+                            "then accept the resume prompt if saved rows are found:\n"
+                            "RESUME=true MODEL_ID=%s uv run --extra cli python -m measure.measure",
+                            shlex.quote(model_id),
+                        )
+                raise
         finally:
             if self._home_assistant is not None:
                 self._home_assistant.close()
@@ -138,6 +153,11 @@ class Measure:
                 "Measurement session finished. Files exported to %s",
                 execution.output_directory,
             )
+            if request.generate_model_json:
+                _LOGGER.info(
+                    "Next, add product metadata and validate the profile:\nuv run powercalc-profile prepare %s",
+                    shlex.quote(str(execution.output_directory)),
+                )
 
     def _select_measure_type(self) -> None:
         if self.config.selected_measure_type:

--- a/utils/measure/tests/test_measure.py
+++ b/utils/measure/tests/test_measure.py
@@ -110,12 +110,16 @@ def test_wizard(mock_config_factory: MockConfigFactory) -> None:
     assert (output / "model.json").is_file()
 
 
-def test_run_light(mock_config_factory: MockConfigFactory) -> None:
+def test_run_light(mock_config_factory: MockConfigFactory, caplog: pytest.LogCaptureFixture) -> None:
     """Simulate a full run of the light measure using brightness mode"""
+    caplog.set_level(logging.INFO, logger="measure")
     mock_config = mock_config_factory()
 
     measure = _create_measure_instance(config=mock_config)
     measure.start()
+
+    assert "Measurement output directory:" in caplog.text
+    assert f"uv run powercalc-profile prepare {PROJECT_DIR / 'export/LCT010'}" in caplog.text
 
     assert os.path.exists(os.path.join(PROJECT_DIR, "export/LCT010/brightness.csv.gz"))
     model_json_path = os.path.join(PROJECT_DIR, "export/LCT010/model.json")
@@ -127,6 +131,29 @@ def test_run_light(mock_config_factory: MockConfigFactory) -> None:
         MODEL_JSON_VOLTAGE_RANGE_MAX: 233.0,
     }
     assert model_json["mains_voltage"] == 230
+
+
+@pytest.mark.parametrize("error", [KeyboardInterrupt(), RuntimeError("Meter disconnected")])
+def test_interrupted_light_prints_recovery(
+    mock_config_factory: MockConfigFactory,
+    caplog: pytest.LogCaptureFixture,
+    error: BaseException,
+) -> None:
+    caplog.set_level(logging.INFO, logger="measure")
+    measure = _create_measure_instance(config=mock_config_factory())
+
+    def interrupt() -> None:
+        assert "Measurement output directory:" in caplog.text
+        raise error
+
+    with patch("measure.cli.main.MeasurementExecution.run", side_effect=interrupt), pytest.raises(type(error)):
+        measure.start()
+
+    assert f"Any saved output is kept in {PROJECT_DIR / 'export/LCT010'}" in caplog.text
+    assert "RESUME=true MODEL_ID=LCT010 uv run --extra cli python -m measure.measure" in caplog.text
+    assert "same device and settings" in caplog.text
+    assert "Files exported to" not in caplog.text
+    assert "powercalc-profile prepare" not in caplog.text
 
 
 def test_take_measurement_tracks_voltage_range(mock_config_factory: MockConfigFactory) -> None:


### PR DESCRIPTION
Setup values were lost when visiting Settings, and failed measurements hid saved output and the available resume action. Preserve incomplete setup values across in-app navigation and expose partial downloads and recovery for failed runs.

Also compact the measurement screens and mobile profile form, collapse optional metadata, and keep validation visible while scrolling. Use a native modal for JSON inspection with Escape, focus containment, and focus restoration. Clarify that measurements continue with the browser closed, show the last received update when reconnecting, and print CLI output paths plus resume and profile-preparation commands.

Validation:

- 749 backend tests passed.
- 283 frontend unit tests and 28 Chromium browser tests passed.
- 100% coverage of changed executable Python lines and frontend statements.
- Frontend production build, TypeScript, ESLint, Ruff, formatting, and repository hooks passed.
- Manually inspected the mobile form in the browser using mocked measurement data; no hardware measurements were started.
