### PR TITLE
Added laundrify mini

### DIFF
--- a/profile_library/laundrify/manufacturer.json
+++ b/profile_library/laundrify/manufacturer.json
@@ -1,0 +1,6 @@
+{
+  "name": "laundrify",
+  "website": "https://laundrify.de",
+  "country": "DE",
+  "description": "German provider of smart plugs that measure washing machines and dryers power consumption."
+}

--- a/profile_library/laundrify/mini/model.json
+++ b/profile_library/laundrify/mini/model.json
@@ -9,7 +9,7 @@
       "wifi"
     ]
   },
-  "measure_description": "measured via the PowerCalc HA app"
+  "measure_description": "measured via the PowerCalc HA app",
   "measure_device": "IKEA GRILLPLATS",
   "measure_method": "script",
   "mains_voltage": 230,

--- a/profile_library/laundrify/mini/model.json
+++ b/profile_library/laundrify/mini/model.json
@@ -1,0 +1,27 @@
+{
+  "calculation_strategy": "fixed",
+  "created_at": "2026-09-08T19:59:21Z",
+  "device_type": "smart_switch",
+  "device_specs": {
+    "form_factor": "plug",
+    "power_monitoring": true,
+    "connectivity": [
+      "wifi"
+    ]
+  },
+  "measure_description": "measured via the PowerCalc HA app"
+  "measure_device": "IKEA GRILLPLATS",
+  "measure_method": "script",
+  "mains_voltage": 230,
+  "name": "mini",
+  "product_url": "https://laundrify.de/blog/laundrify-wlan-adapter-mini",
+  "only_self_usage": true,
+  "standby_power": 0.9,
+  "standby_power_on": 0.9,
+  "authors": [
+    {
+      "name": "ps1noob",
+      "github": "ps1noob"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
[laundrify](https://laundrify.de)
This is a smart plug provided by the company named "laundrify". It's based in Germany. Currently, there seems to be a new release upcoming, therefore the website just shows some information based around the newsletter.

This smart plug is the version called "mini", the second generation. 

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
WLAN-Adapter mini
by laundrify 

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] The model name does not repeat the manufacturer name.
- [x] I have checked existing profiles for this manufacturer for consistent naming and metadata.
- [x] I have reused the existing `measure_device` value when my measurement device is already in the library.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->

I used the Powercalc Measure app under HA, while using the "Home Assistant sensor" with an "Average" measurement.