### PR TITLE
Add Shelly 2PM Gen4 with multiple sub-profiles

### DIFF
--- a/profile_library/shelly/S4SW-002P16EU/model.json
+++ b/profile_library/shelly/S4SW-002P16EU/model.json
@@ -1,0 +1,41 @@
+{
+  "aliases": [
+    "Shelly 2PM Gen4"
+  ],
+  "calculation_strategy": "fixed",
+  "description": "Compact Smart Wi-Fi Relay with Power Monitoring",
+  "config_flow_sub_profile_remarks": "You need to select a profile depending on your settings.\nThe ECO setting only changes the power consumption in the listed configurations. Activating any other settings not listed in the profile name will change the power draw.\n\"WLAN + BT + ECO\": All three turned on, repeater turned off.\n\"WLAN + ECO\": Both turned on, repeater turned off.\n\"WLAN + BT\": Both turned on, ECO and repeater turned off.\n\"WLAN\": Only WLAN turned on, ECO and repeater turned off.",
+  "created_at": "2026-09-10T23:00:25Z",
+  "device_type": "smart_switch",
+  "device_specs": {
+    "form_factor": "in_wall",
+    "max_load_watts": 2300,
+    "power_monitoring": true,
+    "rated_power": 1.4,
+    "connectivity": [
+      "wifi",
+      "bluetooth",
+      "matter",
+      "zigbee"
+    ]
+  },
+  "ean": [
+    "3800238070748"
+  ],
+  "measure_description": "Measured with 33.7 W dummy load, averaged over 60 seconds. Multiple combinations of settings were tested. Firmware version 2.0.0.",
+  "measure_device": "Shelly Plug S Gen3",
+  "measure_method": "manual",
+  "mains_voltage": 230,
+  "measure_settings": {
+    "VERSION": "v0.6.0:app"
+  },
+  "name": "2PM Gen4",
+  "only_self_usage": true,
+  "product_url": "https://www.shelly.com/products/shelly-2pm-gen4",
+  "authors": [
+    {
+      "name": "Maxik933",
+      "github": "Maxik933"
+    }
+  ]
+}

--- a/profile_library/shelly/S4SW-002P16EU/wlan/model.json
+++ b/profile_library/shelly/S4SW-002P16EU/wlan/model.json
@@ -1,0 +1,5 @@
+{
+  "name": "WLAN",
+  "standby_power": 0.47,
+  "standby_power_on": 0.7
+}

--- a/profile_library/shelly/S4SW-002P16EU/wlan_+bt/model.json
+++ b/profile_library/shelly/S4SW-002P16EU/wlan_+bt/model.json
@@ -1,0 +1,5 @@
+{
+  "name": "WLAN + Bluetooth",
+  "standby_power": 0.62,
+  "standby_power_on": 0.87
+}

--- a/profile_library/shelly/S4SW-002P16EU/wlan_+bt_+eco/model.json
+++ b/profile_library/shelly/S4SW-002P16EU/wlan_+bt_+eco/model.json
@@ -1,0 +1,5 @@
+{
+  "name": "WLAN + Bluetooth + ECO",
+  "standby_power": 0.4,
+  "standby_power_on": 0.71
+}

--- a/profile_library/shelly/S4SW-002P16EU/wlan_+eco/model.json
+++ b/profile_library/shelly/S4SW-002P16EU/wlan_+eco/model.json
@@ -1,0 +1,5 @@
+{
+  "name": "WLAN + ECO",
+  "standby_power": 0.29,
+  "standby_power_on": 0.52
+}


### PR DESCRIPTION
This PR adds the Shelly 2PM Gen4 as a smart_switch. It is a compact smart Wi-Fi relay with power monitoring for in-wall installation. Power draw was measured using a Shelly Plug S Gen3 with a 33.5 W dummy load, averaged over 60 seconds. Multiple setting combinations were tested (firmware 2.0.0).

Important for sub-profile selection:

Wi-Fi + BT + ECO: Wi-Fi, Bluetooth and ECO enabled, repeater off.
Wi-Fi + ECO: Wi-Fi and ECO enabled, repeater off.
Wi-Fi + BT: Wi-Fi and Bluetooth enabled, ECO and repeater off.
Wi-Fi: Only Wi-Fi enabled, ECO and repeater off.