### PR TITLE
Restrict standalone measurement API access

### DIFF
--- a/utils/measure/README.md
+++ b/utils/measure/README.md
@@ -102,12 +102,15 @@ See the [measurement tool architecture](../../docs/source/contributing/measure/a
 **Terminal 1 — backend** (from `utils/measure`):
 ```
 uv run --extra app python -m measure.ha_app.main \
+  --allow-local-access \
   --host 127.0.0.1 --port 8099 \
   --data-root .dev-data \
   --hass-url ws://127.0.0.1:8123/api/websocket \
   --hass-token <LONG_LIVED_TOKEN>
 ```
 Use the full Home Assistant WebSocket endpoint: `ws://<host>:8123/api/websocket` for a direct connection, or `ws://supervisor/core/websocket` from a Home Assistant add-on. `--hass-token` may be omitted if `SUPERVISOR_TOKEN` is exported instead. Session state and settings are written to `--data-root` (here `.dev-data`).
+
+The backend binds to `127.0.0.1` by default and requires Home Assistant ingress access. `--allow-local-access` explicitly enables unauthenticated local development: the bind address and incoming clients must both be loopback IP addresses. Setting `MEASURE_TRUSTED_INGRESS_ONLY=false` selects the same local access policy. `--hass-token` authenticates outgoing Home Assistant requests; it does not authenticate incoming API requests. The Home Assistant app keeps ingress protection enabled and listens on the container interface through its Docker command.
 
 GitHub device login requires a GitHub OAuth App with Device Flow enabled. Set its public client ID in `POWERCALC_GITHUB_CLIENT_ID` before starting the backend. Device login requests `public_repo` and `workflow`; the latter is needed to base a clean contribution branch on an upstream commit when the user's fork has stale workflow files. Without a client ID, the UI disables device login and retains the personal-access-token fallback.
 
@@ -120,7 +123,7 @@ npm run dev
 ```
 Open http://localhost:5173. The Vite dev server proxies `/api` (including the SSE event stream) to the backend on port 8099, mirroring the single-origin ingress deployment.
 
-To run the app the way it ships (single origin, no hot-reload), build the frontend with `npm run build` and start the backend with `create_app(..., static_root=Path("frontend/dist"))`; the UI is then served by FastAPI on port 8099.
+To run the app locally with a single origin and no hot-reload, build the frontend with `npm run build` and start the backend with `create_app(..., static_root=Path("frontend/dist"), trusted_ingress_only=False)` on `127.0.0.1:8099`, with Uvicorn proxy headers disabled. The UI is then served by FastAPI on port 8099, and requests must come from loopback.
 
 ### Checks
 

--- a/utils/measure/measure/ha_app/access.py
+++ b/utils/measure/measure/ha_app/access.py
@@ -1,0 +1,19 @@
+"""Access policy shared by the app factory and standalone entry point."""
+
+from ipaddress import ip_address
+import os
+
+
+def trusted_ingress_only_enabled() -> bool:
+    """Require ingress unless local access was explicitly enabled."""
+    return os.environ.get("MEASURE_TRUSTED_INGRESS_ONLY", "true").lower() != "false"
+
+
+def is_loopback_address(host: str | None) -> bool:
+    """Accept literal loopback addresses without trusting DNS or proxy headers."""
+    if host is None:
+        return False
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False

--- a/utils/measure/measure/ha_app/api.py
+++ b/utils/measure/measure/ha_app/api.py
@@ -22,6 +22,7 @@ from measure.const import PARAMETER_LIMITS, MeasureType
 from measure.controller.light.const import LutMode
 from measure.dummy_load import DummyLoadCalibration, power_meter_fingerprint
 from measure.execution import ImmediateInteraction, OperatingPoint
+from measure.ha_app.access import is_loopback_address, trusted_ingress_only_enabled
 from measure.ha_app.contribution import (
     ConnectPatRequest,
     ContributionApiCoordinator,
@@ -419,7 +420,7 @@ def create_app(
     if not token:
         raise RuntimeError("SUPERVISOR_TOKEN is required to start the Home Assistant app")
     if trusted_ingress_only is None:
-        trusted_ingress_only = os.environ.get("MEASURE_TRUSTED_INGRESS_ONLY", "false").lower() == "true"
+        trusted_ingress_only = trusted_ingress_only_enabled()
     context = AppContext(
         data_root=data_root,
         hass_url=hass_url,
@@ -442,15 +443,21 @@ def create_app(
         return {"status": "ok"}
 
     @app.middleware("http")
-    async def restrict_to_ingress(
+    async def restrict_access(
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         client_host = request.client.host if request.client else None
+        if context.trusted_ingress_only:
+            allowed = client_host == "172.30.32.2"
+            code, message = "ingress_required", "Ingress access required"
+        else:
+            allowed = is_loopback_address(client_host)
+            code, message = "local_access_required", "Local access required"
         # /health is probed by the container HEALTHCHECK from localhost and
         # exposes no data, so it bypasses the ingress source check.
-        if context.trusted_ingress_only and request.url.path != "/health" and client_host != "172.30.32.2":
-            error = ErrorResponse(code="ingress_required", message="Ingress access required")
+        if request.url.path != "/health" and not allowed:
+            error = ErrorResponse(code=code, message=message)
             return JSONResponse(status_code=403, content=error.model_dump())
         return await call_next(request)
 

--- a/utils/measure/measure/ha_app/main.py
+++ b/utils/measure/measure/ha_app/main.py
@@ -5,12 +5,13 @@ from pathlib import Path
 
 import uvicorn
 
+from measure.ha_app.access import is_loopback_address, trusted_ingress_only_enabled
 from measure.ha_app.api import create_app
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Powercalc Measure Home Assistant app")
-    parser.add_argument("--host", default="0.0.0.0")  # noqa: S104
+    parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8099)
     parser.add_argument("--data-root", type=Path, default=Path("/data"))
     parser.add_argument(
@@ -24,11 +25,19 @@ def main() -> None:
         help="Home Assistant access token. Defaults to the SUPERVISOR_TOKEN environment variable.",
     )
     parser.add_argument(
+        "--allow-local-access",
+        action="store_true",
+        help="Allow unauthenticated local development access. Requires a loopback bind address.",
+    )
+    parser.add_argument(
         "--developer-mode",
         action="store_true",
         help="Show developer testing options in the app, such as virtual (dummy) device controllers.",
     )
     args = parser.parse_args()
+    trusted_ingress_only = not args.allow_local_access and trusted_ingress_only_enabled()
+    if not trusted_ingress_only and not is_loopback_address(args.host):
+        parser.error("Local access requires a loopback IP address for --host (127.0.0.1 or ::1)")
     options = _read_options(args.data_root)
     debug = bool(options.get("debug_logging", False))
     _configure_logging(debug)
@@ -36,6 +45,7 @@ def main() -> None:
         data_root=args.data_root,
         hass_url=args.hass_url,
         hass_token=args.hass_token,
+        trusted_ingress_only=trusted_ingress_only,
         developer_mode=args.developer_mode or bool(options.get("developer_mode", False)),
     )
     uvicorn.run(

--- a/utils/measure/tests/test_api.py
+++ b/utils/measure/tests/test_api.py
@@ -356,7 +356,7 @@ def client(tmp_path: Path, *, trusted_ingress_only: bool = False, developer_mode
         points=(LightLoadProbePoint(label="Brightness 1", mode=LutMode.BRIGHTNESS, power_w=1.25),),
     )
     app.state.context.coordinator = MeasurementCoordinator(SessionStorage(tmp_path), CompletingService)
-    return TestClient(app)
+    return TestClient(app, client=("127.0.0.1", 50000))
 
 
 def test_app_metadata_uses_the_runtime_measure_version(tmp_path: Path) -> None:
@@ -493,7 +493,9 @@ def test_index_is_not_cached(tmp_path: Path) -> None:
             data_root=tmp_path,
             hass_token="test-token",  # noqa: S106
             static_root=static_root,
+            trusted_ingress_only=False,
         ),
+        client=("127.0.0.1", 50000),
     )
 
     response = test_client.get("/")
@@ -715,7 +717,7 @@ def test_app_closes_home_assistant_manager_at_shutdown(tmp_path: Path) -> None:
     home_assistant = MagicMock(spec=HomeAssistantManager)
     app.state.context.home_assistant = home_assistant
 
-    with TestClient(app) as test_client:
+    with TestClient(app, client=("127.0.0.1", 50000)) as test_client:
         assert test_client.get("/api/capabilities").status_code == 200
 
     home_assistant.close.assert_called_once_with()
@@ -1658,6 +1660,66 @@ def test_trusted_ingress_mode_rejects_other_source(tmp_path: Path) -> None:
 
     assert response.status_code == 403
     assert response.json()["code"] == "ingress_required"
+
+
+@pytest.mark.parametrize(
+    "trusted_ingress_only,source,expected_status",
+    [
+        (None, "198.51.100.10", 403),
+        (None, "127.0.0.1", 403),
+        (None, "172.30.32.2", 200),
+        (True, "172.30.32.2", 200),
+        (True, "::1", 403),
+        (False, "127.0.0.1", 200),
+        (False, "::1", 200),
+        (False, "198.51.100.10", 403),
+        (False, "172.30.32.2", 403),
+        (False, "localhost", 403),
+        (False, None, 403),
+    ],
+)
+def test_settings_access_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    trusted_ingress_only: bool | None,
+    source: str | None,
+    expected_status: int,
+) -> None:
+    monkeypatch.delenv("MEASURE_TRUSTED_INGRESS_ONLY", raising=False)
+    app = create_app(
+        data_root=tmp_path,
+        hass_token="test-token",  # noqa: S106
+        trusted_ingress_only=trusted_ingress_only,
+    )
+    test_client = TestClient(app, client=(source, 50000) if source else None)
+
+    assert test_client.get("/api/settings").status_code == expected_status
+    response = test_client.put("/api/settings", json={"default_measure_device": "Test meter"})
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize("setting", [None, "true", "false", "", "invalid"])
+@pytest.mark.parametrize("path", ["/", "/openapi.json", "/api/settings", "/api/sessions", "/api/contribution/auth"])
+def test_external_requests_cannot_disable_access_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    setting: str | None,
+    path: str,
+) -> None:
+    if setting is None:
+        monkeypatch.delenv("MEASURE_TRUSTED_INGRESS_ONLY", raising=False)
+    else:
+        monkeypatch.setenv("MEASURE_TRUSTED_INGRESS_ONLY", setting)
+    app = create_app(data_root=tmp_path, hass_token="test-token")  # noqa: S106
+    test_client = TestClient(app, client=("198.51.100.10", 50000))
+
+    response = test_client.get(
+        path,
+        headers={"X-Forwarded-For": "172.30.32.2", "X-Real-IP": "127.0.0.1"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["code"] == ("local_access_required" if setting == "false" else "ingress_required")
 
 
 def test_health_endpoint_for_container_healthcheck(tmp_path: Path) -> None:

--- a/utils/measure/tests/test_app.py
+++ b/utils/measure/tests/test_app.py
@@ -1,8 +1,77 @@
 import json
 import logging
 from pathlib import Path
+from unittest.mock import patch
 
-from measure.ha_app.main import _configure_logging, _read_options
+from measure.ha_app.main import _configure_logging, _read_options, main
+import pytest
+
+
+@pytest.mark.parametrize(
+    "arguments,setting,host,ingress_only",
+    [
+        ([], None, "127.0.0.1", True),
+        (["--developer-mode"], None, "127.0.0.1", True),
+        (["--allow-local-access"], None, "127.0.0.1", False),
+        (["--allow-local-access", "--host", "::1"], None, "::1", False),
+        ([], "false", "127.0.0.1", False),
+        (["--host", "0.0.0.0"], "true", "0.0.0.0", True),  # noqa: S104
+        (["--host", "0.0.0.0"], None, "0.0.0.0", True),  # noqa: S104
+        (["--host", "0.0.0.0"], "invalid", "0.0.0.0", True),  # noqa: S104
+    ],
+)
+def test_main_access_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    arguments: list[str],
+    setting: str | None,
+    host: str,
+    ingress_only: bool,
+) -> None:
+    if setting is None:
+        monkeypatch.delenv("MEASURE_TRUSTED_INGRESS_ONLY", raising=False)
+    else:
+        monkeypatch.setenv("MEASURE_TRUSTED_INGRESS_ONLY", setting)
+    monkeypatch.setattr("sys.argv", ["measure-app", "--data-root", str(tmp_path), *arguments])
+    with patch("measure.ha_app.main.create_app") as create_app, patch("measure.ha_app.main.uvicorn.run") as run:
+        main()
+
+    assert create_app.call_args.kwargs["trusted_ingress_only"] is ingress_only
+    run.assert_called_once_with(
+        create_app.return_value,
+        host=host,
+        port=8099,
+        workers=1,
+        proxy_headers=False,
+        log_level="info",
+    )
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.0.2.1", "localhost", "example.com"])  # noqa: S104
+@pytest.mark.parametrize("use_environment", [False, True])
+def test_main_rejects_external_local_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    host: str,
+    use_environment: bool,
+) -> None:
+    monkeypatch.setenv("MEASURE_TRUSTED_INGRESS_ONLY", "false" if use_environment else "true")
+    arguments = ["measure-app", "--data-root", str(tmp_path), "--host", host]
+    if not use_environment:
+        arguments.append("--allow-local-access")
+    monkeypatch.setattr("sys.argv", arguments)
+    with (
+        patch("measure.ha_app.main.create_app") as create_app,
+        patch("measure.ha_app.main.uvicorn.run") as run,
+        pytest.raises(SystemExit) as error,
+    ):
+        main()
+
+    assert error.value.code == 2
+    assert "Local access requires a loopback IP address" in capsys.readouterr().err
+    create_app.assert_not_called()
+    run.assert_not_called()
 
 
 def test_read_options_empty_when_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
Starting the measurement backend outside Home Assistant previously exposed an unauthenticated API on all interfaces when no ingress setting was supplied. Require ingress by default and bind the standalone CLI to `127.0.0.1`.

Local development now requires `--allow-local-access` or `MEASURE_TRUSTED_INGRESS_ONLY=false`. In that mode, the CLI refuses non-loopback bind addresses and the API independently rejects non-loopback clients. Missing or unrecognized ingress settings keep ingress protection enabled. The Home Assistant app's explicit ingress configuration, disabled proxy-header handling, and healthcheck remain supported. The README documents the new local startup option.

Regression tests cover settings reads and writes, IPv4/IPv6 loopback access, rejected external binds, missing client addresses, forged proxy headers, and protected UI/API routes.

Validation:

- Full measurement suite: 808 tests passed.
- 100% coverage of changed executable production lines; existing uncovered code is unchanged.
- Strict measurement mypy check: passed (136 files).
- `uv run prek run --all-files`: passed.
