### PR TITLE
Limit decompressed profile CSV data to 10 MiB

### DIFF
--- a/custom_components/powercalc/strategy/lut.py
+++ b/custom_components/powercalc/strategy/lut.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from decimal import Decimal
 from enum import StrEnum
 from functools import partial
-import gzip
 import logging
 import os
 from typing import Any, TextIO, cast
@@ -30,6 +29,7 @@ from custom_components.powercalc.errors import (
 )
 from custom_components.powercalc.power_profile.power_profile import PowerProfile
 
+from .profile_data import open_profile_csv
 from .strategy_interface import PowerCalculationStrategyInterface
 
 _LOGGER = logging.getLogger(__name__)
@@ -184,11 +184,11 @@ class LutRegistry:
         gzip_path = f"{path}.gz"
         if os.path.exists(gzip_path):
             _LOGGER.debug("Loading LUT data file: %s", gzip_path)
-            return gzip.open(gzip_path, "rt")
+            return open_profile_csv(gzip_path)
 
         if os.path.exists(path):
             _LOGGER.debug("Loading LUT data file: %s", path)
-            return open(path)
+            return open_profile_csv(path)
 
         raise LutFileNotFoundError(f"Data file not found: {path}")
 

--- a/custom_components/powercalc/strategy/playbook.py
+++ b/custom_components/powercalc/strategy/playbook.py
@@ -4,7 +4,6 @@ import csv
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-import gzip
 import logging
 import os
 
@@ -25,6 +24,7 @@ from custom_components.powercalc.const import (
 )
 from custom_components.powercalc.errors import StrategyConfigurationError
 
+from .profile_data import open_profile_csv
 from .strategy_interface import PowerCalculationStrategyInterface
 
 CONFIG_SCHEMA = vol.All(
@@ -222,8 +222,7 @@ class PlaybookStrategy(PowerCalculationStrategyInterface):
                     f"Playbook file '{file_path}' does not exist",
                 )
             actual_path = file_path if os.path.exists(file_path) else f"{file_path}.gz"
-            open_func = gzip.open if actual_path.endswith(".gz") else open
-            with open_func(actual_path, mode="rt") as csv_file:
+            with open_profile_csv(actual_path) as csv_file:
                 csv_reader = csv.reader(csv_file)
                 entries = []
                 for row in csv_reader:

--- a/custom_components/powercalc/strategy/profile_data.py
+++ b/custom_components/powercalc/strategy/profile_data.py
@@ -1,0 +1,22 @@
+"""Bounded readers for profile CSV data."""
+
+import gzip
+from io import BytesIO, TextIOWrapper
+from typing import TextIO
+
+from custom_components.powercalc.errors import StrategyConfigurationError
+
+MAX_UNCOMPRESSED_SIZE = 10 * 1024 * 1024
+
+
+def open_profile_csv(path: str) -> TextIO:
+    """Reject oversized CSV data before exposing it to parsers."""
+    open_func = gzip.open if path.endswith(".gz") else open
+    with open_func(path, "rb") as source:
+        # Bound the decompression itself, including concatenated gzip members.
+        data = source.read(MAX_UNCOMPRESSED_SIZE + 1)
+    if len(data) > MAX_UNCOMPRESSED_SIZE:
+        raise StrategyConfigurationError(
+            f"Profile data file '{path}' exceeds the uncompressed size limit of {MAX_UNCOMPRESSED_SIZE} bytes",
+        )
+    return TextIOWrapper(BytesIO(data), encoding="utf-8")

--- a/tests/strategy/test_lut.py
+++ b/tests/strategy/test_lut.py
@@ -1,5 +1,9 @@
 from decimal import Decimal
+from functools import partial
+import gzip
 import logging
+from pathlib import Path
+from unittest.mock import patch
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -19,7 +23,10 @@ from custom_components.powercalc.common import SourceEntity
 from custom_components.powercalc.const import CONF_MANUFACTURER, CONF_MODEL, CalculationStrategy
 from custom_components.powercalc.errors import StrategyConfigurationError
 from custom_components.powercalc.power_profile.library import ModelInfo, ProfileLibrary
+from custom_components.powercalc.power_profile.power_profile import PowerProfile
+from custom_components.powercalc.strategy import profile_data
 from custom_components.powercalc.strategy.factory import PowerCalculatorStrategyFactory
