### PR TITLE
Add controlled entity to the Measure session status sensor

### DIFF
--- a/custom_components/powercalc/measure.py
+++ b/custom_components/powercalc/measure.py
@@ -40,6 +40,7 @@ class MeasureStatus:
     state: str
     session_id: str | None
     error: str | None
+    controlled_entity: str | None = None
 
 
 class MeasureAppCoordinator:
@@ -86,11 +87,13 @@ class MeasureAppCoordinator:
         app_version = event_data.get("app_version")
         session_id = event_data.get("session_id")
         error = event_data.get("error")
+        controlled_entity = event_data.get("controlled_entity")
         if (
             state not in MEASURE_SESSION_STATES
             or not isinstance(app_version, str)
             or (session_id is not None and not isinstance(session_id, str))
             or (error is not None and not isinstance(error, str))
+            or (controlled_entity is not None and not isinstance(controlled_entity, str))
         ):
             _LOGGER.debug("Ignoring invalid Powercalc Measure status event: %s", event_data)
             return False
@@ -100,6 +103,7 @@ class MeasureAppCoordinator:
             state=str(state),
             session_id=session_id,
             error=error,
+            controlled_entity=controlled_entity,
         )
         self.available = True
         if self._cancel_stale_timer is not None:

--- a/custom_components/powercalc/sensors/measure.py
+++ b/custom_components/powercalc/sensors/measure.py
@@ -39,6 +39,8 @@ class MeasureSessionStatusSensor(SensorEntity):
         attributes: dict[str, Any] = {"app_version": status.app_version}
         if status.session_id is not None:
             attributes["session_id"] = status.session_id
+        if status.controlled_entity is not None:
+            attributes["controlled_entity"] = status.controlled_entity
         if status.error is not None:
             attributes["error"] = status.error
         return attributes

--- a/docs/source/contributing/measure/home-assistant-app.md
+++ b/docs/source/contributing/measure/home-assistant-app.md
@@ -110,8 +110,11 @@ When both the Powercalc integration and the Measure app are running, Powercalc c
 installations that do not use the Measure app.
 
 The sensor reports the current session state, such as `idle`, `running`, `completed`, or `failed`. Its attributes
-include the Measure app version and, when available, the session ID and error message. The sensor becomes unavailable
-when the app stops sending status updates, for example when the app is stopped.
+include the Measure app version and, when available, the session ID, controlled entity, and error message.
+The `controlled_entity` attribute contains the Home Assistant entity ID controlled by the session, or a comma-separated
+list for measurements controlling multiple lights. It remains available after the session finishes and is omitted for
+measurements without a controlled Home Assistant entity. The sensor becomes unavailable when the app stops sending
+status updates, for example when the app is stopped.
 
 You can use the sensor in an automation to be notified when a long-running measurement completes. Replace the notify
 action with the one for your device:

