### PR TITLE
Profile/sonoff s60

### DIFF
--- a/profile_library/sonoff/S60/model.json
+++ b/profile_library/sonoff/S60/model.json
@@ -1,7 +1,7 @@
 {
   "aliases": [
     "S60ZBTPF",
-	"S60ZBTPG"
+    "S60ZBTPG"
   ],
   "calculation_strategy": "fixed",
   "created_at": "2026-09-06T08:26:19Z",
@@ -16,7 +16,7 @@
   },
   "ean": [
     "6920075743005",
-	"6920075740462"
+    "6920075740462"
   ],
   "measure_description": "Manually measured.",
   "measure_device": "Trotec BX09",

--- a/profile_library/sonoff/S60/model.json
+++ b/profile_library/sonoff/S60/model.json
@@ -1,0 +1,36 @@
+{
+  "aliases": [
+    "S60ZBTPF",
+	"S60ZBTPG"
+  ],
+  "calculation_strategy": "fixed",
+  "created_at": "2026-09-06T08:26:19Z",
+  "device_type": "smart_switch",
+  "device_specs": {
+    "form_factor": "plug",
+    "max_load_watts": 4000,
+    "power_monitoring": true,
+    "connectivity": [
+      "zigbee"
+    ]
+  },
+  "ean": [
+    "6920075743005",
+	"6920075740462"
+  ],
+  "measure_description": "Manually measured.",
+  "measure_device": "Trotec BX09",
+  "measure_method": "manual",
+  "mains_voltage": 231,
+  "name": "iPlug Zigbee Smart Plug S60",
+  "only_self_usage": true,
+  "standby_power": 0.3,
+  "standby_power_on": 0.8,
+  "product_url": "https://sonoff.tech/en-us/products/sonoff-iplug-zigbee-smart-plug-s60-series",
+  "authors": [
+    {
+      "name": "Nino",
+      "github": "TheLexus"
+    }
+  ]
+}

--- a/profile_library/sonoff/S60/model.json
+++ b/profile_library/sonoff/S60/model.json
@@ -1,7 +1,7 @@
 {
   "aliases": [
-    "S60ZBTPF",
-    "S60ZBTPG"
+    "Zigbee smart plug (S60ZBTPF)",
+    "Zigbee smart plug (S60ZBTPG)",
   ],
   "calculation_strategy": "fixed",
   "created_at": "2026-09-06T08:26:19Z",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
https://sonoff.tech/de-de/products/sonoff-iplug-zigbee-smart-plug-s60-series

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
Zigbee smart plug (S60ZBTPF)
von SONOFF

Verbunden über Zigbee2MQTT Bridge
Firmware: 2.0.5
Hardware: 16

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [X] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [X] The model name does not repeat the manufacturer name.
- [X] I have checked existing profiles for this manufacturer for consistent naming and metadata.
- [X] I have reused the existing `measure_device` value when my measurement device is already in the library.
- [X] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [X] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
