### PR TITLE
Add new metadata about measure settings for L122AA63H11A6.5W

### DIFF
--- a/profile_library/megos/L122AA63H11A6.5W/model.json
+++ b/profile_library/megos/L122AA63H11A6.5W/model.json
@@ -20,7 +20,7 @@
   "mains_voltage": 230,
   "measure_settings": {
     "SAMPLE_COUNT": 1,
-    "SLEEP_TIME": 2.0, 
+    "SLEEP_TIME": 2.0,
     "NUM_LIGHTS": 2,
     "DUMMY_LOAD": true,
     "DUMMY_LOAD_POWER": 45,

--- a/profile_library/megos/L122AA63H11A6.5W/model.json
+++ b/profile_library/megos/L122AA63H11A6.5W/model.json
@@ -20,7 +20,10 @@
   "mains_voltage": 230,
   "measure_settings": {
     "SAMPLE_COUNT": 1,
-    "SLEEP_TIME": 2.0,
+    "SLEEP_TIME": 2.0, 
+    "NUM_LIGHTS": 2,
+    "DUMMY_LOAD": true,
+    "DUMMY_LOAD_POWER": 45,
     "VERSION": "v0.3.0:app"
   },
   "name": "LIGHTWAY smart home LED-lamp - candle",


### PR DESCRIPTION
Followup of https://github.com/bramstroker/homeassistant-powercalc/pull/4493 adding the new fields introduced in https://github.com/bramstroker/homeassistant-powercalc/issues/4718#issuecomment-5551052412

Only thing I could not add/find out is `DUMMY_LOAD_RESISTANCE`. I did check in the diagnostics and the web interface of the measure app in the previous run, but did not find the data. Anyway, this should already be helpful data here,

IIRC it was logged through (with changing values, however).