### PR TITLE
feat(profile): add AwoX EZMB-RGB-TW-I2C linked to signify/LCT015

### DIFF
--- a/profile_library/awox/EZMB-RGB-TW-I2C/model.json
+++ b/profile_library/awox/EZMB-RGB-TW-I2C/model.json
@@ -1,0 +1,18 @@
+{
+    "name": "AwoX EZMB-RGB-TW-I2C Extended Color Light",
+    "device_type": "light",
+    "calculation_strategy": "lut",
+    "linked_profile": "signify/LCT015",
+    "created_at": "2026-09-12T00:00:00Z",
+    "measure_method": "script",
+    "measure_device": "AVM Fritz!DECT 200",
+    "measure_description": "No measurements available for this device. Power usage is linked to the measurements of the Signify LCT015 (Hue White and Color Ambiance A19), the closest measured equivalent for this RGB + tunable white bulb.",
+    "mains_voltage": 230,
+    "standby_power": 0.47,
+    "authors": [
+        {
+            "name": "Locodice67",
+            "github": "Locodice67"
+        }
+    ]
+}

--- a/profile_library/awox/manufacturer.json
+++ b/profile_library/awox/manufacturer.json
@@ -1,0 +1,5 @@
+{
+    "name": "AwoX",
+    "country": "FR",
+    "description": "French smart home manufacturer. Its Zigbee bulbs can be paired to a Philips Hue bridge and are reported by Home Assistant with the AwoX manufacturer name."
+}


### PR DESCRIPTION
## New profile: AwoX `EZMB-RGB-TW-I2C`

Adds a Powercalc profile for the AwoX `EZMB-RGB-TW-I2C` Zigbee bulb. As reported by the `hue` integration:

| Field | Value |
|---|---|
| Manufacturer | `AwoX` |
| Model id | `EZMB-RGB-TW-I2C` |
| Model (HA) | `Extended color light` |
| Platform | `hue` (paired to a Philips Hue bridge) |
| Color capabilities | `color_temp` + `xy` (RGB + tunable white) |

### Implementation

No power measurements are available for this device, so the profile uses `linked_profile` to reuse the measurements of `signify/LCT015` (Hue White and Color Ambiance A19), the closest measured equivalent. This is the same approach already used by e.g. `signify/LWO002 -> signify/LWO001` and `ikea/LED1936G5 -> ikea/LED1937T5_E27`.

No CSV data is added; the linked profile supplies the LUT files.

### Why this is needed

Neither the `AwoX` manufacturer nor the `EZMB-RGB-TW-I2C` model id exists in the library, so Powercalc cannot discover these bulbs. Users currently have to map them manually to a Signify profile, which is fragile: pointing a brightness-only filament profile (e.g. `LWO001`) at one of these color-capable bulbs raises

```
Lookup table not found for color mode (model: LWO001, color_mode: hs)
```

as soon as the bulb is set to a color, because the profile has no `hs` LUT.

### Files

- `profile_library/awox/manufacturer.json` — new manufacturer entry
- `profile_library/awox/EZMB-RGB-TW-I2C/model.json` — profile with `"linked_profile": "signify/LCT015"`

### Notes

If you would prefer a different linked target (for example `signify/LCA006`), or actual measurements before this is merged, I can update the PR.