--- a/tests/sensors/test_measure.py
+++ b/tests/sensors/test_measure.py
@@ -34,6 +34,53 @@ async def test_measure_sensor_is_only_created_after_app_announcement(hass: HomeA
     assert state.state == "running"
     assert state.attributes["app_version"] == "1.2.3"
     assert state.attributes["session_id"] == "session-1"
+    assert "controlled_entity" not in state.attributes
+
+
+@pytest.mark.parametrize("controlled_entity", ["light.test", "light.one, light.two"])
+async def test_measure_sensor_controlled_entity_is_retained_and_cleared(
+    hass: HomeAssistant,
+    controlled_entity: str,
+) -> None:
+    await run_powercalc_setup(hass)
+    for session_state in ("running", "completed"):
+        hass.bus.async_fire(
+            MEASURE_STATUS_EVENT,
+            {
+                "app_version": "1.2.3",
+                "state": session_state,
+                "session_id": "session-1",
+                "controlled_entity": controlled_entity,
+            },
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.measure_session_status")
+        assert state is not None
+        assert state.state == session_state
+        assert state.attributes["controlled_entity"] == controlled_entity
+
+    hass.bus.async_fire(
+        MEASURE_STATUS_EVENT,
+        {"app_version": "1.2.3", "state": "running", "session_id": "session-2", "controlled_entity": None},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.measure_session_status")
+    assert state is not None
+    assert state.attributes["session_id"] == "session-2"
+    assert "controlled_entity" not in state.attributes
+
+
+@pytest.mark.parametrize("controlled_entity", [123, ["light.test"], {"entity_id": "light.test"}])
+def test_measure_status_rejects_invalid_controlled_entity(hass: HomeAssistant, controlled_entity: object) -> None:
+    coordinator = MeasureAppCoordinator(hass, {})
+
+    assert not coordinator.async_process_event(
+        {"app_version": "1.2.3", "state": "running", "controlled_entity": controlled_entity},
+    )
+    assert coordinator.data is None
+    assert not coordinator.available
 
 
 async def test_measure_sensor_updates_and_becomes_unavailable_without_heartbeat(hass: HomeAssistant) -> None:

--- a/utils/measure/measure/ha_app/status.py
+++ b/utils/measure/measure/ha_app/status.py
@@ -73,10 +73,13 @@ class MeasureStatusPublisher:
 
     def _publish(self) -> None:
         snapshot = self._coordinator.current
+        request = self._coordinator.storage.load_request(snapshot.id) if snapshot is not None else None
+        controlled_entity_ids = request.controlled_entity_ids if request is not None else ()
         self._home_assistant.fire_event(
             HASS_EVENT_MEASURE_STATUS,
             app_version=measure_version(),
             state=snapshot.state if snapshot is not None else SessionState.IDLE,
             session_id=snapshot.id if snapshot is not None else None,
+            controlled_entity=", ".join(controlled_entity_ids) or None,
             error=snapshot.error if snapshot is not None else None,
         )

--- a/utils/measure/tests/test_status.py
+++ b/utils/measure/tests/test_status.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from measure.const import HASS_EVENT_MEASURE_STATUS
-from measure.controller.light.spec import DummyLightControllerSpec
+from measure.controller.light.spec import (
+    DummyLightControllerSpec,
+    HassLightControllerSpec,
+    HassMultiLightControllerSpec,
+    LightControllerSpec,
+)
 from measure.ha_app.coordinator import MeasurementCoordinator
 from measure.ha_app.session import SessionSnapshot, SessionState
 from measure.ha_app.status import MeasureStatusPublisher
@@ -38,11 +43,27 @@ def test_status_publisher_announces_idle_app(tmp_path: Path) -> None:
         app_version=measure_version(),
         state=SessionState.IDLE,
         session_id=None,
+        controlled_entity=None,
         error=None,
     )
 
 
-def test_status_publisher_announces_retained_session(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "controller,controlled_entity",
+    [
+        (DummyLightControllerSpec(), None),
+        (HassLightControllerSpec(entity_id="light.test"), "light.test"),
+        (
+            HassMultiLightControllerSpec(entity_ids=["light.one", "light.two"]),
+            "light.one, light.two",
+        ),
+    ],
+)
+def test_status_publisher_announces_retained_session(
+    tmp_path: Path,
+    controller: LightControllerSpec,
+    controlled_entity: str | None,
+) -> None:
     storage = SessionStorage(tmp_path)
     snapshot = SessionSnapshot(
         id="failed-session",
@@ -51,7 +72,7 @@ def test_status_publisher_announces_retained_session(tmp_path: Path) -> None:
         updated_at="2026-08-15T12:01:00Z",
         error="Meter disconnected",
     )
-    storage.create(snapshot, light_request())
+    storage.create(snapshot, light_request().model_copy(update={"controller": controller}))
     home_assistant = MagicMock(spec=HomeAssistantManager)
     publisher = MeasureStatusPublisher(home_assistant, MeasurementCoordinator(storage, MagicMock()))
 
@@ -62,6 +83,7 @@ def test_status_publisher_announces_retained_session(tmp_path: Path) -> None:
         app_version=measure_version(),
         state=SessionState.FAILED,
         session_id="failed-session",
+        controlled_entity=controlled_entity,
         error="Meter disconnected",
     )
 


### PR DESCRIPTION
The Measure session status sensor currently omits which Home Assistant entity is being controlled. Add a `controlled_entity` attribute populated from the session's saved request, so completion and failure automations can identify the measured device.

The attribute remains available for retained sessions, contains comma-separated entity IDs for multi-light measurements, and is omitted when no Home Assistant entity is controlled. Older app announcements remain supported. Update the sensor documentation and cover attribute retention, clearing, and invalid payloads.

Validation:
- Full integration suite: 1,272 tests passed.
- Full measure suite: 754 tests passed.
- 100% coverage for the changed status publisher, integration coordinator, and sensor modules.
- Repository-wide `uv run prek run --all-files`, targeted type checks, and Zensical documentation build passed.

Both the integration and Measure app need updating to expose the new attribute.
