### PR TITLE
Add Dreo DR-HPF017S profile

### DIFF
--- a/profile_library/dreo/DR-HPF017S/model.json
+++ b/profile_library/dreo/DR-HPF017S/model.json
@@ -1,0 +1,38 @@
+{
+  "calculation_strategy": "linear",
+  "created_at": "2026-09-12T00:00:00Z",
+  "device_type": "fan",
+  "device_specs": {
+    "form_factor": "pedestal",
+    "connectivity": [
+      "wifi"
+    ],
+    "rated_power": 36
+  },
+  "linear_config": {
+    "attribute": "percentage",
+    "calibrate": [
+      "8 -> 3.2",
+      "25 -> 6.7",
+      "33 -> 8.05",
+      "50 -> 11.6",
+      "58 -> 13.7",
+      "75 -> 18.3",
+      "83 -> 21.6",
+      "100 -> 31.0"
+    ]
+  },
+  "measure_description": "Measured with a Shelly Plug S Gen3 at 2-second sampling, holding each fan-speed step for 25 seconds and discarding the initial transient before recording. Standby (fan off, 45 s hold) read a constant 0.0 W / 0.000 A, which is below the Shelly's measurement resolution rather than a true zero. standby_power below is a fallback estimate (not a direct measurement), based on the 0.87-1.57 W standby range measured across other Dreo fan/purifier profiles in this library.",
+  "measure_device": "Shelly Plug S Gen3",
+  "measure_method": "manual",
+  "mains_voltage": 230,
+  "name": "Smart TurboPoly Fan 517S",
+  "product_url": "https://www.dreo.com/products/turbopoly%E2%84%A2-fan-517s",
+  "standby_power": 0.9,
+  "authors": [
+    {
+      "name": "zuranihenry",
+      "github": "zuranihenry"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
Dreo DR-HPF017S, sold as the "Smart TurboPoly Fan 517S": https://www.dreo.com/products/turbopoly%E2%84%A2-fan-517s

Measured with a Shelly Plug S Gen3, 2-second sampling, 25-second hold per fan-speed step with the initial transient discarded.

Standby power is a fallback estimate, not a direct measurement. I used 0.9 W, based on the 0.87-1.57 W standby range measured across the other Dreo profiles already in this library (DR-HTF001S, DR-HTF002S, DR-HTF008S, DR-HAF001S, DR-HPF005S).

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
- Manufacturer: Dreo
- Model: DR-HPF017S
- Integration: [hass-dreo](https://github.com/JeffSteinbok/hass-dreo) (custom component)

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [x] The model name does not repeat the manufacturer name.
- [x] I have checked existing profiles for this manufacturer for consistent naming and metadata.
- [x] I have reused the existing `measure_device` value when my measurement device is already in the library.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
This is a progressive power curve rather than the linear min/max used by the existing Dreo fan profiles, e.g. 50% draws 11.6 W, well above what a straight line between the 8% and 100% points would predict. The 8-point calibration should capture that shape.