+from custom_components.powercalc.strategy.lut import LookupMode, LutRegistry
 from custom_components.powercalc.strategy.strategy_interface import (
     PowerCalculationStrategyInterface,
 )
@@ -485,6 +492,44 @@ async def test_fallback_to_non_gzipped_file(hass: HomeAssistant) -> None:
         state=_create_light_color_temp_state(1, 153),
         expected_power=0.96,
     )
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+@pytest.mark.parametrize("mode", list(LookupMode))
+async def test_oversized_lut_is_rejected(
+    hass: HomeAssistant,
+    tmp_path: Path,
+    compressed: bool,
+    mode: LookupMode,
+) -> None:
+    path = tmp_path / f"{mode}.csv{'.gz' if compressed else ''}"
+    rows = {
+        LookupMode.BRIGHTNESS: b"brightness,power\n1,2\n",
+        LookupMode.COLOR_TEMP: b"brightness,color_temp,power\n1,153,2\n",
+        LookupMode.HS: b"brightness,hue,saturation,power\n1,0,0,2\n",
+        LookupMode.EFFECT: b"effect,brightness,power\nrainbow,1,2\n",
+    }
+    valid_data = rows[mode]
+    oversized_data = valid_data + valid_data.splitlines(keepends=True)[1] * 100
+    path.write_bytes(gzip.compress(oversized_data) if compressed else oversized_data)
+    profile = PowerProfile(hass, "test", "test", str(tmp_path), {})
+    registry = LutRegistry(hass)
+    load_entry = (
+        partial(registry.get_effect_entry, profile)
+        if mode == LookupMode.EFFECT
+        else partial(registry.get_lookup_entry, profile, mode)
+    )
+
+    with patch.object(profile_data, "MAX_UNCOMPRESSED_SIZE", 64):
+        with pytest.raises(StrategyConfigurationError, match="uncompressed size limit"):
+            await load_entry()
+
+        # Failed loads must not cache partial data or prevent a corrected file from loading.
+        path.write_bytes(gzip.compress(valid_data) if compressed else valid_data)
+        if mode == LookupMode.EFFECT:
+            assert (await registry.get_effect_entry(profile)).table == {"rainbow": {1: 2.0}}
+        else:
+            assert (await registry.get_lookup_entry(profile, mode)).sorted_keys == [1]
 
 
 async def _create_lut_strategy(

--- a/tests/strategy/test_playbook.py
+++ b/tests/strategy/test_playbook.py
@@ -1,3 +1,7 @@
+import gzip
+from pathlib import Path
+from unittest.mock import patch
+
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
@@ -8,7 +12,7 @@ from homeassistant.const import (
     STATE_PAUSED,
     STATE_PLAYING,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 import pytest
 
@@ -29,6 +33,7 @@ from custom_components.powercalc.const import (
     SERVICE_STOP_PLAYBOOK,
 )
 from custom_components.powercalc.errors import StrategyConfigurationError
+from custom_components.powercalc.strategy import profile_data
 from custom_components.powercalc.strategy.playbook import PlaybookStrategy
 from tests.common import (
     assert_entity_state,
@@ -257,6 +262,27 @@ async def test_lazy_load_playbook(hass: HomeAssistant) -> None:
     strategy = PlaybookStrategy(hass, {CONF_PLAYBOOKS: {"program1": "test.csv"}})
     await strategy.activate_playbook("program1")
     await strategy.activate_playbook("program1")
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+async def test_oversized_playbook_is_rejected(hass: HomeAssistant, tmp_path: Path, compressed: bool) -> None:
+    path = tmp_path / ("test.csv.gz" if compressed else "test.csv")
+    data = b"0,1\n" * 100
+    path.write_bytes(gzip.compress(data) if compressed else data)
+    strategy = PlaybookStrategy(hass, {CONF_PLAYBOOKS: {"program1": "test.csv"}}, str(tmp_path))
+
+    with patch.object(profile_data, "MAX_UNCOMPRESSED_SIZE", 64):
+        with pytest.raises(StrategyConfigurationError, match="uncompressed size limit"):
+            await strategy.activate_playbook("program1")
+        assert strategy.get_active_playbook() is None
+
+        # A failed load must not leave partial data in the playbook cache.
+        valid_data = b"0,2\n60,2\n"
+        path.write_bytes(gzip.compress(valid_data) if compressed else valid_data)
+        await strategy.activate_playbook("program1")
+        await async_advance_time(hass, 1)
+        assert await strategy.calculate(State("sensor.test", STATE_ON)) == 2
+        await strategy.stop_playbook()
 
 
 async def test_load_csv_from_subdirectory(hass: HomeAssistant) -> None:

--- a/tests/strategy/test_profile_data.py
+++ b/tests/strategy/test_profile_data.py
@@ -1,0 +1,65 @@
+import gzip
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.powercalc.errors import StrategyConfigurationError
+from custom_components.powercalc.strategy import profile_data
+from custom_components.powercalc.strategy.profile_data import open_profile_csv
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+@pytest.mark.parametrize("extra_bytes", [-1, 0, 1])
+def test_uncompressed_size_limit(tmp_path: Path, compressed: bool, extra_bytes: int) -> None:
+    """Accept the exact byte limit and reject even one extra decompressed byte."""
+    limit = 64
+    data = b"x" * (limit + extra_bytes)
+    path = tmp_path / ("test.csv.gz" if compressed else "test.csv")
+    path.write_bytes(gzip.compress(data) if compressed else data)
+
+    with patch.object(profile_data, "MAX_UNCOMPRESSED_SIZE", limit):
+        if extra_bytes > 0:
+            with pytest.raises(StrategyConfigurationError, match="uncompressed size limit of 64 bytes"):
+                open_profile_csv(str(path))
+        else:
+            with open_profile_csv(str(path)) as source:
+                assert source.read() == data.decode()
+
+
+def test_decompression_read_is_bounded(tmp_path: Path) -> None:
+    """A highly compressible file without newlines must not be fully decompressed."""
+    path = tmp_path / "bomb.csv.gz"
+    path.write_bytes(gzip.compress(b"x" * (1024 * 1024)))
+    with (
+        patch.object(profile_data, "MAX_UNCOMPRESSED_SIZE", 1024),
+        patch.object(gzip.GzipFile, "read", autospec=True, side_effect=gzip.GzipFile.read) as read,
+        pytest.raises(StrategyConfigurationError, match="uncompressed size limit"),
+    ):
+        open_profile_csv(str(path))
+    assert read.call_count == 1
+    assert read.call_args.args[1] == 1025
+
+
+def test_concatenated_gzip_members_share_size_limit(tmp_path: Path) -> None:
+    path = tmp_path / "test.csv.gz"
+    path.write_bytes(gzip.compress(b"x" * 32) + gzip.compress(b"y" * 33))
+    with (
+        patch.object(profile_data, "MAX_UNCOMPRESSED_SIZE", 64),
+        pytest.raises(StrategyConfigurationError, match="uncompressed size limit"),
+    ):
+        open_profile_csv(str(path))
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+def test_utf8_csv_and_newlines(tmp_path: Path, compressed: bool) -> None:
+    data = "🌈,1\r\n".encode()
+    path = tmp_path / ("test.csv.gz" if compressed else "test.csv")
+    path.write_bytes(gzip.compress(data) if compressed else data)
+    with patch.object(profile_data, "MAX_UNCOMPRESSED_SIZE", len(data)), open_profile_csv(str(path)) as source:
+        assert list(source) == ["🌈,1\n"]
+    with (
+        patch.object(profile_data, "MAX_UNCOMPRESSED_SIZE", len(data) - 1),
+        pytest.raises(StrategyConfigurationError, match="uncompressed size limit"),
+    ):
+        open_profile_csv(str(path))


### PR DESCRIPTION
A small downloaded gzip file could expand without a limit when loading LUT data or playbooks. Cap each CSV at 10 MiB of uncompressed data and reject oversized files before parsing or caching entries. The shared reader bounds decompression itself and applies the same limit to plain CSV files and concatenated gzip members.

Regression tests cover the exact byte boundary, highly compressed input without newlines, concatenated members, UTF-8 byte counts, all LUT modes, and recovery after replacing an oversized file. All 854 CSV files in the bundled library fit below the limit; the largest expands to 474,459 bytes.

Validation:

- Full integration suite: 1,287 tests passed; 100% coverage across all three affected production modules.
- Updated reader tests: 10 passed.
- `uv run prek run --all-files`: passed, including Ruff, mypy, ty, schema validation, and workflow checks.
